### PR TITLE
fix(claude-runtime): bump BASHRC_VERSION 81→82 to ship Bun polyfill

### DIFF
--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
@@ -660,7 +660,16 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
     //        Direct execve target, libDir SELinux label allows it,
     //        no script-read audit involved. Also drops the
     //        ~/.shelly-xdg-open.js extraction (not needed anymore).
-    private const val BASHRC_VERSION = 81
+    //    82: PR #40 added Bun.which / Bun.semver / Bun.YAML / Bun.gc /
+    //        Bun.generateHeapSnapshot polyfills to the
+    //        ~/.shelly-claude-node-preload.js heredoc, but I forgot to
+    //        bump BASHRC_VERSION — devices with an existing $HOME (i.e.
+    //        every device that already had Shelly installed) kept the
+    //        v81 bashrc on disk and the v81 preload, so cli.js still
+    //        threw `globalThis.Bun.which is not a function` even after
+    //        the v82 APK install. Bumping the version forces bashrc
+    //        regeneration on next shell start and the new preload lands.
+    private const val BASHRC_VERSION = 82
 
     fun getHomeDir(context: Context): File =
         File(context.filesDir, "home").also { it.mkdirs() }


### PR DESCRIPTION
## What

One-line bump of \`BASHRC_VERSION\` 81 → 82 + history-comment update.

## Why

PR #40 (\`65b002e9\`, merged in \`672ed29e\`) added five Bun.* polyfills (\`which\`, \`semver\`, \`YAML\`, \`gc\`, \`generateHeapSnapshot\`) to the \`~/.shelly-claude-node-preload.js\` heredoc — but I forgot to bump \`BASHRC_VERSION\`. The bashrc regen check at \`HomeInitializer.kt\` is:

\`\`\`kotlin
if (!bashrc.exists() || currentVersion < BASHRC_VERSION) {
  // regenerate
}
\`\`\`

\`$HOME\` is app-private storage and survives APK reinstall. Devices with an existing v81 bashrc on disk **don't regenerate**, so the new polyfills never land — even after installing the v82 APK from #830.

## Repro

Install build #830 (which has both PR #39 and PR #40):

\`\`\`bash
$ claude
# ... Bun SEA segfaults, falls back through Path C-bis to cli.js tier ...
ERROR  globalThis.Bun.which is not a function
\`\`\`

The extracted-cli.js path correctly loads \`~/.shelly-claude-node-preload.js\` via \`NODE_OPTIONS --require\` (verified at line 1414). The preload is just **stale** — it's the v81 version with only \`Bun.hash\` + \`Bun.stringWidth\`.

## Fix

Bump only. No behavior change beyond forcing bashrc regeneration on next shell start, which writes the new preload with all five Bun.* polyfills in place.

## Verification plan

- [ ] CI build green
- [ ] After install: \`cat ~/.shelly-claude-node-preload.js | grep -c 'Bun.which'\` returns 1
- [ ] \`claude\` → REPL starts on cli.js fallback tier without \`Bun.which is not a function\`
- [ ] (Bun SEA still segfaults — separate upstream Bun stability issue, not in scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)