### PR TITLE
feat(deeplink): Google OAuth URLs auto-upgrade to Custom Tabs (Phase 1.2 Stage 2)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -468,6 +468,53 @@ export default function RootLayout() {
             logError('DeepLinkQueue', `rejected non-http(s) url: ${url.slice(0, 64)}`);
             continue;
           }
+          // Phase 1.2 Stage 2 (Google OAuth safety routing): upgrade any
+          // queue line currently routed in-app whose host is
+          // accounts.google.com to external-browser dispatch. Google's
+          // OAuth flow blocks WebView via the X-Requested-With header
+          // that Chromium injects unconditionally, and UA spoofing alone
+          // can't bypass it (established 2026-05-08). Custom Tabs runs
+          // the same Chromium core but as the system browser process, no
+          // `wv` token, no X-Requested-With, so Google accepts the sign-in.
+          //
+          // SAFETY WINS over explicit declaration: an emitter that sent
+          // {"authMode":"in-app"} for a Google OAuth URL is also upgraded.
+          // OAuth URLs in WebView fail predictably; routing them through
+          // Custom Tabs is the safer default. Emitters that have a real
+          // reason to need in-app rendering for accounts.google.com would
+          // be misrouting OAuth into a known-broken path. Explicit
+          // {"authMode":"external-browser"} is left untouched (already
+          // resolved upstream of this branch).
+          //
+          // We narrow the auto-upgrade to accounts.google.com exactly
+          // (NOT *.google.com) because:
+          //   - User-pasted YouTube / Drive / Maps URLs should still open
+          //     in-app (Phase 1 behaviour, no auth gating).
+          //   - Only the OAuth host is the one that fingerprints WebView.
+          //
+          // Scope note: this layer makes Google OAuth URLs SAFE once they
+          // reach the queue. It does NOT implement Gemini auth on its
+          // own. Gemini CLI must invoke xdg-open (which routes through
+          // shelly-xdg-open.c → file queue) for this upgrade to fire. If
+          // Gemini CLI only prints the OAuth URL to stdout without
+          // invoking xdg-open, a follow-up wrapper that pushes the URL
+          // into the queue is still needed (deferred until on-device
+          // observation confirms which behaviour Gemini CLI exhibits).
+          if (authMode === 'in-app') {
+            try {
+              const parsedUrl = new URL(url);
+              if (parsedUrl.host.toLowerCase() === 'accounts.google.com') {
+                authMode = 'external-browser';
+                provider = provider ?? 'google';
+                logInfo('DeepLinkQueue', `auto-upgraded Google OAuth URL to external-browser: ${url}`);
+              }
+            } catch {
+              // URL constructor threw on a string that passed http(s)
+              // regex earlier — extremely unlikely. Fall through to
+              // existing in-app dispatch; safer than hard-fail on a path
+              // that's only best-effort anyway.
+            }
+          }
           if (authMode === 'external-browser') {
             await dispatchExternalBrowser(url, provider);
             logInfo('DeepLinkQueue', `external dispatched (provider=${provider ?? 'unknown'}): ${url}`);


### PR DESCRIPTION
## Summary

External-browser routing layer for Google OAuth. Any URL queue line whose host is exactly \`accounts.google.com\` is auto-upgraded to \`WebBrowser.openBrowserAsync\` (Custom Tabs) instead of the in-app Browser Pane. Five-line condition in \`drainQueue\`, no new files.

This unblocks Gemini login (and any future CLI doing Google OAuth) without per-CLI wrappers.

## Scope (and what this is NOT)

This layer makes Google OAuth URLs SAFE once they reach the URL queue. It does NOT implement Gemini auth by itself. Gemini CLI must invoke \`xdg-open\` (which routes through \`shelly-xdg-open.c\` → file queue → this drain loop) for the upgrade to fire. If Gemini CLI only prints the OAuth URL to stdout without invoking \`xdg-open\`, a follow-up wrapper that pushes the URL into the queue will still be needed. That decision gates on real-device observation of \`gemini auth login\` output.

## Why this works (per Codex 2026-05-08 design)

- Google detects WebView via \`X-Requested-With\` header that Chromium injects unconditionally; UA spoofing alone can't bypass it.
- Custom Tabs uses the same Chromium core but as the system browser process — no \`wv\` token, no \`X-Requested-With\`, so Google accepts the sign-in.
- Shelly's role is only \"launch the right user-agent\". CLI keeps full ownership of OAuth flow (PKCE verifier, loopback callback, token exchange, credential write) per RFC 8252.

## Behaviour

| Queue line | Before | After |
|---|---|---|
| Plain URL, host=accounts.google.com | in-app Browser Pane (Google blocks) | Custom Tabs ✅ |
| Plain URL, host=any other | in-app Browser Pane | in-app Browser Pane (unchanged) |
| JSON authMode=in-app, host=accounts.google.com | in-app | **Custom Tabs (safety wins)** |
| JSON authMode=in-app, host=any other | in-app | in-app (unchanged) |
| JSON authMode=external-browser | Custom Tabs | Custom Tabs (unchanged) |

\"Safety wins over explicit\" for accounts.google.com because OAuth URLs in WebView fail predictably; emitters declaring \`in-app\` for the OAuth host would be misrouting into a known-broken path.

## Why exact-host match (not \`*.google.com\`)

User-pasted YouTube / Drive / Maps URLs keep their Phase 1 in-app Browser Pane behaviour. Only the OAuth host fingerprints WebView. Wider patterns would change UX for non-auth Google URLs.

## Codex review trail

| Round | Finding | Fix |
|---|---|---|
| Design (2026-05-08) | Shelly should open URL only, CLI owns OAuth flow | Implementation matches design |
| Push-prep (2026-05-09) | Inline comment claimed \"explicit JSON authMode is precedence\" — actual behaviour upgrades \`{authMode:'in-app'}\` for Google host too | Reframed comment as \"safety wins over explicit\" |
| Push-prep | Scope note missing — readers might think this implements Gemini auth | Added explicit \"this is a routing layer; Gemini wrapper may still be needed\" note |

## Test plan

- [ ] Build green
- [ ] Reinstall on Z Fold6
- [ ] Phase A check: \`claude --version\` / \`codex login\` (existing flows) unchanged
- [ ] Phase B check: \`gemini auth login\` (or whatever Gemini's OAuth command is) — observe whether xdg-open is invoked. If yes, this PR enables full sign-in via Custom Tabs.
- [ ] If Gemini CLI prints URL without xdg-open: follow-up wrapper PR needed to push the URL into the queue. The drainQueue side stays as-is.
- [ ] No regression on user-pasted in-app URLs (YouTube, Drive, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)