### PR TITLE
fix(claude-runtime): PR #48 — runtime updater reliability hardening

### DIFF
--- a/modules/terminal-emulator/android/src/main/assets/shelly-runtime-update.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-runtime-update.js
@@ -54,7 +54,21 @@ const FORCE = process.argv.includes('--force');
 // the full updater. No network downloads happen in this mode beyond the
 // metadata fetch (~10KB per package).
 const CHECK_ONLY = process.argv.includes('--check-only');
-const FAILED_COOLDOWN_S = Number(process.env.SHELLY_FAILED_VERSION_COOLDOWN || 3600);
+// 2026-05-08 Codex review (PR #48): 1h was too short. Foreground native
+// crashes corrupt the user's TUI; making them re-pay every hour is
+// painful. 24h gives the bg updater time to fetch a newer version.
+// Debug: set SHELLY_FAILED_VERSION_COOLDOWN=60 to force fast retries.
+//
+// Codex 3rd-pass review (push-prep): validate the env override so a
+// non-numeric value doesn't yield NaN and break (now - epoch) < NaN
+// comparisons (which always evaluates false → cooldown becomes a no-op,
+// silently bad). Bash side already validates via `*[!0-9]*`; this keeps
+// the two halves of the cooldown check in sync.
+const __PARSED_FAILED_COOLDOWN = Number(process.env.SHELLY_FAILED_VERSION_COOLDOWN || 86400);
+const FAILED_COOLDOWN_S =
+  Number.isFinite(__PARSED_FAILED_COOLDOWN) && __PARSED_FAILED_COOLDOWN > 0
+    ? __PARSED_FAILED_COOLDOWN
+    : 86400;
 const TOOL = process.argv.find((arg) => arg === 'claude' || arg === 'codex' || arg === 'gemini') || 'all';
 
 // Channel selection — default `verified` per 2026-04-25 design
@@ -358,13 +372,72 @@ function readFailedVersions() {
   }
 }
 
