### PR TITLE
fix(browser): URL bar text visibility + IME compose + nav race

### DIFF
--- a/components/panes/BrowserPane.tsx
+++ b/components/panes/BrowserPane.tsx
@@ -451,6 +451,23 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
   const urlFocusedRef = useRef(false);
   useEffect(() => { urlFocusedRef.current = urlFocused; }, [urlFocused]);
 
+  // Android: TextInput.onBlur does NOT fire when the soft keyboard is
+  // dismissed via the system back button (RN issue facebook/react-native#29571,
+  // open since 2020). If the user focuses the URL bar, types nothing, then
+  // back-presses to close the keyboard, `urlFocused` stays true forever and
+  // `handleNavigationStateChange` permanently stops syncing the URL bar with
+  // the live WebView URL — every subsequent page navigation looks broken.
+  // Wire keyboardDidHide as a forced-blur fallback. Safe because if the bar
+  // really is focused with keyboard up via a different IME path, hide-then-
+  // show cycles will re-focus and re-set urlFocused via onFocus.
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    const sub = Keyboard.addListener('keyboardDidHide', () => {
+      setUrlFocused(false);
+    });
+    return () => sub.remove();
+  }, []);
+
   const handleNavigationStateChange = useCallback((state: WebViewNavigation) => {
     setCanGoBack(state.canGoBack);
     setCanGoForward(state.canGoForward);
@@ -549,7 +566,7 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
             onPress={() => setInputUrl('')}
             style={[styles.navBtn, compactChrome && styles.navBtnCompact]}
           >
-            <MaterialIcons name="close" size={compactChrome ? 12 : 14} color="#6B7280" />
+            <MaterialIcons name="close" size={compactChrome ? 12 : 14} color={C.text2} />
           </TouchableOpacity>
         )}
         <TouchableOpacity

--- a/components/panes/BrowserPane.tsx
+++ b/components/panes/BrowserPane.tsx
@@ -441,10 +441,20 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
     setCurrentUrl(url);
   }, [inputUrl]);
 
+  // Track URL bar focus so background navigation events (redirects, OAuth
+  // bounces, YouTube prefetch frames, etc.) don't trample the URL the user
+  // is in the middle of typing. Without this guard, typing
+  // `youtube.com<enter>` while WebView still has a previous page mounted
+  // results in setInputUrl(currentPageUrl) firing mid-keystroke and the
+  // user sees their input apparently deleted.
+  const [urlFocused, setUrlFocused] = useState(false);
+  const urlFocusedRef = useRef(false);
+  useEffect(() => { urlFocusedRef.current = urlFocused; }, [urlFocused]);
+
   const handleNavigationStateChange = useCallback((state: WebViewNavigation) => {
     setCanGoBack(state.canGoBack);
     setCanGoForward(state.canGoForward);
-    if (state.url && state.url !== 'about:blank') {
+    if (state.url && state.url !== 'about:blank' && !urlFocusedRef.current) {
       setInputUrl(state.url);
     }
     setCurrentUrl(state.url ?? 'about:blank');
@@ -508,8 +518,10 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
           value={inputUrl}
           onChangeText={setInputUrl}
           onSubmitEditing={handleSubmit}
+          onFocus={() => setUrlFocused(true)}
+          onBlur={() => setUrlFocused(false)}
           placeholder="Enter a URL"
-          placeholderTextColor="#6B7280"
+          placeholderTextColor={C.text2}
           // Explicit selectionColor / cursorColor so the caret + text-
           // selection highlight remain visible against the dark URL bar
           // background regardless of the active theme preset. Some Android
@@ -521,9 +533,16 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
           cursorColor={C.accent}
           autoCapitalize="none"
           autoCorrect={false}
+          // autoComplete + importantForAutofill kill the Android autofill
+          // overlay that competes with IME composition on URL fields. Without
+          // these, Samsung IME on Galaxy Z Fold6 shows suggestion chips for
+          // "youtube" but never commits the composing text into the field
+          // because autofill thinks it owns the input — user sees their typed
+          // text disappear into the suggestion bar.
+          autoComplete="off"
+          importantForAutofill="no"
           keyboardType="url"
           returnKeyType="go"
-          selectTextOnFocus
         />
         {inputUrl.length > 0 && (
           <TouchableOpacity
@@ -731,19 +750,22 @@ const styles = StyleSheet.create({
   },
   urlInput: {
     flex: 1,
-    height: 28,
+    height: 32,
     borderRadius: 4,
     backgroundColor: C.border,
     paddingHorizontal: 8,
+    paddingVertical: 0,
     fontFamily: F.family,
-    fontSize: 11,
+    fontSize: 13,
     color: C.text1,
+    textAlignVertical: 'center',
+    includeFontPadding: false,
   },
   urlInputCompact: {
-    height: 22,
+    height: 26,
     borderRadius: 3,
     paddingHorizontal: 6,
-    fontSize: 9,
+    fontSize: 12,
   },
   bookmarksBar: {
     height: 32,


### PR DESCRIPTION
## Summary

Three stacked regressions causing the **"address bar text isn't visible"** report on Galaxy Z Fold6:

1. **`fontSize: 9` in compact mode** — illegible. Bumped compact to 12, standard to 13. Heights raised so taller glyphs aren't clipped. Added `textAlignVertical:'center'` + `includeFontPadding:false`.
2. **Navigation race overwrites typing** — `handleNavigationStateChange` unconditionally called `setInputUrl(state.url)` on every WebView nav event, including background redirects / OAuth bounces / iframe prefetches. Tracking `urlFocused` via ref now guards the auto-update.
3. **Samsung IME compose mode breaks `selectTextOnFocus`** — field auto-selects on focus, IME composition for replacement text never commits, user sees suggestion chips for "youtube" but the field stays apparently empty. Removed `selectTextOnFocus`; added `autoComplete="off"` + `importantForAutofill="no"` so Android autofill doesn't compete with IME for input ownership.

Also brightened `placeholderTextColor` from hardcoded `#6B7280` to `C.text2` so it tracks the active theme preset.

This is a follow-up to #39 — that PR fixed the cursor visibility but the underlying triple-bug here was masked by it.

## Test plan

- [ ] Open Browser Pane on Z Fold6 cover (compact width)
- [ ] Tap URL bar, type "youtube.com" — text should be clearly visible at every keystroke
- [ ] Press Go — navigates correctly
- [ ] While a page is loading, focus URL bar and start typing — typed input should NOT be overwritten by the navigation completion event
- [ ] No autofill suggestion overlay appearing on top of the URL bar
- [ ] Cursor + selection highlight remain visible (regression check vs #39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)