### PR TITLE
fix(browser): WebView responsiveness + addPane/openUrl race for OAuth

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -237,12 +237,21 @@ export default function RootLayout() {
           const raw = parsed.queryParams?.url;
           const target = Array.isArray(raw) ? raw[0] : raw;
           if (typeof target === 'string' && target.length > 0) {
-            // Ensure a Browser pane exists before firing the openSignal —
-            // otherwise navigations fire into the void if the user has no
-            // Browser pane materialised yet. addPane is idempotent with
-            // respect to 'browser' type (the multi-pane store merges into
-            // an existing slot when available).
-            try { useMultiPaneStore.getState().addPane('browser'); } catch {}
+            // Only addPane('browser') when no Browser Pane is mounted.
+            // The store's addPane unconditionally creates a new slot; if
+            // we called it on every deep link, repeated `shelly://browser`
+            // dispatches would spawn extra Browser Panes side-by-side.
+            // BrowserPane reads openSignal.url at initial mount so a
+            // freshly-created pane still picks up the URL on first
+            // render. (Was: "addPane is idempotent" — that was wrong;
+            // verified by use-multi-pane.ts:471.)
+            try {
+              const slots = useMultiPaneStore.getState().slots;
+              const hasBrowser = slots.some((s) => s?.tab === 'browser');
+              if (!hasBrowser) {
+                useMultiPaneStore.getState().addPane('browser');
+              }
+            } catch {}
             useBrowserStore.getState().openUrl(target);
             logInfo('DeepLink', `openUrl dispatched: ${target}`);
           }
@@ -311,7 +320,25 @@ export default function RootLayout() {
             logError('DeepLinkQueue', `rejected non-http(s) url: ${url.slice(0, 64)}`);
             continue;
           }
-          try { useMultiPaneStore.getState().addPane('browser'); } catch {}
+          // Only call addPane('browser') if no Browser Pane is already
+          // mounted. addPane unconditionally allocates a new slot, so
+          // calling it when a Browser Pane already exists creates a
+          // SECOND one — and even worse, the new pane misses the
+          // openSignal because its lastOpenSeqRef captures the current
+          // (post-openUrl) seq on mount and the useEffect skips the
+          // navigation. The combined effect is the "Browser Pane
+          // appears but the URL doesn't load" bug observed on Z Fold6.
+          // BrowserPane's currentUrl initial state also reads
+          // openSignal.url so a fresh pane picks up the URL on first
+          // render; this guard just keeps us from spamming new panes
+          // on every queued URL.
+          try {
+            const slots = useMultiPaneStore.getState().slots;
+            const hasBrowser = slots.some((s) => s?.tab === 'browser');
+            if (!hasBrowser) {
+              useMultiPaneStore.getState().addPane('browser');
+            }
+          } catch {}
           useBrowserStore.getState().openUrl(url);
           logInfo('DeepLinkQueue', `openUrl dispatched (queue): ${url}`);
         }

--- a/components/panes/BrowserPane.tsx
+++ b/components/panes/BrowserPane.tsx
@@ -209,6 +209,21 @@ export interface BrowserPaneProps {
   visible?: boolean;
 }
 
+// Module-scoped guard against stale `openSignal.url` poisoning fresh
+// Browser Panes. The store never clears openSignal.url, so once any
+// xdg-open / deep link has dispatched a URL, the value sticks
+// forever. Without this guard, opening a fresh Browser Pane manually
+// (Sidebar "+ browser" / split) hours later would silently reload
+// the last URL — confusing, since the user expected about:blank.
+//
+// We track the last seq the BrowserPane mount-initializer has
+// consumed. A new mount only honours `openSignal.url` if its seq is
+// strictly greater than the last consumed one. The existing pane-
+// instance navigation `useEffect` (which has its own per-instance
+// `lastOpenSeqRef`) is unchanged — it still fires on every seq bump
+// to navigate the already-mounted Browser Pane.
+let lastConsumedOpenSignalSeq = 0;
+
 // User-Agent strings. The Android system WebView default UA includes a
 // `wv` token (Build/...; wv) AppleWebKit) which providers like Google,
 // Anthropic, and many other OAuth flows treat as an "embedded WebView"
