### PR TITLE
fix(panes): hotfix Phase 1.1 render storm + YouTube WebView regression

### DIFF
--- a/components/panes/BrowserPane.tsx
+++ b/components/panes/BrowserPane.tsx
@@ -351,7 +351,17 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
     [paneId, enterFullscreen, exitFullscreen],
   );
 
-  const { bookmarks: userBookmarks, addBookmark, removeBookmark, loadBookmarks } = useBrowserStore();
+  // Selector-based reads. Whole-store destructure (`useBrowserStore()`)
+  // re-renders on every store update including `openSignal` / `navSignal`
+  // bumps. Combined with the new pane-resize injectJavaScript effect and
+  // YouTube's heavy SPA traffic (onMessage / onNavigationStateChange
+  // burst), this contributed to the 40 fps render storm observed on
+  // Z Fold6 hardware. Per-key selectors only re-fire on the slice
+  // actually changing.
+  const userBookmarks = useBrowserStore((s) => s.bookmarks);
+  const addBookmark = useBrowserStore((s) => s.addBookmark);
+  const removeBookmark = useBrowserStore((s) => s.removeBookmark);
+  const loadBookmarks = useBrowserStore((s) => s.loadBookmarks);
   // Presets are always shown first, followed by user-added bookmarks
   const bookmarks = React.useMemo(
     () => [...PRESET_BOOKMARKS, ...userBookmarks],
@@ -500,6 +510,15 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
           onSubmitEditing={handleSubmit}
           placeholder="Enter a URL"
           placeholderTextColor="#6B7280"
+          // Explicit selectionColor / cursorColor so the caret + text-
+          // selection highlight remain visible against the dark URL bar
+          // background regardless of the active theme preset. Some Android
+          // themes default to a near-invisible cursor on dark inputs,
+          // which user-facing logged as "address bar text isn't visible"
+          // (the text was there, the caret wasn't, and the user couldn't
+          // see where they were typing).
+          selectionColor={C.accent}
+          cursorColor={C.accent}
           autoCapitalize="none"
           autoCorrect={false}
           keyboardType="url"
@@ -612,10 +631,16 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
           // UX between text and surrounding chrome.
           textZoom={compactChrome ? 90 : 100}
           userAgent={desktopMode ? DESKTOP_UA : MOBILE_UA}
-          // GPU-accelerated rendering. Default Android WebView uses
-          // software layers in some configurations; hardware speeds up
-          // scrolling, video, and CSS-transform-driven OAuth UIs.
-          androidLayerType="hardware"
+          // androidLayerType intentionally left at default ('none').
+          // Phase 1.1 (PR #37) tried 'hardware' for GPU-accelerated
+          // scroll / video / CSS transforms, but on-device test on
+          // Galaxy Z Fold6 (Android 14) revealed partial-paint
+          // regressions on YouTube: the WebView allocated tile
+          // textures that were either too small or never composited,
+          // leaving the player area mostly blank. The default lets
+          // the system pick, and on Android 14 that's already
+          // accelerated for video. Revisit only if profiling shows
+          // the default path is genuinely too slow.
           onNavigationStateChange={handleNavigationStateChange}
           onMessage={handleMessage}
           // RESPONSIVE_BRIDGE_JS must run BEFORE first paint so the

--- a/components/panes/TerminalPane.tsx
+++ b/components/panes/TerminalPane.tsx
@@ -96,7 +96,20 @@ export default function TerminalScreen() {
     return null;
   });
   const globalActiveSession = useActiveSession();
-  const { removeSession, sessions, settings } = useTerminalStore();
+  // Selector-based reads. The previous `const { removeSession, sessions,
+  // settings } = useTerminalStore()` whole-store destructure caused a
+  // re-render on EVERY store update (transcript byte append, cwd change,
+  // any session field mutation). Combined with `ensureNativeSessions`'s
+  // `[sessions, …]` useCallback deps, that re-built the callback every
+  // render, re-fired the dependent useEffect, and produced the 40 fps
+  // logcat storm observed on Z Fold6 the moment a heavy WebView SPA
+  // (YouTube) started posting onMessage / onNavigationStateChange.
+  // Splitting into per-key selectors keeps each subscription scoped to
+  // its own slice — `sessions` array reference only flips on
+  // add/remove/edit, not on every byte append.
+  const sessions = useTerminalStore((s) => s.sessions);
+  const removeSession = useTerminalStore((s) => s.removeSession);
+  const settings = useTerminalStore((s) => s.settings);
   // Phase B: when a wallpaper is set, ask the native TerminalView to drop
   // its opaque background + padding fill so the wallpaper shows through.
   // Cells with non-default backgrounds still paint, so prompt colours /
@@ -324,7 +337,17 @@ export default function TerminalScreen() {
   }, [createNativeSession]);
 
   // Ensure native sessions exist. Called on mount and foreground resume.
