### PR TITLE
fix(browser): stop WebView resize storm when keyboard toggles

### DIFF
--- a/components/panes/BrowserPane.tsx
+++ b/components/panes/BrowserPane.tsx
@@ -260,18 +260,27 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
   const compactChrome = (paneWidth > 0 && paneWidth < 430) || (paneHeight > 0 && paneHeight < 380);
   const tinyChrome = (paneWidth > 0 && paneWidth < 320) || (paneHeight > 0 && paneHeight < 300);
 
-  // Keyboard height tracking — same pattern as TerminalPane
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
-  useEffect(() => {
-    if (Platform.OS !== 'android') return;
-    const showSub = Keyboard.addListener('keyboardDidShow', (e) => {
-      setKeyboardHeight(e.endCoordinates.height);
-    });
-    const hideSub = Keyboard.addListener('keyboardDidHide', () => {
-      setKeyboardHeight(0);
-    });
-    return () => { showSub.remove(); hideSub.remove(); };
-  }, []);
+  // NOTE (2026-05-08): keyboard avoidance was previously done locally here
+  // with a Keyboard.addListener + paddingBottom: keyboardHeight on the root
+  // View. This duplicated MultiPaneContainer's own keyboard handling
+  // (gridHeight = size.H - keyboardHeight + paddingBottom: keyboardHeight on
+  // its root) — the BrowserPane root was being shrunk a SECOND time on top
+  // of the container shrink, which forced the WebView to resize 2-3 times
+  // per keyboard toggle. YouTube and other heavy SPAs (custom compositors,
+  // IntersectionObservers, layered scrollers) couldn't re-rasterize their
+  // tiles fast enough and ended up with corrupted paint (search bar
+  // duplicated, video grid disappearing, sections going black) until the
+  // keyboard was dismissed. Plain HTML pages were unaffected because their
+  // compositor has nothing to invalidate.
+  //
+  // Removed the local listener + padding entirely. The container already
+  // moves the whole pane grid up by keyboardHeight, so PaneInputBar (which
+  // renders inside this BrowserPane) rides above the keyboard automatically
+  // without WebView needing to resize.
+  //
+  // Codex independent review confirmed the diagnosis (2026-05-08):
+  //   "BrowserPane の paddingBottom は消すべき。MultiPaneContainer の
+  //    設計コメントと矛盾している。これは明確に二重管理"
 
   // Fullscreen bridge: when the WebView posts 'shelly:fs:on' we maximize
   // this pane, force landscape orientation, and hide the system chrome so
@@ -509,7 +518,7 @@ export default function BrowserPane({ initialUrl = 'about:blank' }: BrowserPaneP
 
   return (
     <View
-      style={[styles.root, { backgroundColor: C.bgDeep, paddingBottom: keyboardHeight }]}
+      style={[styles.root, { backgroundColor: C.bgDeep }]}
     >
       {/* URL bar */}
       <View style={[styles.toolbar, compactChrome && styles.toolbarCompact]}>


### PR DESCRIPTION
## Summary

Fixes YouTube + keyboard rendering corruption you flagged ([screenshots](https://github.com/RYOITABASHI/Shelly/issues)) — search bar duplicating, video grid disappearing, sections going black on Galaxy Z Fold6 whenever the soft keyboard pops up.

**Root cause** (confirmed by Codex independent review):

BrowserPane was running its own \`Keyboard.addListener\` and applying \`paddingBottom: keyboardHeight\` to its root View. But \`MultiPaneContainer\` ALREADY does the equivalent at the grid level (\`gridHeight = size.H - keyboardHeight\` + \`paddingBottom: keyboardHeight\` on its root). Combined with the Activity-level \`windowSoftInputMode="adjustResize"\`, the WebView ended up resizing 2-3 times per keyboard toggle.

Chromium's tile compositor for heavy SPA pages (custom compositors, IntersectionObservers, layered scroll containers) couldn't re-rasterize fast enough and left corrupted paint until the keyboard was dismissed. Plain HTML pages were unaffected because their compositor has nothing to invalidate.

**Fix**: drop the local listener + paddingBottom. Container already shifts the entire pane grid up by keyboardHeight, so \`PaneInputBar\` (rendered inside BrowserPane) stays above the keyboard without WebView needing to resize. One fewer resize trigger per toggle is enough to let YouTube's compositor stabilize.

This is **Stage 1** of Codex's three-stage plan. If YouTube still corrupts after this, next step is moving to \`windowSoftInputMode="adjustNothing"\` with central inset management — but that's a bigger change deferred until we verify Stage 1 isn't sufficient.

## Relationship to other PRs

- Independent of #41 (BASHRC bump) and #42 (URL bar visibility). Touches \`components/panes/BrowserPane.tsx\` like #42 but in a different region. If #42 lands first, this branch will need a trivial rebase to keep its \`Keyboard\` / \`Platform\` imports for the keyboardDidHide forced-blur listener.

## Test plan

- [ ] Open YouTube in Browser Pane on Z Fold6
- [ ] Focus URL bar → keyboard pops up → YouTube paint stays intact (no duplicated search bar, no missing video grid)
- [ ] Dismiss keyboard → page renders correctly (regression check)
- [ ] Other heavy SPAs (Twitter, Reddit) — same check
- [ ] PaneInputBar at bottom of Browser Pane (when not in compact mode) is still visible and accessible above the keyboard
- [ ] Standard pages (GitHub, plain HTML) still work
- [ ] Pane split layouts — keyboard toggle doesn't break sibling pane content

🤖 Generated with [Claude Code](https://claude.com/claude-code)