### PR TITLE
feat(deeplink): JSON-line file-queue + external-browser dispatch (Phase 1.2 Stage 1)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -23,6 +23,7 @@ import { useSettingsStore } from '@/store/settings-store';
 import * as Linking from 'expo-linking';
 import * as Clipboard from 'expo-clipboard';
 import * as FileSystem from 'expo-file-system/legacy';
+import * as WebBrowser from 'expo-web-browser';
 import { useBrowserStore } from '@/store/browser-store';
 import { useMultiPaneStore } from '@/hooks/use-multi-pane';
 
@@ -304,46 +305,181 @@ export default function RootLayout() {
     // with a `file://` prefix, and HomeInitializer.kt creates $HOME as
     // `${context.filesDir}/home`, so the queue path resolves correctly.
     const queuePath = `${FileSystem.documentDirectory}home/.shelly-deep-link-queue`;
+
+    // Phase 1.2 (bug #102/#115): each queue line is either a plain URL
+    // (legacy format used by shelly-xdg-open.c and shelly-codex-auth.js)
+    // or a JSON object describing how the URL should be opened. The JSON
+    // form was added to support Google OAuth (Gemini login), which needs
+    // a real Chrome process via Custom Tabs because Chromium WebView
+    // unconditionally appends an X-Requested-With header that
+    // accounts.google.com uses to gate sign-in. JSON shape (all fields
+    // optional except `url`):
+    //
+    //   {
+    //     "type": "open-url",                  // reserved
+    //     "url": "https://accounts.google.com/...",
+    //     "provider": "google",                // diagnostic / future routing
+    //     "authMode": "external-browser"       // "in-app" (default) | "external-browser"
+    //   }
+    //
+    // authMode === "external-browser" → WebBrowser.openBrowserAsync(),
+    // which on Android resolves to Chrome Custom Tabs (or whatever
+    // Custom-Tabs-compatible browser the user has set as default). The
+    // CLI's own loopback callback (http://127.0.0.1:<port>/...) receives
+    // the redirect; Shelly does NOT touch the auth code or token
+    // exchange — the CLI owns the OAuth flow entirely (RFC 8252 path,
+    // per Codex 2026-05-08 design review for Phase 1.2).
+    //
+    // Default (no authMode, plain URL line, or "in-app") preserves the
+    // existing Phase 1 behaviour: navigate Browser Pane in-app.
+    const dispatchExternalBrowser = async (url: string, provider: string | null) => {
+      // Trim provider to a short safe label for log lines.
+      const providerTag = provider ? provider.slice(0, 32) : 'unknown';
+      try {
+        const result = await WebBrowser.openBrowserAsync(url, {
+          // Slight tint so the Custom Tab header matches the Shelly
+          // accent without competing with the OAuth provider's branding.
+          toolbarColor: '#0D1117',
+          showTitle: true,
+          enableBarCollapsing: false,
+        });
+        logInfo('DeepLinkQueue', `external browser opened (provider=${providerTag}): result=${result.type}`);
+        return;
+      } catch (e) {
+        // Codex review (PR #50, Phase 1.2 Stage 1): Custom Tabs binding
+        // can fail for many reasons — no Custom-Tabs-capable default
+        // browser, MDM-style policy, foreground race, etc. Before
+        // collapsing to the in-app Browser Pane (which Google OAuth
+        // would re-block via X-Requested-With), try a plain
+        // Intent.ACTION_VIEW via Linking.openURL. That route still gets
+        // a real Chrome process most of the time on consumer devices,
+        // even when Custom Tabs failed to bind.
+        logError('DeepLinkQueue', `Custom Tabs failed (provider=${providerTag}), trying Linking.openURL: ${e}`);
+      }
+      try {
+        await Linking.openURL(url);
+        logInfo('DeepLinkQueue', `Linking.openURL fallback opened (provider=${providerTag})`);
+        return;
+      } catch (e) {
+        logError('DeepLinkQueue', `Linking.openURL also failed (provider=${providerTag}); collapsing to in-app: ${e}`);
+      }
+      // Last resort: open in-app. For Google OAuth the user will see
+      // the WebView block message, but a visible failure is better than
+      // a silent hang.
+      try {
+        const slots = useMultiPaneStore.getState().slots;
+        const hasBrowser = slots.some((s) => s?.tab === 'browser');
+        if (!hasBrowser) {
+          useMultiPaneStore.getState().addPane('browser');
+        }
+      } catch {}
+      useBrowserStore.getState().openUrl(url);
+    };
+
+    const dispatchInApp = (url: string) => {
+      // Only call addPane('browser') if no Browser Pane is already
+      // mounted. addPane unconditionally allocates a new slot, so
+      // calling it when a Browser Pane already exists creates a
+      // SECOND one — and even worse, the new pane misses the
+      // openSignal because its lastOpenSeqRef captures the current
+      // (post-openUrl) seq on mount and the useEffect skips the
+      // navigation. The combined effect is the "Browser Pane
+      // appears but the URL doesn't load" bug observed on Z Fold6.
+      // BrowserPane's currentUrl initial state also reads
+      // openSignal.url so a fresh pane picks up the URL on first
+      // render; this guard just keeps us from spamming new panes
+      // on every queued URL.
+      try {
+        const slots = useMultiPaneStore.getState().slots;
+        const hasBrowser = slots.some((s) => s?.tab === 'browser');
+        if (!hasBrowser) {
+          useMultiPaneStore.getState().addPane('browser');
+        }
+      } catch {}
+      useBrowserStore.getState().openUrl(url);
+    };
+
+    // Codex review (PR #50, Phase 1.2 Stage 1): the original
+    // read-then-delete flow lost any line a concurrent emitter
+    // (shelly-xdg-open.c, shelly-codex-auth.js, future Gemini wrapper)
+    // appended between the read and the delete. Append-mode atomic
+    // writes survive a missing-file gap, so move-to-spool first then
+    // consume the spool — anything written after the move lands in a
+    // freshly-created queue and survives to the next poll.
+    let isDraining = false;
     const drainQueue = async () => {
+      // Codex review: re-entry guard. drainQueue is async; if a
+      // dispatchExternalBrowser await takes longer than the 250 ms
+      // setInterval period (very plausible for Custom Tabs binding),
+      // setInterval will fire a second drainQueue while the first is
+      // still mid-loop. Two concurrent drains race on the same spool
+      // path. The flag below collapses overlapping wakeups; nothing is
+      // lost because the next setInterval tick will pick up a fresh
+      // queue if there is one.
+      if (isDraining) return;
+      isDraining = true;
       try {
         const info = await FileSystem.getInfoAsync(queuePath);
         if (!info.exists) return;
-        const content = await FileSystem.readAsStringAsync(queuePath);
-        // Delete BEFORE dispatch so URLs that arrive between read and
-        // delete go into a fresh queue rather than being processed
-        // twice. The append-mode writer in shelly-xdg-open.c will
-        // recreate the file lazily.
-        await FileSystem.deleteAsync(queuePath, { idempotent: true });
-        const urls = content.split('\n').map((s) => s.trim()).filter(Boolean);
-        for (const url of urls) {
+        // Per-process unique spool name avoids collisions if two
+        // RootLayout instances ever co-exist (HMR / fast refresh during
+        // development). Date.now() + crypto-ish suffix keeps it readable
+        // in adb logcat without needing a real RNG.
+        const spoolPath = `${queuePath}.${Date.now()}.${Math.random().toString(16).slice(2, 10)}.spool`;
+        try {
+          await FileSystem.moveAsync({ from: queuePath, to: spoolPath });
+        } catch (e) {
+          // The queue file may have been consumed by a sibling drain
+          // between getInfoAsync and moveAsync. Not an error.
+          return;
+        }
+        const content = await FileSystem.readAsStringAsync(spoolPath);
+        await FileSystem.deleteAsync(spoolPath, { idempotent: true });
+        const lines = content.split('\n').map((s) => s.trim()).filter(Boolean);
+        for (const line of lines) {
+          let url: string;
+          let provider: string | null = null;
+          let authMode: 'in-app' | 'external-browser' = 'in-app';
+          if (line.startsWith('{')) {
+            // JSON-line entry. Tolerate malformed JSON by logging and
+            // skipping rather than crashing the poll loop.
+            let parsed: any;
+            try {
+              parsed = JSON.parse(line);
+            } catch (e) {
+              logError('DeepLinkQueue', `rejected malformed JSON line: ${line.slice(0, 96)}`);
+              continue;
+            }
+            if (typeof parsed?.url !== 'string') {
+              logError('DeepLinkQueue', `rejected JSON line without url field: ${line.slice(0, 96)}`);
+              continue;
+            }
+            url = parsed.url;
+            if (typeof parsed.provider === 'string') provider = parsed.provider;
+            if (parsed.authMode === 'external-browser') {
+              authMode = 'external-browser';
+            }
+          } else {
+            // Legacy plain-URL format (still emitted by shelly-xdg-open.c
+            // and shelly-codex-auth.js — keep working unchanged).
+            url = line;
+          }
           if (!/^https?:\/\//i.test(url)) {
             logError('DeepLinkQueue', `rejected non-http(s) url: ${url.slice(0, 64)}`);
             continue;
           }
-          // Only call addPane('browser') if no Browser Pane is already
-          // mounted. addPane unconditionally allocates a new slot, so
-          // calling it when a Browser Pane already exists creates a
-          // SECOND one — and even worse, the new pane misses the
-          // openSignal because its lastOpenSeqRef captures the current
-          // (post-openUrl) seq on mount and the useEffect skips the
-          // navigation. The combined effect is the "Browser Pane
-          // appears but the URL doesn't load" bug observed on Z Fold6.
-          // BrowserPane's currentUrl initial state also reads
-          // openSignal.url so a fresh pane picks up the URL on first
-          // render; this guard just keeps us from spamming new panes
-          // on every queued URL.
-          try {
-            const slots = useMultiPaneStore.getState().slots;
-            const hasBrowser = slots.some((s) => s?.tab === 'browser');
-            if (!hasBrowser) {
-              useMultiPaneStore.getState().addPane('browser');
-            }
-          } catch {}
-          useBrowserStore.getState().openUrl(url);
-          logInfo('DeepLinkQueue', `openUrl dispatched (queue): ${url}`);
+          if (authMode === 'external-browser') {
+            await dispatchExternalBrowser(url, provider);
+            logInfo('DeepLinkQueue', `external dispatched (provider=${provider ?? 'unknown'}): ${url}`);
+          } else {
+            dispatchInApp(url);
+            logInfo('DeepLinkQueue', `openUrl dispatched (queue): ${url}`);
+          }
         }
       } catch (e) {
         logError('DeepLinkQueue', 'poll iteration failed', e);
+      } finally {
+        isDraining = false;
       }
     };
     const queueInterval = setInterval(drainQueue, 250);


### PR DESCRIPTION
## Summary

RN-side foundation for **Phase 1.2 Google OAuth (Gemini login)**. Phase 1's deep-link file queue (\`~/.shelly-deep-link-queue\`, drained every 250ms) accepted only plain-URL lines that always opened in the in-app Browser Pane. Google OAuth detects WebView via the \`X-Requested-With\` header that Chromium injects unconditionally — UA spoofing alone can't bypass it. The fix is to open Google OAuth URLs in a real Chrome process via Custom Tabs, but keep URL ownership with the CLI so PKCE / token-exchange / credential-write all run on the CLI's loopback callback (RFC 8252 path, per Codex 2026-05-08 design review).

This PR adds the **RN-side queue parser + external-browser dispatch path only**. No CLI currently emits the new JSON queue entry yet; the Gemini wrapper integration that actually exercises this code path lands in Phase 1.2 Stage 2 (separate PR). Stage 1 is **dead code on devices** until Stage 2 ships — existing emitters (\`shelly-xdg-open.c\`, \`shelly-codex-auth.js\`) keep working unchanged via the legacy plain-URL path.

## Behaviour

Each queue line is now either:

- **Legacy plain URL** — \`https://accounts.openai.com/...\` → Browser Pane in-app (Phase 1, unchanged).
- **JSON object** — \`{"type":"open-url","url":"...","provider":"google","authMode":"external-browser"}\`
  - \`authMode === "external-browser"\` → \`WebBrowser.openBrowserAsync\` (Custom Tabs on Android).
  - Default (no \`authMode\` / legacy line) preserves Phase 1 in-app behaviour.

## Reliability hardening (Codex review trail)

Three Codex review rounds shaped the implementation; all 7 reviewer-flagged issues are addressed:

**Round 1 (design)**: confirmed Custom Tabs + CLI-loopback architecture, recommended dead-code disclaimer in PR body.

**Round 2 (push-prep)**: caught 4 push-blockers
- **Queue drain race**: read-then-delete lost lines a sibling emitter appended between read and delete. Fixed via \`moveAsync\` to per-process spool path (\`Date.now() + Math.random hex\`); appends after the move land in a freshly-created queue file and survive to the next poll.
- **\`setInterval\` re-entry**: 250 ms interval fires while a previous \`drainQueue\` is still awaiting Custom Tabs. Added \`isDraining\` flag with \`finally\` clear.
- **Fallback chain too aggressive on in-app**: collapsing straight to in-app Browser Pane after Custom Tabs fail re-runs the WebView block on Google. Added \`Linking.openURL\` as a middle-tier fallback before in-app.
- **\`as any\` on \`result.type\`**: dropped, plus \`provider.slice(0, 32)\` to keep log lines bounded.

**Round 3 (final)**: approved push.

## Acknowledged non-blockers (deferred)

- \`Math.random()\` for spool suffix — sufficient for collision avoidance at 8-hex precision (≈ 4 × 10⁹ namespace per ms).
- \`Linking.openURL\` Android silent-fail — not catchable from JS; if observed in real-device testing we add a manual "Open externally failed? Tap to open in Browser Pane" UI nudge.
- \`.spool\` leaks from process kill — small text files, \`drainQueue\` handles missing source idempotently. A 24h sweep can be added in a separate cleanup PR if disk pressure observed.

## Test plan

- [ ] Build green
- [ ] Reinstall on Z Fold6
- [ ] Existing Codex login (\`codex-login --open\`) still works via plain-URL legacy path → Browser Pane
- [ ] Existing \`shelly-xdg-open\` shim still works (e.g. \`xdg-open https://example.com\` from terminal)
- [ ] Manual JSON-line injection: \`echo '{"type":"open-url","url":"https://accounts.google.com/","authMode":"external-browser","provider":"google"}' >> ~/.shelly-deep-link-queue\` → Custom Tabs opens
- [ ] Manual rapid append (10 lines / 1 sec) — no double-dispatch, no lost lines, drainQueue serializes via re-entry guard
- [ ] Custom Tabs failure path: disable Chrome temporarily and observe \`Linking.openURL\` fallback log
- [ ] No regression in Phase 1 OAuth (Anthropic / GitHub via in-app Browser Pane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)