-function recordFailedVersion(tool, version) {
+// Codex review 2026-05-08 (PR #48 spec item 8): failure classification.
+// Previously every smoke failure went into .failed-versions cooldown
+// uniformly. Codex pushed back: auth_failed != binary_failed,
+// network_failed != binary_failed, panic/signal != binary_failed.
+//
+// Classification:
+//   signal     — exit >= 128 (binary genuinely crashed via signal)
+//   exit       — non-zero non-signal status (binary returned an error)
+//   auth       — --print failure with auth-error patterns in output
+//   network    — caller caught a network/IO exception
+//   shape      — tarball or SEA shape unexpected (validateClaudeShape)
+//   extraction — extractClaudeCliFromSea threw
+//
+// Cooldown semantics: only `signal` and `exit` and `shape` are recorded
+// to .failed-versions (the binary itself is bad). `auth` / `network` /
+// `extraction` go to .failure-log (diagnostic only) so the user / next
+// updater run sees the history but the version isn't blocked from
+// promotion when the user fixes their auth or net comes back.
+const FAILURE_LOG = path.join(ROOT, '.failure-log');
+const COOLDOWN_CATEGORIES = new Set(['signal', 'exit', 'shape']);
+
+function classifyFailure({ status, signal, stdout = '', stderr = '' } = {}) {
+  // Native runs return status >= 128 for signal-killed processes
+  // (128 + signal_number). Node child_process also exposes `signal`
+  // directly, which we prefer when present.
+  if (signal) return 'signal';
+  if (typeof status === 'number' && status >= 128) return 'signal';
+  // Auth-failure patterns observed in Claude Code stderr/stdout when
+  // credentials are missing/expired. Conservative — anything that
+  // mentions auth/credentials/401/unauthorized in the output is
+  // classified as auth so we don't mistakenly cooldown a healthy binary
+  // that just lost its login.
+  // Codex push-prep review: `\bunauthor\b` doesn't match `unauthorized`
+  // because the closing \b sits between `r` and `i`, both word chars.
+  // Matched substrings are explicit now; word boundaries only where
+  // they're meaningful (numeric status codes).
+  const combined = `${stdout}${stderr}`.toLowerCase();
+  if (/(unauthori[sz]ed|unauthenticated|authentication|invalid api key|expired token|\b401\b|\b403\b)/.test(combined)) {
+    return 'auth';
+  }
+  // Default: non-zero non-signal exit means the binary returned an error
+  // we can't categorise more specifically. Treat as cooldown-worthy
+  // (the binary itself misbehaved on input it should handle).
+  return 'exit';
+}
+
+function recordFailedVersion(tool, version, category = 'exit', reason = '') {
   try {
     fs.mkdirSync(ROOT, { recursive: true, mode: 0o700 });
-    const line = `${tool}=${version} ${Math.floor(Date.now() / 1000)}\n`;
-    fs.appendFileSync(FAILED_VERSIONS, line);
+    const epoch = Math.floor(Date.now() / 1000);
+    if (COOLDOWN_CATEGORIES.has(category)) {
+      // Backwards-compatible 2-column line for isVersionInCooldown,
+      // plus a 3rd column for the category so future tooling can
+      // surface why a version was cooldown'd. readFailedVersions only
+      // reads the first two columns so adding the 3rd is non-breaking.
+      const line = `${tool}=${version} ${epoch} ${category}\n`;
+      fs.appendFileSync(FAILED_VERSIONS, line);
+    }
+    // Always log to .failure-log for diagnostics regardless of category
+    // — even auth/network failures are useful for the user to see why
+    // the updater couldn't validate a particular version.
+    const reasonOneLine = String(reason).replace(/\s+/g, ' ').slice(0, 240);
+    const logLine = `${tool}=${version} ${epoch} ${category} ${reasonOneLine}\n`;
+    fs.appendFileSync(FAILURE_LOG, logLine);
   } catch (e) {
-    log(`failed-versions write error: ${e.message}`);
+    log(`failed-versions/log write error: ${e.message}`);
   }
 }
 
@@ -880,14 +953,41 @@ async function tryClaudeVersion(pkgMeta, version) {
     fs.writeFileSync(nativeOut, patchedBin, { mode: 0o755 });
     fs.chmodSync(nativeOut, 0o755);
 
-    const nativeSmoke = runClaudeNative(nativeOut, ['--version']);
-    const nativeCombined = `${nativeSmoke.stdout || ''}${nativeSmoke.stderr || ''}`;
-    if (nativeSmoke.status !== 0 || !nativeCombined.includes(version)) {
-      fs.rmSync(nativeStaging, { recursive: true, force: true });
-      recordFailedVersion('claude', version);
-      return { ok: false, reason: `native --version status=${nativeSmoke.status}: ${nativeCombined.slice(0, 200)}` };
+    // PR #48 (Codex 2026-05-08): run --version 3 times. Some upstream Bun
+    // SEA crash modes only fire on the 2nd or 3rd invocation (cache /
+    // .node extraction race). A single PASS isn't enough proof that the
+    // binary is stable for foreground REPL use. Cheap: each --version
+    // takes <500 ms and is fully offline.
+    //
+    // NOTE: this catches *startup-version-smoke* failures, not REPL/TUI
+    // stability. The Z Fold6 2.1.133 crash that motivated PR #47 was
+    // foreground TUI corruption AFTER the welcome banner started
+    // drawing — three --version runs do not exercise the Ink/TUI
+    // rendering path. PR #48 is about not promoting binaries that
+    // outright fail to boot; it does NOT make native safe enough to be
+    // the default again. Native stays opt-in via PR #47's gate.
+    //
+    // Codex push-prep review (item D): validate env override so NaN /
+    // 0 / negative don't break the loop. Floor at 1, default 3.
+    const __PARSED_SMOKE_RUNS = Number(process.env.SHELLY_NATIVE_VERSION_SMOKE_RUNS || 3);
+    const NATIVE_VERSION_SMOKE_RUNS =
+      Number.isInteger(__PARSED_SMOKE_RUNS) && __PARSED_SMOKE_RUNS > 0
+        ? __PARSED_SMOKE_RUNS
+        : 3;
+    let nativeSmoke;
+    let nativeCombined = '';
+    for (let i = 1; i <= NATIVE_VERSION_SMOKE_RUNS; i += 1) {
+      nativeSmoke = runClaudeNative(nativeOut, ['--version']);
+      nativeCombined = `${nativeSmoke.stdout || ''}${nativeSmoke.stderr || ''}`;
+      if (nativeSmoke.status !== 0 || !nativeCombined.includes(version)) {
+        const category = classifyFailure(nativeSmoke);
+        const reason = `native --version run ${i}/${NATIVE_VERSION_SMOKE_RUNS} status=${nativeSmoke.status} signal=${nativeSmoke.signal || ''} cat=${category}: ${nativeCombined.slice(0, 200)}`;
+        fs.rmSync(nativeStaging, { recursive: true, force: true });
+        recordFailedVersion('claude', version, category, reason);
+        return { ok: false, reason };
+      }
     }
-    info(`[claude] try ${version} — native --version smoke OK`);
+    info(`[claude] try ${version} — native --version smoke OK (${NATIVE_VERSION_SMOKE_RUNS}x)`);
 
     if (shouldFunctionalCheckClaude()) {
       const nativeFunc = runClaudeNative(nativeOut, ['--print', 'Reply exactly OK'], {
@@ -895,14 +995,28 @@ async function tryClaudeVersion(pkgMeta, version) {
       });
       const nativeFuncOut = `${nativeFunc.stdout || ''}${nativeFunc.stderr || ''}`;
       if (nativeFunc.status !== 0) {
+        // Codex review (PR #48 spec item 8): classify before recording.
+        // auth/network failures must NOT cooldown the binary — the user
+        // can fix their auth and the same binary version becomes valid
+        // again. Only signal-killed and unexplained-exit failures
+        // genuinely indicate the binary is broken.
+        const category = classifyFailure(nativeFunc);
+        const reason = `native --print status=${nativeFunc.status} signal=${nativeFunc.signal || ''} cat=${category}: ${nativeFuncOut.slice(0, 200)}`;
         fs.rmSync(nativeStaging, { recursive: true, force: true });
-        recordFailedVersion('claude', version);
-        return { ok: false, reason: `native --print status=${nativeFunc.status}: ${nativeFuncOut.slice(0, 200)}` };
+        recordFailedVersion('claude', version, category, reason);
+        return { ok: false, reason };
       }
       if (!/\bOK\b/i.test(nativeFunc.stdout || '')) {
+        // Process exited 0 but didn't say OK — could be rate limit, model
+        // output drift, stderr warning, prompt mismatch, etc. Codex push-
+        // prep review pushed back on the earlier 'auth' label here as too
+        // coarse for diagnostics. Use a dedicated 'unexpected-output'
+        // category so the failure log makes the cause readable; cooldown
+        // exclusion is the same as 'auth' (not in COOLDOWN_CATEGORIES).
+        const reason = `native --print did not return OK: ${nativeFuncOut.slice(0, 200)}`;
         fs.rmSync(nativeStaging, { recursive: true, force: true });
-        recordFailedVersion('claude', version);
-        return { ok: false, reason: `native --print did not return OK: ${nativeFuncOut.slice(0, 200)}` };
+        recordFailedVersion('claude', version, 'unexpected-output', reason);
+        return { ok: false, reason };
       }
       info(`[claude] try ${version} — native functional check OK`);
       fs.writeFileSync(path.join(nativeStaging, '.shelly-functional-smoke-ok'), `${new Date().toISOString()}\n`, { mode: 0o600 });
@@ -1145,17 +1259,63 @@ async function updateCodex() {
   info(`[codex] all ${candidates.length} candidates failed smoke; keeping current=${currentVersion('codex') || '(none)'}`);
 }
 
+// Codex review 2026-05-08 (PR #48): age-aware GC for staging directories.
+// Earlier impl was unconditional — every updater run nuked every claude-*
+// / codex-* entry in TMP, including in-flight stages from a concurrent
+// updater process. RUN_TAG (per-process pid+rand suffix) gives unique
+// paths but doesn't help if a sibling process arrives at startup and
+// finds another's WIP stage. The mtime check below preserves anything
+// touched in the last 24h, so two updater instances don't trample each
+// other while still recovering disk from genuinely abandoned crashes.
+//
+// Codex push-prep review (item F): validate the env override so a
+// malformed SHELLY_STAGING_GC_AGE_S doesn't either disable GC (NaN/0)
+// or set an absurdly small cutoff that nukes in-flight stages. Floor
+// at 3600s (1h) — anything shorter risks racing concurrent updaters.
+const __PARSED_GC_AGE = Number(process.env.SHELLY_STAGING_GC_AGE_S || 86400);
+const STAGING_GC_AGE_S =
+  Number.isFinite(__PARSED_GC_AGE) && __PARSED_GC_AGE >= 3600
+    ? __PARSED_GC_AGE
+    : 86400;
+
 function cleanupStaleStaging() {
-  // Purge any leftover staging directories from crashed previous runs.
-  // Codex audit 2026-04-25: race window between writeFileSync and
-  // promote leaks ~/.shelly-runtime/.tmp/claude-X or codex-Y if the
-  // process dies mid-run. Clean at startup so disk doesn't accrue.
   try {
     if (!fs.existsSync(TMP)) return;
+    const cutoffMs = Date.now() - (STAGING_GC_AGE_S * 1000);
+    let removed = 0;
+    let preserved = 0;
     for (const entry of fs.readdirSync(TMP)) {
-      if (entry.startsWith('claude-') || entry.startsWith('claude-extracted-') || entry.startsWith('codex-')) {
-        fs.rmSync(path.join(TMP, entry), { recursive: true, force: true });
+      if (!(entry.startsWith('claude-') || entry.startsWith('claude-extracted-') || entry.startsWith('codex-'))) {
+        continue;
       }
+      const full = path.join(TMP, entry);
+      let mtimeMs;
+      try {
+        mtimeMs = fs.statSync(full).mtimeMs;
+      } catch (e) {
+        // Stat failed (race with another rm? broken symlink?). Try to
+        // remove it; if rm also fails, log and move on.
+        try {
+          fs.rmSync(full, { recursive: true, force: true });
+          removed += 1;
+        } catch (re) {
+          log(`cleanupStaleStaging: stat+rm both failed for ${entry}: ${re.message}`);
+        }
+        continue;
+      }
+      if (mtimeMs < cutoffMs) {
+        try {
+          fs.rmSync(full, { recursive: true, force: true });
+          removed += 1;
+        } catch (re) {
+          log(`cleanupStaleStaging: rm failed for ${entry}: ${re.message}`);
+        }
+      } else {
+        preserved += 1;
+      }
+    }
+    if (removed > 0 || preserved > 0) {
+      info(`[gc] staging cleanup: removed=${removed} preserved=${preserved} (age cutoff ${STAGING_GC_AGE_S}s)`);
     }
   } catch (err) {
     log(`cleanupStaleStaging: ${err.message}`);

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
@@ -683,7 +683,30 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
     //        list for users who opt back in (Codex pushed back on 137 =
     //        SIGKILL/OOM since cache-clear retry doesn't address memory
     //        pressure; final list is 133/134/135/139/159).
-    private const val BASHRC_VERSION = 83
+    //    84: PR #48 reliability hardening (Codex 2026-05-08 design + push-
+    //        prep review). v83 made native opt-in but didn't close the loop
+    //        on "I opted in once and it crashed; please don't keep retrying
+    //        it". Added __shelly_consume_runtime_failures (drains
+    //        ~/.shelly-runtime/.runtime-failures into .failed-versions on
+    //        every claude() invocation — fast feedback without waiting for
+    //        the next bg-updater run) and __shelly_claude_native_in_cooldown
+    //        (checks the current native version against the cooldown DB).
+    //        Native tier gate now reads "SHELLY_FORCE_NATIVE_CLAUDE=1 OR
+    //        (SHELLY_PREFER_NATIVE_CLAUDE=1 AND not in cooldown)" so opt-in
+    //        users get experimental-fast-path semantics without re-paying
+    //        for known-crashing binaries every shell startup.
+    //        Codex push-prep review fix-ups (5):
+    //          - consume uses mv-spool, not read-then-rm (race-safe; sibling
+    //            shell appends after mv don't get lost)
+    //          - epoch / TTL validate via [!0-9] reverse pattern (no more
+    //            '123abc' slipping through case [0-9]*)
+    //          - default cooldown TTL 3600 (1h) -> 86400 (24h) — 1h made
+    //            users re-pay for crash binaries hourly
+    //          - cooldown skip emits verbose log when SHELLY_VERBOSE_CLI_TIER
+    //            is set (so on-device testers can tell skip reason)
+    //          - version-file fallback: readlink basename of current symlink
+    //            if the version file isn't written
+    private const val BASHRC_VERSION = 84
 
     fun getHomeDir(context: Context): File =
         File(context.filesDir, "home").also { it.mkdirs() }
@@ -1115,6 +1138,103 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
             sb.appendLine("__shelly_paste_tui_end() { rm -f \"\$HOME/.shelly_paste_force_tui\" 2>/dev/null || true; }")
             sb.appendLine()
 
+            // ── PR #48: foreground crash → cooldown fast feedback ─────────
+            // Codex review (2026-05-08) recommended pulling the runtime-
+            // failures consume out of the background updater path so the
+            // foreground claude() function reads the latest crash log
+            // BEFORE deciding whether to run native. Otherwise a freshly-
+            // crashed native binary keeps getting re-tried until the next
+            // background updater run, defeating the cooldown.
+            //
+            // Format mirrors shelly-runtime-update.js:
+            //   .runtime-failures: `claude=<ver> <epoch> <exit_code> [tier]`
+            //                      written by the claude() function on signal-
+            //                      exit (134/139/etc.); consumed here
+            //   .failed-versions:  `<tool>=<version> <epoch>` (cooldown DB)
+            //                      append-only; isVersionInCooldown reads it
+            //   SHELLY_FAILED_VERSION_COOLDOWN: cooldown TTL in seconds
+            //                                   (default 3600 = 1h, mirrors JS)
+            // Codex review fix-up (PR #48 Stage 1, push-prep):
+            // The earlier read-then-rm flow lost any failure record that a
+            // sibling shell appended between our last read line and the
+            // rm -f. Move the file to a per-process spool name FIRST (mv
+            // is atomic on the same filesystem on POSIX), then consume the
+            // spool. Failures appended after the mv land in a freshly-
+            // created .runtime-failures and survive to the next consume.
+            sb.appendLine("__shelly_consume_runtime_failures() {")
+            sb.appendLine("  local __rf=\"\$HOME/.shelly-runtime/.runtime-failures\"")
+            sb.appendLine("  local __fv=\"\$HOME/.shelly-runtime/.failed-versions\"")
+            sb.appendLine("  local __spool=\"\$HOME/.shelly-runtime/.runtime-failures.\$\$.spool\"")
+            sb.appendLine("  mkdir -p \"\$HOME/.shelly-runtime\" 2>/dev/null")
+            sb.appendLine("  mv \"\$__rf\" \"\$__spool\" 2>/dev/null || return 0")
+            sb.appendLine("  local __now")
+            sb.appendLine("  __now=\$(date -u +%s 2>/dev/null) || { rm -f \"\$__spool\" 2>/dev/null; return 0; }")
+            sb.appendLine("  local __line __keyver __ver __consumed=0")
+            sb.appendLine("  while IFS= read -r __line || [ -n \"\$__line\" ]; do")
+            sb.appendLine("    __keyver=\${__line%% *}")
+            sb.appendLine("    case \"\$__keyver\" in")
+            sb.appendLine("      claude=*)")
+            sb.appendLine("        __ver=\${__keyver#claude=}")
+            sb.appendLine("        case \"\$__ver\" in")
+            sb.appendLine("          [0-9]*.[0-9]*.[0-9]*)")
+            sb.appendLine("            printf 'claude=%s %s\\n' \"\$__ver\" \"\$__now\" >> \"\$__fv\" 2>/dev/null || true")
+            sb.appendLine("            __consumed=\$((__consumed + 1))")
+            sb.appendLine("            ;;")
+            sb.appendLine("        esac")
+            sb.appendLine("        ;;")
+            sb.appendLine("    esac")
+            sb.appendLine("  done < \"\$__spool\"")
+            sb.appendLine("  rm -f \"\$__spool\" 2>/dev/null")
+            sb.appendLine("  if [ -n \"\$SHELLY_VERBOSE_CLI_TIER\" ] && [ \"\$__consumed\" -gt 0 ]; then")
+            sb.appendLine("    echo \"[shelly] claude: consumed \$__consumed runtime failure(s) into cooldown\" >&2")
+            sb.appendLine("  fi")
+            sb.appendLine("}")
+            sb.appendLine()
+
+            // Returns 0 if Claude's currently-promoted native version is in
+            // the failed-versions cooldown window (default 3600 s). Used by
+            // claude() to skip the native tier even when
+            // SHELLY_PREFER_NATIVE_CLAUDE=1 is set, unless the user set
+            // SHELLY_FORCE_NATIVE_CLAUDE=1 to override (e.g. for debugging).
+            // Codex review fix-ups (PR #48 Stage 1, push-prep):
+            //   - epoch/TTL: use [!0-9] reverse pattern so '123abc' doesn't
+            //     slip through (the previous [0-9]* case would accept any
+            //     line starting with a digit, even malformed ones)
+            //   - default TTL bumped 3600 (1h) -> 86400 (24h). 1h was too
+            //     short — native crashes corrupt the foreground TUI, so
+            //     having the user re-pay for the same broken binary every
+            //     hour is bad UX. 24h gives the bg updater time to fetch
+            //     a new version. Debug: SHELLY_FAILED_VERSION_COOLDOWN=60.
+            //   - version-file fallback: if ~/.shelly-runtime/claude/version
+            //     is missing, fall back to readlink basename of the current
+            //     symlink so cooldown still works on devices where the
+            //     updater forgot to emit the version file
+            sb.appendLine("__shelly_claude_native_in_cooldown() {")
+            sb.appendLine("  local __vf=\"\$HOME/.shelly-runtime/claude/version\"")
+            sb.appendLine("  local __fv=\"\$HOME/.shelly-runtime/.failed-versions\"")
+            sb.appendLine("  [ -f \"\$__fv\" ] || return 1")
+            sb.appendLine("  local __cur __now __ttl __latest __keyver __epoch")
+            sb.appendLine("  __cur=\$(cat \"\$__vf\" 2>/dev/null | tr -d '\\n')")
+            sb.appendLine("  if [ -z \"\$__cur\" ]; then")
+            sb.appendLine("    __cur=\$(basename \"\$(readlink \"\$HOME/.shelly-runtime/claude/current\" 2>/dev/null)\" 2>/dev/null)")
+            sb.appendLine("  fi")
+            sb.appendLine("  [ -n \"\$__cur\" ] || return 1")
+            sb.appendLine("  case \"\$__cur\" in [0-9]*.[0-9]*.[0-9]*) ;; *) return 1 ;; esac")
+            sb.appendLine("  __now=\$(date -u +%s 2>/dev/null) || return 1")
+            sb.appendLine("  __ttl=\${SHELLY_FAILED_VERSION_COOLDOWN:-86400}")
+            sb.appendLine("  case \"\$__ttl\" in ''|*[!0-9]*) __ttl=86400 ;; esac")
+            sb.appendLine("  __latest=0")
+            sb.appendLine("  while IFS=' ' read -r __keyver __epoch || [ -n \"\$__keyver\" ]; do")
+            sb.appendLine("    [ \"\$__keyver\" = \"claude=\$__cur\" ] || continue")
+            sb.appendLine("    case \"\$__epoch\" in ''|*[!0-9]*) continue ;; esac")
+            sb.appendLine("    [ \"\$__epoch\" -gt \"\$__latest\" ] && __latest=\$__epoch")
+            sb.appendLine("  done < \"\$__fv\"")
+            sb.appendLine("  [ \"\$__latest\" -eq 0 ] && return 1")
+            sb.appendLine("  [ \$((__now - __latest)) -lt \$__ttl ] && return 0")
+            sb.appendLine("  return 1")
+            sb.appendLine("}")
+            sb.appendLine()
+
             // Tool functions
             sb.appendLine("# v51: PATH-visible Android-compatible shell/env for AI CLIs")
             sb.appendLine("if [ ! -e \"\$HOME/bin/bash\" ] || [ \"\$(readlink \"\$HOME/bin/bash\" 2>/dev/null)\" != \"\$SHELL\" ]; then")
@@ -1353,6 +1473,11 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
             sb.appendLine("  local __extracted_cli_js=\"\"")
             sb.appendLine("  local __bun_tmp=\"\${BUN_TMPDIR:-\$HOME/.bun-tmp}\"")
             sb.appendLine("  mkdir -p \"\$__bun_tmp\" 2>/dev/null")
+            // PR #48: Drain runtime-failures into failed-versions BEFORE
+            // deciding the tier. Without this, a freshly-crashed native
+            // version keeps getting re-tried until the next background
+            // updater run wakes up and consumes the queue.
+            sb.appendLine("  __shelly_consume_runtime_failures")
             sb.appendLine("  if [ -f \"\$__runtime_extracted_cli_js\" ]; then")
             sb.appendLine("    __extracted_cli_js=\"\$__runtime_extracted_cli_js\"")
             sb.appendLine("  elif [ -f \"\$__apk_extracted_cli_js\" ]; then")
@@ -1381,7 +1506,22 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
             // Power users / CI smoke tests can re-enable the native foreground
             // path; the runtime updater's background smoke is the right place
             // to validate native binaries before promoting them.
-            sb.appendLine("    if [ \"\${SHELLY_PREFER_NATIVE_CLAUDE:-0}\" = \"1\" ] && [ -x \"\$__runtime_claude\" ]; then")
+            // PR #48: even when SHELLY_PREFER_NATIVE_CLAUDE=1, skip native if
+            // the current version is in the failed-versions cooldown window.
+            // Reason: Codex review pushed back on auto-retrying known-crashing
+            // native binaries — the user opted in expecting "use native if it
+            // works", not "use native even if I just saw it segfault". A
+            // separate SHELLY_FORCE_NATIVE_CLAUDE=1 ignores the cooldown for
+            // debugging.
+            //
+            // Diagnostic visibility: when PREFER is set but cooldown is
+            // active and FORCE is not, surface a verbose-tier message so
+            // real-device testers can tell apart "native skipped because
+            // not opted in" vs "native skipped because crash record".
+            sb.appendLine("    if [ \"\${SHELLY_PREFER_NATIVE_CLAUDE:-0}\" = \"1\" ] && [ \"\${SHELLY_FORCE_NATIVE_CLAUDE:-0}\" != \"1\" ] && [ -n \"\$SHELLY_VERBOSE_CLI_TIER\" ] && __shelly_claude_native_in_cooldown; then")
+            sb.appendLine("      echo '[shelly] claude: native cooldown active, skipping native tier (set SHELLY_FORCE_NATIVE_CLAUDE=1 to override)' >&2")
+            sb.appendLine("    fi")
+            sb.appendLine("    if { [ \"\${SHELLY_FORCE_NATIVE_CLAUDE:-0}\" = \"1\" ] || { [ \"\${SHELLY_PREFER_NATIVE_CLAUDE:-0}\" = \"1\" ] && ! __shelly_claude_native_in_cooldown; }; } && [ -x \"\$__runtime_claude\" ]; then")
             sb.appendLine("      if [ -n \"\$SHELLY_VERBOSE_CLI_TIER\" ] && [ -z \"\$SHELLY_CLAUDE_TIER_ANNOUNCED\" ]; then")
             sb.appendLine("        export SHELLY_CLAUDE_TIER_ANNOUNCED=1")
             sb.appendLine("        echo '[shelly] claude: runtime latest (musl Bun SEA)' >&2")
@@ -1430,20 +1570,22 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
             sb.appendLine("          ;;")
             sb.appendLine("      esac")
             sb.appendLine("    fi")
-            // Codex review fix-up: announce condition must also gate on
-            // SHELLY_PREFER_NATIVE_CLAUDE=1 — without it, the "Path C-bis"
-            // banner prints (and SHELLY_CLAUDE_TIER_ANNOUNCED=1 is set,
-            // suppressing the *real* banner from the extracted Node tier
-            // below) even though the native execution block is skipped.
-            sb.appendLine("    if [ \"\${SHELLY_PREFER_NATIVE_CLAUDE:-0}\" = \"1\" ] && [ -x \"\$__musl_claude\" ] && [ -n \"\$SHELLY_VERBOSE_CLI_TIER\" ] && [ -z \"\$SHELLY_CLAUDE_TIER_ANNOUNCED\" ]; then")
+            // PR #48: announce + execution gates must agree, and both must
+            // honor FORCE_NATIVE bypass and the cooldown skip when
+            // PREFER_NATIVE is the only active flag. Path C-bis is the APK-
+            // bundled binary; it has no version file under
+            // ~/.shelly-runtime/claude/, so __shelly_claude_native_in_cooldown
+            // returns 1 (not in cooldown) — that's intentional: APK upgrades
+            // ship a new binary so cooldown semantics don't apply, and the
+            // PREFER flag still gates it correctly. We keep the helper call
+            // for consistency with the latest tier above so the gate
+            // expression reads identically; if a future build adds version
+            // tracking for Path C-bis, the cooldown will start firing.
+            sb.appendLine("    if { [ \"\${SHELLY_FORCE_NATIVE_CLAUDE:-0}\" = \"1\" ] || { [ \"\${SHELLY_PREFER_NATIVE_CLAUDE:-0}\" = \"1\" ] && ! __shelly_claude_native_in_cooldown; }; } && [ -x \"\$__musl_claude\" ] && [ -n \"\$SHELLY_VERBOSE_CLI_TIER\" ] && [ -z \"\$SHELLY_CLAUDE_TIER_ANNOUNCED\" ]; then")
             sb.appendLine("      export SHELLY_CLAUDE_TIER_ANNOUNCED=1")
             sb.appendLine("      echo '[shelly] claude: Path C-bis (musl Bun SEA)' >&2")
             sb.appendLine("    fi")
-            // Same opt-in flag as the runtime-tier block above — Path C-bis
-            // is the APK-bundled musl Bun SEA, and exhibits the same 133/135
-            // crash modes as the runtime-tier latest. Default skips it; opt-in
-            // via SHELLY_PREFER_NATIVE_CLAUDE=1 keeps the foreground path.
-            sb.appendLine("    if [ \"\${SHELLY_PREFER_NATIVE_CLAUDE:-0}\" = \"1\" ] && [ -x \"\$__musl_claude\" ]; then")
+            sb.appendLine("    if { [ \"\${SHELLY_FORCE_NATIVE_CLAUDE:-0}\" = \"1\" ] || { [ \"\${SHELLY_PREFER_NATIVE_CLAUDE:-0}\" = \"1\" ] && ! __shelly_claude_native_in_cooldown; }; } && [ -x \"\$__musl_claude\" ]; then")
             sb.appendLine("    __shelly_paste_tui_begin")
             sb.appendLine("    BUN_TMPDIR=\"\$__bun_tmp\" SHELLY_MUSL_LD_PRELOAD=\"\$__musl_exec_wrapper\" /system/bin/env -u LD_PRELOAD /system/bin/linker64 \"\$__trampoline\" \"\$__musl_ld\" \"\$__musl_claude\" \"\$@\"")
             sb.appendLine("    local __musl_rc=$?")
@@ -2171,7 +2313,8 @@ else { console.error("usage: node shelly-patcher.js codex <libDir> [<nm>] | gemi
             sb.appendLine("# v61: per-launch quick version check (bypasses 24h gate when newer found)")
             sb.appendLine("__shelly_quick_check_marker=\"\$HOME/.shelly-cli/.last_quick_check\"")
             sb.appendLine("__shelly_quick_check_interval=\${SHELLY_QUICK_CHECK_INTERVAL:-3600}")
-            sb.appendLine("__shelly_failed_cooldown=\${SHELLY_FAILED_VERSION_COOLDOWN:-3600}")
+            sb.appendLine("__shelly_failed_cooldown=\${SHELLY_FAILED_VERSION_COOLDOWN:-86400}")
+            sb.appendLine("case \"\$__shelly_failed_cooldown\" in ''|*[!0-9]*) __shelly_failed_cooldown=86400 ;; esac")
             sb.appendLine("__shelly_quick_check_clis() {")
             sb.appendLine("  if [ -z \"\$__SHELLY_QUICK_CHECK_SUBSHELL\" ]; then")
             sb.appendLine("    ( __SHELLY_QUICK_CHECK_SUBSHELL=1 __shelly_quick_check_clis </dev/null >/dev/null 2>&1 & )")


### PR DESCRIPTION
## Summary

Reliability hardening for the Claude CLI runtime updater, follow-up to PR #47. Three rounds of Codex review (design + push-prep + final) shaped the implementation; all 9 reviewer-flagged blockers are addressed.

**What this fixes**: PR #47 demoted native Bun SEA to \`SHELLY_PREFER_NATIVE_CLAUDE=1\` opt-in to stop the foreground TUI corruption on Z Fold6, but it didn't close the loop on "I opted in once, native crashed, please don't keep retrying that exact version every shell startup". This PR connects the foreground crash log to the updater's cooldown DB on the fast path, hardens the smoke-test gate against false PASS, and tightens the staging GC against concurrent updater races.

## Stage 1 — bash-side cooldown integration (commit 61d124a6)

\`HomeInitializer.kt\`, +155/-13 lines. PR #48 spec items 1/2/3/9.

- **\`__shelly_consume_runtime_failures\`**: drains \`~/.shelly-runtime/.runtime-failures\` into \`.failed-versions\` on every \`claude()\` invocation. mv-spool first (atomic on POSIX same-fs) so sibling-shell appends after the move land in a fresh \`.runtime-failures\` instead of getting nuked by \`rm -f\`.
- **\`__shelly_claude_native_in_cooldown\`**: looks up the current promoted native version against the cooldown DB. Fallback to \`readlink basename\` of \`current\` symlink when \`version\` file is missing. Strict numeric validation on epoch and TTL via \`*[!0-9]*\` reverse pattern.
- **Native tier gate** (3 sites: latest exec, Path C-bis announce, Path C-bis exec):
  \`\`\`
  { FORCE=1 || (PREFER=1 && !in_cooldown) } && [ -x $bin ]
  \`\`\`
  \`SHELLY_FORCE_NATIVE_CLAUDE=1\` is the debug escape hatch. \`SHELLY_PREFER_NATIVE_CLAUDE=1\` keeps experimental-fast-path semantics without re-paying for known-crashing binaries.
- **Verbose log** on cooldown skip when \`SHELLY_VERBOSE_CLI_TIER=1\` so on-device testers can tell apart "skipped because not opted in" from "skipped because crash record".
- **TTL default** 3600s (1h) → 86400s (24h). \`SHELLY_FAILED_VERSION_COOLDOWN=60\` for debug shrink. Quick-check site at line 2316 also bumped + validated.
- **BASHRC_VERSION** 83 → 84.

## Stage 2 — JS-side updater hardening (commit b7b1ec6a)

\`shelly-runtime-update.js\`, +182/-22 lines. PR #48 spec items 6/7/8.

- **Age-aware staging GC**: \`cleanupStaleStaging\` was nuking every \`claude-*\` / \`codex-*\` entry in TMP unconditionally on every updater startup, destroying in-flight stages from concurrent updaters. Replaced with mtime-based filtering (default 24h, override via \`SHELLY_STAGING_GC_AGE_S\`, validated >= 3600). Surfaces removed/preserved counts.
- **3x \`--version\` smoke loop**: a single PASS isn't enough for foreground-REPL stability proof — Bun SEA crash modes can fire on the 2nd/3rd invocation due to .node extraction race. \`SHELLY_NATIVE_VERSION_SMOKE_RUNS\` (default 3, integer-validated > 0). NB: this catches startup-version-smoke failures, not REPL/TUI stability. Native stays opt-in via PR #47's gate; this PR doesn't make native safe enough to be the default again.
- **Failure classification**: \`classifyFailure({status, signal, stdout, stderr})\` returns one of \`signal\` | \`auth\` | \`exit\` | \`unexpected-output\`. \`COOLDOWN_CATEGORIES = {signal, exit, shape}\` are recorded to \`.failed-versions\`; \`auth\` / \`unexpected-output\` / \`network\` (caller-classified via outer catch) go to \`.failure-log\` for diagnostics only. Auth regex fixed for \`unauthorized\` word-boundary bug. \`recordFailedVersion(tool, version, category, reason)\` 3-column \`.failed-versions\` is backwards-compatible (\`readFailedVersions\` parses only first 2 columns).
- **\`FAILED_COOLDOWN_S\`** validation parity with bash side (NaN / non-positive falls back to 86400).

## Codex review trail

- **Round 1** (design): full spec for items 1-10, recommended Stage 1+2 split with item 10 (README) deferred. Approved direction.
- **Round 2** (push-prep): caught 5 blockers — race in consume rm-f flow, weak epoch validation, short TTL default, missing verbose log, missing version-file fallback. All 5 fixed via fixup commits, autosquashed.
- **Round 3** (final): pinpointed 4 more — JS smoke runs validation, JS GC age validation, auth regex word-boundary bug, exit-0-no-OK label coarseness. All fixed.
- **Round 4** (verification): caught the JS \`FAILED_COOLDOWN_S\` validation gap (HomeInitializer side was validated, JS side wasn't). Fixed pre-push.

## Known limitations (intentionally out of scope)

1. \`consumeRuntimeFailures\` records use default \`exit\` category — the runtime-failures line format includes exit_code which could derive signal/exit, but both sit in COOLDOWN_CATEGORIES so cooldown semantics match. Diagnostic granularity only.
2. codex / gemini smoke paths not 3x'd or classified — observed crashes are Claude-only; widen if/when codex/gemini hit similar issues.
3. \`auth\` cooldown exclusion has no rate limiter — bg updater retries on every wake. If observed in practice, add a backoff in a follow-up.

Stage 3 (README note about native being experimental, extracted Node being the stable default) follows as a separate doc PR.

## Test plan

- [ ] Build green
- [ ] Reinstall on Z Fold6
- [ ] Default \`claude\` REPL launches via extracted Node tier — clean banner, no Bun panic interleave (regression check vs PR #47)
- [ ] \`SHELLY_PREFER_NATIVE_CLAUDE=1 claude\` and the cooldown DB has a \`claude=2.1.133\` entry → native skipped silently → extracted Node runs → \`SHELLY_VERBOSE_CLI_TIER=1\` shows the "native cooldown active, skipping" message
- [ ] \`SHELLY_FORCE_NATIVE_CLAUDE=1 claude\` overrides cooldown — native attempted (will still crash on this device, that's expected)
- [ ] Force a foreground native crash, observe \`.runtime-failures\` consumed into \`.failed-versions\` on the next claude invocation
- [ ] Updater run logs \`[gc] staging cleanup: removed=N preserved=M\` and \`native --version smoke OK (3x)\` for a healthy candidate
- [ ] Wrong-format \`SHELLY_FAILED_VERSION_COOLDOWN=abc\` — both bash and JS fall back to 86400 (no NaN propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)