### PR TITLE
fix(claude-runtime): Bun.* polyfill expansion for Claude Code 2.1.133

### DIFF
--- a/modules/terminal-emulator/android/src/main/assets/shelly-runtime-update.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-runtime-update.js
@@ -140,6 +140,69 @@ if (typeof globalThis.Bun.hash !== 'function') {
   __shellyHashBase.crc32 = __shellyHash32;
   globalThis.Bun.hash = __shellyHashBase;
 }
+// v82 (2026-05-08): Bun.* polyfill expansion. Sync mirror of the
+// HomeInitializer.kt heredoc — Claude Code 2.1.133's cli.js wraps every
+// Bun.* call in \`typeof Bun !== "u"\` guards then unconditionally
+// invokes the member, so when our polyfill installs \`Bun = {}\` every
+// guard takes the Bun branch and unfilled members crash. Repro 2026-05-08
+// on Z Fold6: \`globalThis.Bun.which is not a function\`. Audit found 4
+// surfaces called every startup (which / semver / YAML / gc) plus 1 rare
+// (generateHeapSnapshot) that we shim for safety. The remaining Bun.*
+// (wrapAnsi / JSONL / embeddedFiles / listen / spawn / version) are
+// tolerantly handled by cli.js when undefined and stay absent.
+if (typeof globalThis.Bun.which !== 'function') {
+  const __shellyChild = require('child_process');
+  globalThis.Bun.which = function shellyBunWhich(name) {
+    if (!name) return null;
+    try {
+      const r = __shellyChild.spawnSync('which', [String(name)], { encoding: 'utf8', stdio: ['ignore','pipe','ignore'], timeout: 1000 });
+      if (r.status === 0 && r.stdout) return r.stdout.trim() || null;
+    } catch (_) {}
+    return null;
+  };
+}
+if (!globalThis.Bun.semver || typeof globalThis.Bun.semver.order !== 'function') {
+  const __shellySemverCmp = function(a, b) {
+    const pa = String(a).replace(/^v/, '').split(/[.+-]/).map(function(x){ return /^\\d+$/.test(x) ? Number(x) : x; });
+    const pb = String(b).replace(/^v/, '').split(/[.+-]/).map(function(x){ return /^\\d+$/.test(x) ? Number(x) : x; });
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+      const x = pa[i] === undefined ? 0 : pa[i];
+      const y = pb[i] === undefined ? 0 : pb[i];
+      if (typeof x === 'number' && typeof y === 'number') { if (x !== y) return x < y ? -1 : 1; }
+      else { const sx = String(x), sy = String(y); if (sx !== sy) return sx < sy ? -1 : 1; }
+    }
+    return 0;
+  };
+  globalThis.Bun.semver = {
+    order: __shellySemverCmp,
+    satisfies: function(version, range) {
+      const v = String(version).replace(/^v/, '');
+      const r = String(range).trim();
+      const m = r.match(/^([<>]=?|=)?\\s*v?([\\w.+-]+)$/);
+      if (!m) return false;
+      const op = m[1] || '=', target = m[2];
+      const c = __shellySemverCmp(v, target);
+      return op === '=' ? c === 0 : op === '>=' ? c >= 0 : op === '<=' ? c <= 0 : op === '>' ? c > 0 : c < 0;
+    }
+  };
+}
+if (!globalThis.Bun.YAML || typeof globalThis.Bun.YAML.parse !== 'function') {
+  globalThis.Bun.YAML = {
+    parse: function(s) {
+      try { return require('yaml').parse(String(s)); }
+      catch (e) { throw new Error('Shelly Bun.YAML.parse: yaml package unavailable: ' + e.message); }
+    }
+  };
+}
+if (typeof globalThis.Bun.gc !== 'function') {
+  globalThis.Bun.gc = function shellyBunGc() {
+    try { if (typeof global !== 'undefined' && typeof global.gc === 'function') global.gc(); }
+    catch (_) {}
+  };
+}
+if (typeof globalThis.Bun.generateHeapSnapshot !== 'function') {
+  globalThis.Bun.generateHeapSnapshot = function() { throw new Error('Bun.generateHeapSnapshot unavailable on Shelly Node tier'); };
+}
 `;
 
 function log(line) {

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
@@ -1230,6 +1230,73 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
             sb.appendLine("  __shellyHashBase.crc32 = __shellyHash32;")
             sb.appendLine("  globalThis.Bun.hash = __shellyHashBase;")
             sb.appendLine("}")
+            // v82 Bun.* polyfill expansion. Claude Code 2.1.133's bundled
+            // cli.js (extracted-Node tier) checks `typeof globalThis.Bun
+            // !== "u"` before every Bun.* call, then unconditionally calls
+            // the member. Our previous polyfill installed `globalThis.Bun
+            // = {}` which makes ALL 33 typeof guards take the Bun branch
+            // — any unfilled member crashes. On-device repro 2026-05-08
+            // (Z Fold6): `globalThis.Bun.which is not a function` thrown
+            // from cli.js exec-discovery path. Independent agent audit
+            // (`grep "Bun\." cli.js`) found 13 distinct Bun.* surfaces;
+            // 4 of them (which / semver / YAML / gc) are called on every
+            // startup and need shims. The rest (wrapAnsi / JSONL /
+            // embeddedFiles / listen / spawn / generateHeapSnapshot /
+            // version) are tolerantly handled by cli.js when undefined,
+            // so we leave them absent.
+            sb.appendLine("if (typeof globalThis.Bun.which !== 'function') {")
+            sb.appendLine("  const __shellyChild = require('child_process');")
+            sb.appendLine("  globalThis.Bun.which = function shellyBunWhich(name) {")
+            sb.appendLine("    if (!name) return null;")
+            sb.appendLine("    try {")
+            sb.appendLine("      const r = __shellyChild.spawnSync('which', [String(name)], { encoding: 'utf8', stdio: ['ignore','pipe','ignore'], timeout: 1000 });")
+            sb.appendLine("      if (r.status === 0 && r.stdout) return r.stdout.trim() || null;")
+            sb.appendLine("    } catch (_) {}")
+            sb.appendLine("    return null;")
+            sb.appendLine("  };")
+            sb.appendLine("}")
+            sb.appendLine("if (!globalThis.Bun.semver || typeof globalThis.Bun.semver.order !== 'function') {")
+            sb.appendLine("  const __shellySemverCmp = function(a, b) {")
+            sb.appendLine("    const pa = String(a).replace(/^v/, '').split(/[.+-]/).map(function(x){ return /^\\d+\$/.test(x) ? Number(x) : x; });")
+            sb.appendLine("    const pb = String(b).replace(/^v/, '').split(/[.+-]/).map(function(x){ return /^\\d+\$/.test(x) ? Number(x) : x; });")
+            sb.appendLine("    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {")
+            sb.appendLine("      const x = pa[i] === undefined ? 0 : pa[i];")
+            sb.appendLine("      const y = pb[i] === undefined ? 0 : pb[i];")
+            sb.appendLine("      if (typeof x === 'number' && typeof y === 'number') { if (x !== y) return x < y ? -1 : 1; }")
+            sb.appendLine("      else { const sx = String(x), sy = String(y); if (sx !== sy) return sx < sy ? -1 : 1; }")
+            sb.appendLine("    }")
+            sb.appendLine("    return 0;")
+            sb.appendLine("  };")
+            sb.appendLine("  globalThis.Bun.semver = {")
+            sb.appendLine("    order: __shellySemverCmp,")
+            sb.appendLine("    satisfies: function(version, range) {")
+            sb.appendLine("      const v = String(version).replace(/^v/, '');")
+            sb.appendLine("      const r = String(range).trim();")
+            sb.appendLine("      const m = r.match(/^([<>]=?|=)?\\s*v?([\\w.+-]+)\$/);")
+            sb.appendLine("      if (!m) return false;")
+            sb.appendLine("      const op = m[1] || '=', target = m[2];")
+            sb.appendLine("      const c = __shellySemverCmp(v, target);")
+            sb.appendLine("      return op === '=' ? c === 0 : op === '>=' ? c >= 0 : op === '<=' ? c <= 0 : op === '>' ? c > 0 : c < 0;")
+            sb.appendLine("    }")
+            sb.appendLine("  };")
+            sb.appendLine("}")
+            sb.appendLine("if (!globalThis.Bun.YAML || typeof globalThis.Bun.YAML.parse !== 'function') {")
+            sb.appendLine("  globalThis.Bun.YAML = {")
+            sb.appendLine("    parse: function(s) {")
+            sb.appendLine("      try { return require('yaml').parse(String(s)); }")
+            sb.appendLine("      catch (e) { throw new Error('Shelly Bun.YAML.parse: yaml package unavailable: ' + e.message); }")
+            sb.appendLine("    }")
+            sb.appendLine("  };")
+            sb.appendLine("}")
+            sb.appendLine("if (typeof globalThis.Bun.gc !== 'function') {")
+            sb.appendLine("  globalThis.Bun.gc = function shellyBunGc() {")
+            sb.appendLine("    try { if (typeof global !== 'undefined' && typeof global.gc === 'function') global.gc(); }")
+            sb.appendLine("    catch (_) {}")
+            sb.appendLine("  };")
+            sb.appendLine("}")
+            sb.appendLine("if (typeof globalThis.Bun.generateHeapSnapshot !== 'function') {")
+            sb.appendLine("  globalThis.Bun.generateHeapSnapshot = function() { throw new Error('Bun.generateHeapSnapshot unavailable on Shelly Node tier'); };")
+            sb.appendLine("}")
             sb.appendLine("__SHELLY_CLAUDE_NODE_PRELOAD__")
             sb.appendLine("chmod 600 \"\$__shelly_claude_node_preload\" 2>/dev/null || true")
             // @anthropic-ai/claude-code dispatch. Default route is the