@@ -356,9 +371,21 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
   // openSignal.url at mount time and use it as the initial URL when
   // present. This is the fix for "xdg-open https://example.com opens
   // a Browser Pane but the URL doesn't load" reported on Z Fold6.
+  //
+  // The `lastConsumedOpenSignalSeq > seq` guard prevents stale URLs
+  // from poisoning fresh manual Browser Pane opens long after the
+  // last queued URL. Without it, a Sidebar "+ browser" hours later
+  // would silently reload the last xdg-open'd URL.
   const initialResolvedUrl = (() => {
-    const pending = useBrowserStore.getState().openSignal.url;
-    if (pending && /^https?:\/\//i.test(pending)) return pending;
+    const s = useBrowserStore.getState();
+    if (
+      s.openSignal.url &&
+      s.openSignal.seq > lastConsumedOpenSignalSeq &&
+      /^https?:\/\//i.test(s.openSignal.url)
+    ) {
+      lastConsumedOpenSignalSeq = s.openSignal.seq;
+      return s.openSignal.url;
+    }
     return initialUrl;
   })();
   const [inputUrl, setInputUrl] = useState(

--- a/components/panes/BrowserPane.tsx
+++ b/components/panes/BrowserPane.tsx
@@ -128,6 +128,65 @@ const FULLSCREEN_BRIDGE_JS = `
 true;
 `;
 
+// JS injected BEFORE the page document loads — handles WebView
+// fingerprint masking and responsiveness setup before the page first
+// queries them.
+//
+//   1. navigator.userAgentData (Client Hints) is populated by Chromium
+//      independently of the `userAgent` prop and on Android WebView
+//      still reports the embedded build, which sites doing modern
+//      UA-CH detection (increasingly common) use to detect WebView
+//      regardless of the UA string. Define `userAgentData` as
+//      undefined so detection falls back to the (cleaned) UA string.
+//
+//   2. Inject a default `<meta name=viewport>` for pages that don't
+//      set one. Done in *before-content* so the WebView's first layout
+//      pass sees it. Post-load injection on Android is a no-op — the
+//      viewport is read once at initial layout and Chromium doesn't
+//      re-read it from a mutated tag.
+//
+//      Heuristic: skip injection if a viewport meta tag exists at all
+//      (regardless of its content). Pages that ship a viewport meta —
+//      including OAuth providers and most mainstream sites — already
+//      have intentional values, e.g. `user-scalable=no`. Overwriting
+//      drops those.
+//
+//   3. Define `window.__shellyResize` so the RN side can hand-fire a
+//      `resize` event on pane dimension changes (the WebView's bounds
+//      change but Chromium doesn't always dispatch the event on a
+//      same-document layout shift, leaving frameworks with
+//      ResizeObserver / window.onresize listeners stale).
+//
+// `true;` at the end is the react-native-webview convention so the
+// injection result is JSON-serialisable; we don't use the value.
+const RESPONSIVE_BRIDGE_JS = `
+(function() {
+  if (window.__shellyResponsiveInstalled) return;
+  window.__shellyResponsiveInstalled = true;
+  try {
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: undefined, configurable: true,
+    });
+  } catch (e) {}
+  try {
+    var existing = document.querySelector('meta[name="viewport"]');
+    if (!existing) {
+      var meta = document.createElement('meta');
+      meta.setAttribute('name', 'viewport');
+      meta.setAttribute('content', 'width=device-width, initial-scale=1');
+      if (document.head) document.head.appendChild(meta);
+      else document.addEventListener('DOMContentLoaded', function() {
+        if (document.head) document.head.appendChild(meta);
+      });
+    }
+  } catch (e) {}
+  window.__shellyResize = function() {
+    try { window.dispatchEvent(new Event('resize')); } catch (e) {}
+  };
+})();
+true;
+`;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -150,11 +209,26 @@ export interface BrowserPaneProps {
   visible?: boolean;
 }
 
-// User-Agent strings. Mobile is the react-native-webview default, so when
-// the user picks "Desktop" we send a current Chrome UA instead. Desktop UA
-// is useful on sites like YouTube where the mobile layout has giant tiles
-// and is painful to scroll through looking for a video.
-const MOBILE_UA = undefined; // let the WebView pick its default
+// User-Agent strings. The Android system WebView default UA includes a
+// `wv` token (Build/...; wv) AppleWebKit) which providers like Google,
+// Anthropic, and many other OAuth flows treat as an "embedded WebView"
+// signal and refuse to show their sign-in UI for. Google's
+// "disable_webview_sign_in" policy is the canonical example: it returns
+// a "this browser or app may not be secure" error page in Chrome WebView.
+//
+// Phase 1 OAuth on Shelly fundamentally needs WebView to look like a
+// real Chrome instance to providers, otherwise Browser Pane navigation
+// reaches the auth URL but the consent / sign-in UI is gated. Strip
+// the `wv` token by setting a custom mobile UA matching real Chrome on
+// Android. Same UA Chrome on Android sends today (Chrome 131 stable).
+//
+// When the user picks "Desktop" we send a Mac Chrome UA instead — same
+// rationale as before (YouTube etc. show a more usable layout on
+// desktop).
+const MOBILE_UA =
+  'Mozilla/5.0 (Linux; Android 14) ' +
+  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 ' +
+  'Mobile Safari/537.36';
 const DESKTOP_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
   'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
@@ -269,8 +343,28 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
     [userBookmarks],
   );
 
-  const [inputUrl, setInputUrl] = useState(initialUrl === 'about:blank' ? '' : initialUrl);
-  const [currentUrl, setCurrentUrl] = useState(initialUrl);
+  // Resolve the URL to show on first mount. The drainQueue path in
+  // app/_layout.tsx and the deep-link handler both call
+  // `addPane('browser')` THEN `openUrl(url)` — addPane creates a fresh
+  // Browser Pane in a new slot and openUrl bumps the openSignal seq.
+  // If we naively initialised currentUrl to `initialUrl` ('about:blank'),
+  // the new Browser Pane would mount with about:blank, then its
+  // useEffect would compare openSignal.seq to lastOpenSeqRef (set to
+  // CURRENT seq on mount, which is post-openUrl), see they're equal,
+  // and skip the navigation — the user gets an empty Browser Pane
+  // even though a URL was queued. Instead, peek at the latest
+  // openSignal.url at mount time and use it as the initial URL when
+  // present. This is the fix for "xdg-open https://example.com opens
+  // a Browser Pane but the URL doesn't load" reported on Z Fold6.
+  const initialResolvedUrl = (() => {
+    const pending = useBrowserStore.getState().openSignal.url;
+    if (pending && /^https?:\/\//i.test(pending)) return pending;
+    return initialUrl;
+  })();
+  const [inputUrl, setInputUrl] = useState(
+    initialResolvedUrl === 'about:blank' ? '' : initialResolvedUrl,
+  );
+  const [currentUrl, setCurrentUrl] = useState(initialResolvedUrl);
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const [activeBookmarkIdx, setActiveBookmarkIdx] = useState(0);
@@ -322,6 +416,20 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
   const handleBack = useCallback(() => { webviewRef.current?.goBack(); }, []);
   const handleForward = useCallback(() => { webviewRef.current?.goForward(); }, []);
   const handleRefresh = useCallback(() => { webviewRef.current?.reload(); }, []);
+
+  // Force a JS-level resize event whenever the pane changes size. The
+  // Android WebView container resizes its viewport, but pages that use
+  // ResizeObserver / window.onresize listeners often miss the change
+  // because no `resize` is dispatched on a same-document layout shift.
+  // Result: page stays laid out for the previous pane width — content
+  // gets cut off / scaled wrong. Hand-firing keeps the page in sync.
+  useEffect(() => {
+    if (paneWidth <= 0 || paneHeight <= 0) return;
+    webviewRef.current?.injectJavaScript(`
+      try { window.__shellyResize && window.__shellyResize(); } catch (e) {}
+      true;
+    `);
+  }, [paneWidth, paneHeight]);
 
   const handleBookmarkTap = useCallback((url: string, index: number) => {
     setActiveBookmarkIdx(index);
@@ -468,11 +576,29 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
           ref={webviewRef}
           source={{ uri: currentUrl }}
           style={styles.webview}
-          textZoom={compactChrome ? 85 : 100}
+          // textZoom kept at 90% in compact panes as a legibility safety
+          // net. The viewport-meta injection handles pages that lack a
+          // viewport tag, but mainstream pages already ship their own
+          // viewport — for those, only a textZoom nudge actually
+          // affects perceived text size in a narrow pane. 90% is
+          // gentler than the previous 85% which produced inconsistent
+          // UX between text and surrounding chrome.
+          textZoom={compactChrome ? 90 : 100}
           userAgent={desktopMode ? DESKTOP_UA : MOBILE_UA}
+          // GPU-accelerated rendering. Default Android WebView uses
+          // software layers in some configurations; hardware speeds up
+          // scrolling, video, and CSS-transform-driven OAuth UIs.
+          androidLayerType="hardware"
           onNavigationStateChange={handleNavigationStateChange}
           onMessage={handleMessage}
-          injectedJavaScriptBeforeContentLoaded={FULLSCREEN_BRIDGE_JS}
+          // RESPONSIVE_BRIDGE_JS must run BEFORE first paint so the
+          // injected viewport meta and userAgentData mask are in
+          // place before Chromium's initial layout / fingerprinting.
+          // FULLSCREEN_BRIDGE_JS is appended to the same string so we
+          // only invoke one before-content-loaded payload.
+          injectedJavaScriptBeforeContentLoaded={
+            RESPONSIVE_BRIDGE_JS + FULLSCREEN_BRIDGE_JS
+          }
           javaScriptEnabled
           domStorageEnabled
           mediaPlaybackRequiresUserAction={false}
@@ -480,6 +606,14 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
           thirdPartyCookiesEnabled
           sharedCookiesEnabled
           allowsInlineMediaPlayback
+          // Allow https pages to load http subresources where modern
+          // browsers would. `compatibility` matches Chrome stable's
+          // mixed-content policy — opt out of `never` (the WebView
+          // default) which silently breaks legacy intranet/SAML setups.
+          // Note: this is not what fixes Google / Anthropic OAuth (those
+          // are HTTPS end-to-end); it's just bringing WebView in line
+          // with system browser behaviour.
+          mixedContentMode="compatibility"
           onError={() => {
             // Reload on render-process crash so YouTube recovers instead
             // of showing a blank white screen until manual refresh.


### PR DESCRIPTION
Phase 1.1 follow-up to the in-app OAuth bridge from #34. On-device
testing on Galaxy Z Fold6 (Android 14) surfaced two distinct WebView
problems and one race condition.

## Symptoms reported

1. **OAuth providers refuse the WebView or render degraded UI** — auth
   pages load but interaction is awkward, Google sign-in hits the
   "this browser may not be secure" page (Google's
   \`disable_webview_sign_in\` policy).

2. **Pane resize doesn't reflow page content** — when the user drags
   the multi-pane divider, the WebView's bounds change but the page
   inside keeps its previous layout. Text inputs and YouTube are
   cramped at the wrong scale.

3. **\`xdg-open <url>\` queues correctly but Browser Pane appears
   empty** — the URL is dispatched, the pane mounts, but no
   navigation happens.

## Root causes

- **(1)** Android WebView's default UA contains the \`wv\` token, which
  OAuth providers detect as \"embedded WebView\". \`navigator.user
  AgentData\` (Client Hints) is also populated independently and gives
  away the WebView identity even with a clean UA string.
- **(2)** Chromium reads \`<meta name=viewport>\` only at initial
  layout — post-load mutation doesn't re-trigger reflow. Pages
  without a viewport meta render at the legacy 980 px and never adapt
  to the actual pane width. Pages WITH a viewport meta still don't
  fire \`resize\` events on a same-document pane resize, so framework-
  level ResizeObserver / window.onresize listeners stay frozen.
- **(3)** \`useMultiPaneStore.addPane('browser')\` always allocates a
  new slot (verified at use-multi-pane.ts:471 — comment claiming
  \"idempotent for type 'browser'\" was wrong). The new BrowserPane
  mounts AFTER \`openSignal.seq\` is bumped, so its
  \`lastOpenSeqRef\` captures the post-\`openUrl\` seq on mount and
  the navigation \`useEffect\` skips. Combined effect: empty pane
  even though a URL was queued.

## Fixes

### components/panes/BrowserPane.tsx

- Generic Chrome-Mobile UA without the \`wv\` token — unblocks
  Anthropic, GitHub, and most non-Google OAuth flows. **Google still
  blocks the WebView via the \`X-Requested-With\` header that Chromium
  injects with the host package name; that's a Custom Tabs / external-
  browser-handoff fix and is out of scope here.**
- \`RESPONSIVE_BRIDGE_JS\` injected via \`injectedJavaScript
  BeforeContentLoaded\` (alongside the existing fullscreen bridge):
  - Masks \`navigator.userAgentData\` to undefined so UA-CH detection
    falls back to the cleaned UA string.
  - Injects a default \`<meta name=viewport>\` for pages that lack
    one (skip if any viewport meta exists — overwriting drops
    intentional directives like \`user-scalable=no\`).
  - Exposes \`window.__shellyResize()\` for the RN side to fire a
    real \`resize\` event.
- \`useEffect\` on \`[paneWidth, paneHeight]\` calls
  \`__shellyResize()\` whenever the pane dimensions change. Pages
  using ResizeObserver / window.onresize listeners reflow on pane-
  divider drag instead of staying frozen.
- \`androidLayerType=\"hardware\"\` for GPU-accelerated rendering.
- \`mixedContentMode=\"compatibility\"\` matches Chrome stable's
  policy. (Comment notes this is **not** the OAuth fix —
  Anthropic/Google are HTTPS end-to-end — just brings WebView in line
  with the system browser on legacy intranet/SAML edge cases.)
- \`textZoom={compactChrome ? 90 : 100}\` (was 85 / 100). The
  viewport injection helps no-viewport pages but mainstream pages
  ship their own viewport, so a gentle textZoom nudge is the only
  thing that actually shrinks text on narrow panes. 90 % is less
  aggressive than 85 %.
- \`currentUrl\` initial state reads
  \`useBrowserStore.getState().openSignal.url\` (gated by a module-
  level \`lastConsumedOpenSignalSeq\`). Solves the
  addPane/openUrl race without poisoning manual Browser Pane opens
  with stale URLs from earlier sessions.

### app/_layout.tsx

- Both \`drainQueue\` and \`handleDeepLink\` paths now check whether a
  Browser Pane already exists before calling \`addPane('browser')\`.
  Without the guard, repeated queued URLs spawn extra Browser Panes
  side-by-side.

## Out of scope (Phase 1.2 candidates)

- **Google OAuth in-WebView is still gated** by the
  \`X-Requested-With\` header. Custom Tabs trampoline or
  \`onShouldStartLoadWithRequest\` + custom request rewrite is the
  proper fix.
- Multiple Browser Panes both navigate on every \`openUrl\` —
  \`openSignal\` is global. Making per-pane targeting (focused-pane-
  only consumes) is a follow-up if split-browser usage becomes
  common.
- DRY the addPane guard between drainQueue and handleDeepLink
  into an \`ensureBrowserPane()\` helper.
- \`androidLayerType=\"hardware\"\` smoke test against pane-contained
  YouTube fullscreen (the existing CSS-fake fullscreen uses extreme
  z-index which can clip under hardware layers).

## Test plan

- [ ] On-device build green for run \`25543799099\`
- [ ] After install: \`xdg-open https://example.com\` actually loads
      example.com in Browser Pane (was empty in v82)
- [ ] Drag pane divider while Browser Pane has a page loaded — page
      reflows to new width
- [ ] Open \`auth.anthropic.com\` Claude login — sign-in UI is
      interactive (Google sign-in still blocked, expected)
- [ ] Tap text input on a no-viewport page — no excessive auto-zoom
- [ ] After xdg-open completes + Browser Pane closed, manually open
      a new Browser Pane — does NOT auto-reload the previous URL
- [ ] YouTube fullscreen still works pane-contained (smoke test for
      hardware layer regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)