### PR TITLE
feat(sidebar): Quick Launch section for one-tap CLI spawning

### DIFF
--- a/components/layout/QuickLaunchSection.tsx
+++ b/components/layout/QuickLaunchSection.tsx
@@ -1,0 +1,121 @@
+// components/layout/QuickLaunchSection.tsx
+//
+// One-tap CLI launchers in the sidebar. Spawns a fresh Terminal pane and
+// queues the matching CLI as a pendingCommand so it runs as soon as the
+// new session is alive. Mirrors the WorktreesSection chip styling but
+// skips the worktree-binding dance — this is for "I just want a Codex
+// REPL right now" use cases.
+//
+// Trigger: tapping a chip → addPane('terminal') → insertCommand(cli).
+// If the terminal pane cap (3) is hit the underlying useAddPane shows
+// the standard alert and we bail without queuing the command.
+
+import React, { useCallback } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { useAddPane } from '@/hooks/use-add-pane';
+import { useTerminalStore } from '@/store/terminal-store';
+import { SidebarSection } from './SidebarSection';
+import { colors as C, fonts as F, padding as P, sizes as S } from '@/theme.config';
+import { neonGlowSky } from '@/lib/neon-glow';
+
+type Cli = 'claude' | 'codex' | 'gemini';
+
+const CLI_COLORS: Record<Cli, string> = {
+  claude: '#A78BFA',
+  codex: '#22C55E',
+  gemini: '#60A5FA',
+};
+
+const CLI_EMOJI: Record<Cli, string> = {
+  claude: '🟣',
+  codex: '🟢',
+  gemini: '🔵',
+};
+
+const CLI_LABEL: Record<Cli, string> = {
+  claude: 'Claude Code',
+  codex: 'Codex',
+  gemini: 'Gemini',
+};
+
+type Props = {
+  isOpen: boolean;
+  onToggle: () => void;
+  iconsOnly: boolean;
+};
+
+export function QuickLaunchSection({ isOpen, onToggle, iconsOnly }: Props) {
+  const addPane = useAddPane();
+
+  const launch = useCallback(
+    (cli: Cli) => {
+      const result = addPane('terminal');
+      if (result !== null) return; // useAddPane already alerted
+      // The shell function name on the user's $PATH matches the cli token
+      // (claude/codex/gemini are all bashrc-defined functions in
+      // HomeInitializer.kt). Trailing newline so bash auto-runs it the
+      // moment the new pane's TerminalPane effect picks pendingCommand up.
+      useTerminalStore.getState().insertCommand(`${cli}\n`);
+    },
+    [addPane],
+  );
+
+  return (
+    <SidebarSection
+      title="QUICK LAUNCH"
+      icon="rocket-launch"
+      isOpen={isOpen}
+      onToggle={onToggle}
+      iconsOnly={iconsOnly}
+      accent={C.accentSky}
+      glow={neonGlowSky}
+    >
+      <View style={styles.row}>
+        {(['claude', 'codex', 'gemini'] as const).map((cli) => (
+          <Pressable
+            key={cli}
+            style={[styles.chip, { borderColor: CLI_COLORS[cli] }]}
+            onPress={() => launch(cli)}
+            hitSlop={4}
+            accessibilityRole="button"
+            accessibilityLabel={`Launch ${CLI_LABEL[cli]} in a new terminal pane`}
+          >
+            <Text style={styles.emoji}>{CLI_EMOJI[cli]}</Text>
+            <Text style={[styles.chipLabel, { color: CLI_COLORS[cli] }]}>
+              {CLI_LABEL[cli]}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </SidebarSection>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: P.xs,
+    paddingHorizontal: P.sm,
+    paddingVertical: P.xs,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: P.sm,
+    paddingVertical: 4,
+    borderRadius: S.radius,
+    borderWidth: 1,
+    backgroundColor: 'rgba(0,0,0,0.25)',
+  },
+  emoji: {
+    fontSize: 11,
+    lineHeight: 14,
+  },
+  chipLabel: {
+    fontFamily: F.mono,
+    fontSize: 11,
+    fontWeight: '600',
+  },
+});

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -33,6 +33,7 @@ import { SidebarSection } from './SidebarSection';
 import { FileTree } from './FileTree';
 import { ProfilesSection } from './ProfilesSection';
 import { WorktreesSection } from './WorktreesSection';
+import { QuickLaunchSection } from './QuickLaunchSection';
 import {
   neonTextGlow,
   neonDotGlow,
@@ -369,6 +370,16 @@ export function Sidebar() {
             </Text>
           )}
         </SidebarSection>
+
+        {/* QUICK LAUNCH — one-tap CLI launchers (claude/codex/gemini) into a
+            new Terminal pane. Sits between TASKS and REPOSITORIES so the
+            most-used "I just want a REPL right now" affordance is at the
+            top of the sidebar, above repo/worktree management. */}
+        <QuickLaunchSection
+          isOpen={openSections.quickLaunch ?? true}
+          onToggle={() => toggleSection('quickLaunch')}
+          iconsOnly={iconsOnly}
+        />
 
         {/* REPOSITORIES */}
         <SidebarSection

--- a/store/sidebar-store.ts
+++ b/store/sidebar-store.ts
@@ -7,7 +7,7 @@ import { logInfo, logError } from '@/lib/debug-logger';
 import { normalizePath } from '@/lib/normalize-path';
 
 export type SidebarMode = 'expanded' | 'icons' | 'hidden';
-export type SidebarSection = 'tasks' | 'repos' | 'files' | 'device' | 'ports' | 'profiles' | 'worktrees';
+export type SidebarSection = 'tasks' | 'repos' | 'files' | 'device' | 'ports' | 'profiles' | 'worktrees' | 'quickLaunch';
 
 interface SidebarState {
   mode: SidebarMode;
@@ -31,7 +31,7 @@ export const useSidebarStore = create<SidebarState>()(
   persist(
     (set, get) => ({
   mode: 'expanded',
-  openSections: { tasks: true, repos: true, files: true, device: false, ports: false, profiles: false, worktrees: true },
+  openSections: { tasks: true, repos: true, files: true, device: false, ports: false, profiles: false, worktrees: true, quickLaunch: true },
   activeRepoPath: null,
   repoPaths: [],
 


### PR DESCRIPTION
## Summary
- New sidebar section between **TASKS** と **REPOSITORIES** に **Claude / Codex / Gemini** 一発起動 chip を追加 (Apple Superset 風のトップ近接ショートカット)
- chip タップ → `addPane('terminal')` → `useTerminalStore.insertCommand(cli + '\n')` という既存パターンの再利用 (Snippet 経路 + Worktrees の \"open in pane\" と同じ)
- terminal pane cap (3) は `useAddPane` 既存 alert で respect

## 変更点
- \`components/layout/QuickLaunchSection.tsx\` (新規 ~120 LOC)
- \`components/layout/Sidebar.tsx\` (1 import + 1 ブロック挿入)
- \`store/sidebar-store.ts\` (SidebarSection union に \`quickLaunch\` 追加、default open)

## Test plan
- [ ] CI build (#804?) → APK install
- [ ] Sidebar に新 \"QUICK LAUNCH\" セクションが TASKS の直下に出る
- [ ] Claude chip タップ → 新 terminal pane が開く + \`claude\` プロンプト
- [ ] Codex / Gemini chip も同様
- [ ] terminal cap (3) に達してる状態でタップ → 既存 alert
- [ ] persist hydration: 旧 install からの upgrade で section が default open

🤖 Generated with [Claude Code](https://claude.com/claude-code)