### PR TITLE
docs(readme): surface codex-login --open in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ On first launch Shelly asks for **All files access** so the terminal can read sc
 
 After that, open **Settings → API Keys** (or run `shelly config` from the terminal pane) to paste your Claude / Gemini / Cerebras / Groq / Perplexity keys. Keys are stored in `expo-secure-store` and never written to logs. The terminal is ready in under 5 minutes.
 
+### Sign in to the AI CLIs
+
+Each CLI has a different login path on Shelly today. The TL;DR:
+
+| CLI | How to sign in | Notes |
+|---|---|---|
+| **Codex** (ChatGPT subscription) | `codex-login --open` from any terminal pane | Fully in-app — opens auth.openai.com in Shelly's Browser Pane, writes `~/.codex/auth.json` (mode `0600`) on success. No OpenAI API key needed; uses your ChatGPT Plus/Pro/Team/Enterprise subscription. Verify with `shelly doctor`. |
+| **Claude Code** | Credential transplant | First-run OAuth from Anthropic does not yet complete inside Shelly — finish `/login` in another environment (Termux, PC, Codespaces) and copy the credentials. See [Bring your own credentials](#bring-your-own-credentials). |
+| **Gemini CLI** | Credential transplant | Same pattern as Claude — authenticate elsewhere, then transplant `~/.gemini/`. See [Bring your own credentials](#bring-your-own-credentials). |
+
+> **Codex login was easy to miss.** If you ran `codex` and tried `/login` inside the REPL, it returned "Unknown command" — the bundled `codex-termux` rebuild has the login subcommand compiled out. The flow above (`codex-login --open` from bash, *not* `codex /login` inside the REPL) is the supported path.
+
+In-app OAuth for Claude / Gemini is being worked on (browser-launch via `xdg-open` shim → in-app Browser Pane). Until that lands, the credential-transplant path is the recommended one.
+
 ---
 
 ## Flagship Runtime


### PR DESCRIPTION
## Summary
Fixes a user-discoverability bug. ナホン ([@s130424](https://twitter.com/s130424)) tried Shelly, ran \`codex\`, typed \`/login\` inside the REPL, got \"Unknown command\", gave up — and posted on X that Codex login doesn't work. It does, but only for users who know the magic incantation \`codex-login --open\`.

The only README reference to \`codex-login\` was at line 614 inside the long Known Limitations section. The Quick Start section above only mentioned API Keys. Anyone who reads top-down through Quick Start has zero way to learn about the actual in-app device-auth flow that's already been shipping for weeks.

## Change
Adds a \"Sign in to the AI CLIs\" subsection right inside Quick Start with a per-CLI table:

| CLI | How to sign in | Notes |
|---|---|---|
| Codex | \`codex-login --open\` from any terminal pane | Already works in-app today |
| Claude Code | Credential transplant | OAuth in-app not yet complete |
| Gemini CLI | Credential transplant | Same as Claude |

Plus an explicit warning that \`codex /login\` inside the REPL **won't** work — the bundled codex-termux rebuild has the login subcommand compiled out, so the supported path is \`codex-login --open\` from bash.

## Why this is its own PR
- Docs-only, no code touched
- Independent of the in-flight CI hotfix ([apps#35](https://github.com/RYOITABASHI/Shelly/pull/35)) and Phase 1 OAuth work ([apps#34](https://github.com/RYOITABASHI/Shelly/pull/34))
- Mergeable today regardless of those — fixes the most acute user-pain symptom (people not finding the login flow at all) without waiting on the build pipeline to recover

## Test plan
- [ ] Render the README on github.com — section renders correctly with the table and callout
- [ ] Cross-link from \`#bring-your-own-credentials\` continues to work (anchor preserved)

## Out of scope
- Updating the Zenn article (\`zenn.dev/ryoitabashi/articles/dc498e0ff46313\`) — that's the author's territory; recommend mirroring the same Codex login section there since that's the actual entry point most users came through
- Phase 1 OAuth landing for Claude / Gemini ([apps#34](https://github.com/RYOITABASHI/Shelly/pull/34))

🤖 Generated with [Claude Code](https://claude.com/claude-code)