### PR DESCRIPTION
On-device test of Phase 1.1 (build #826, Galaxy Z Fold6) hit a new failure when the native Bun-SEA tier crashes and Shelly falls back to extracted-Node:

\`\`\`
ERROR  globalThis.Bun.which is not a function
/data/data/dev.shelly.terminal/files/termux-libs/node_modules/@anthropic-ai/claude-code-extracted/cli.js:664:8823
\`\`\`

The Bun-SEA segfault is independently broken (separate issue, not addressed here). The extracted-Node fallback was supposed to catch that — and does — but cli.js then throws because our Bun.* polyfill is missing several methods Claude 2.1.133 uses.

## Why every miss is fatal

cli.js guards every Bun.* call:
\`\`\`js
if (typeof globalThis.Bun !== "u")
  return globalThis.Bun.X(...)
return /* Node fallback */ ...
\`\`\`

Our pre-PR polyfill installs \`globalThis.Bun = {}\`. All 33 \`typeof Bun\` guards take the Bun branch. Any unfilled member crashes.

## Audit (independent agent)

Found 13 distinct Bun.* surfaces in cli.js. Already polyfilled: \`Bun.hash\`, \`Bun.stringWidth\`. Missing-and-fatal:

| API | When called |
|---|---|
| \`Bun.which\` | exec discovery (just hit on-device) |
| \`Bun.semver.order\` / \`.satisfies\` | plugin/MCP version gating, every startup |
| \`Bun.YAML.parse\` | config load path |
| \`Bun.gc\` | startup \`setInterval(Bun.gc, 1000)\` |
| \`Bun.generateHeapSnapshot\` | rare \`/heap\` diag, stubbed for safety |

The remaining (\`wrapAnsi\`, \`JSONL.parseChunk\`, \`embeddedFiles\`, \`listen\`, \`spawn\`, \`version\`, \`process.versions.bun\`) are tolerantly handled by cli.js when undefined and intentionally stay absent.

## Sync across two locations

The polyfill ships from two places, kept in sync:

- \`modules/.../java/.../HomeInitializer.kt\` (line ~1232) — bashrc heredoc that writes to \`~/.shelly-claude-node-preload.js\`. Applies on every shell start.
- \`modules/.../assets/shelly-runtime-update.js\` (line ~142) — runtime updater's own polyfill written to \`~/.shelly-runtime/claude/current/preload.js\`. Applies during nightly / manual refresh.

Same JS body, both 60-ish lines.

## Verified design

Independent agent code-review confirmed:
- \`Bun.which\` polyfill matches Bun's own contract (\`spawnSync('which', ...)\` with 1s timeout, returns string|null)
- \`Bun.semver\` minimal-range syntax covers what cli.js uses today (\`>=\`, \`<\`, \`=\`, exact). If upstream shifts to \`^\` / \`~\` ranges later we bring in the bundled \`semver\` package.
- \`Bun.YAML.parse\` defers to require('yaml') from cli.js's own node_modules.
- \`Bun.gc\` no-ops if --expose-gc isn't set; cli.js doesn't observe the result.

## Test plan

- [ ] CI build green
- [ ] After install: \`claude /login\` → completes auth without \`Bun.which is not a function\` (or any other Bun.* TypeError) on the cli.js fallback tier
- [ ] \`claude\` → REPL starts on cli.js fallback tier when Bun SEA segfaults
- [ ] (Stretch) Bun SEA tier might still segfault — that's the upstream Bun issue, not blocked by this PR

## Related

- Bun-SEA segfault upstream issue (linux-arm64-musl + bionic loader + 1.3.14): track at https://github.com/oven-sh/bun. Not addressed in this PR; cli.js fallback tier is now the reliable path.
- Related on-device discovery sequence: PR #34 (file-queue OAuth bridge), PR #37 (Phase 1.1 WebView), PR #39 (hotfix render storm), this PR (Bun polyfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)