+  // Reads `sessions` via getState() rather than via the closure to keep
+  // this useCallback's identity stable across re-renders. Previously the
+  // dep `[sessions, ...]` made the callback re-create on every store
+  // update, which re-fired the dependent useEffect (line ~370) and
+  // produced a 40 fps render storm visible in logcat as
+  // `ensureNativeSessions called` once per render. Mutex on line 329
+  // already prevented runaway PTY creation; the loop was just log /
+  // scheduling churn, but enough to starve the WebView render thread
+  // when YouTube SPA was busy posting messages.
   const ensureNativeSessions = useCallback(async () => {
+    const sessions = useTerminalStore.getState().sessions;
     logInfo('Terminal', 'ensureNativeSessions called, sessions=' + sessions.length + ', mutex=' + sessionMutexRef.current);
     if (sessionMutexRef.current) return;
     sessionMutexRef.current = true;
@@ -357,7 +380,7 @@ export default function TerminalScreen() {
     } finally {
       sessionMutexRef.current = false;
     }
-  }, [sessions, createNativeSession, recoverSession]);
+  }, [createNativeSession, recoverSession]);
 
   // Run when terminal sessions are mounted or rehydrated. APK installs /
   // process restarts can restore persisted sessions after the first render;


### PR DESCRIPTION
Three on-device regressions surfaced when testing build #826 (Phase 1.1, PR #37) on Galaxy Z Fold6 / Android 14.

## Symptoms

1. **TerminalPane render storm** — logcat shows `[Shelly][TerminalScreen] ⚡ render` every ~25 ms (40 fps), each followed by \`ensureNativeSessions called, sessions=N\`. Hundreds of identical entries back-to-back, starves WebView render thread.

2. **WebView partial paint on YouTube** — Browser Pane shows search icon and "マイページ" placeholder text but most of the player area is blank. Persists across reload.

3. **URL bar caret invisible** — user reported "address bar text isn't visible". The text IS rendered; the caret isn't, and on some themes the contrast makes it look like the input is empty.

## Root causes (validated by independent agent review)

- **(1)** Pre-existing latent bug exposed by Phase 1.1. \`const { …, sessions, settings } = useTerminalStore()\` is a whole-store destructure that subscribes to every field. \`ensureNativeSessions\`'s \`useCallback([sessions, …])\` re-builds on every store mutation, the dependent \`useEffect\` re-fires, and \`logInfo('Terminal', 'ensureNativeSessions called…')\` runs each time. Mutex prevented runaway PTY creation; the cost was log/scheduling churn. Phase 1.1's real-Chrome UA makes YouTube serve the heavier m.youtube.com SPA which posts WebView messages frequently, exposing the bug.

- **(2)** \`androidLayerType=\"hardware\"\` (added in PR #37) is the documented react-native-webview regression for sites with heavy CSS transforms. Tile-texture allocation fails intermittently, especially on flex-display Android.

- **(3)** TextInput lacked explicit \`selectionColor\` / \`cursorColor\`. Default Android cursor on dark inputs is near-invisible.

## Fixes

### \`components/panes/TerminalPane.tsx\`
- Split whole-store destructure into per-key selectors: \`sessions\`, \`removeSession\`, \`settings\`.
- \`ensureNativeSessions\` reads sessions via \`useTerminalStore.getState().sessions\` inside the callback body and drops \`sessions\` from \`useCallback\` deps. Callback identity is now stable across renders.

### \`components/panes/BrowserPane.tsx\`
- Same selector pattern for \`useBrowserStore()\` (bookmarks / addBookmark / removeBookmark / loadBookmarks). Removes re-render trigger on \`openSignal\`/\`navSignal\` seq bumps.
- Drop \`androidLayerType=\"hardware\"\`. Default lets Android pick; Android 14 accelerates video paths anyway. Comment retained as a permanent warning.
- Explicit \`selectionColor={C.accent}\` / \`cursorColor={C.accent}\` on URL TextInput.

## Test plan (after install)

- [ ] logcat: \`adb logcat -s ReactNativeJS:I | grep TerminalScreen\` → renders only on actual user interaction, not 40 fps
- [ ] Browser Pane → youtube.com → video player area renders fully (no white slabs)
- [ ] Browser Pane → tap URL bar → caret visible, type → text shows up clearly
- [ ] xdg-open https://example.com → loads (Phase 1.1 race fix should still work)
- [ ] codex-login --open → still works end-to-end (Phase 1 + 1.1 sanity)

## Scope acknowledged

This PR does NOT audit every other component for whole-store destructures. Other panes (e.g., MarkdownPane, AIPane) may have the same anti-pattern; the symptom here was only TerminalPane + BrowserPane because those are the ones that re-render on YouTube SPA traffic. Filing a P1 follow-up to sweep the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)