### PR TITLE
Tier-1: agent credential isolation + autonomous-mode specs

### DIFF
--- a/__tests__/agent-executor-credential.test.ts
+++ b/__tests__/agent-executor-credential.test.ts
@@ -1,0 +1,44 @@
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+import { generateRunScript } from '@/lib/agent-executor';
+import { Agent, ToolChoice } from '@/store/types';
+
+const agent = (tool: ToolChoice): Agent => ({
+  id: 't',
+  name: 'T',
+  description: '',
+  prompt: 'hi',
+  schedule: null,
+  tool,
+  outputPath: '~/out',
+  outputTemplate: null,
+  enabled: true,
+  lastRun: null,
+  lastResult: null,
+  createdAt: 0,
+  version: 1,
+});
+
+const UNSET = 'unset PERPLEXITY_API_KEY GEMINI_API_KEY';
+
+describe('generateRunScript credential isolation (Tier-1)', () => {
+  it('scrubs API keys for OAuth/local tools', () => {
+    expect(generateRunScript(agent({ type: 'cli', cli: 'codex' }))).toContain(UNSET);
+    expect(generateRunScript(agent({ type: 'local' }))).toContain(UNSET);
+    expect(generateRunScript(agent({ type: 'ab-article-eval' }))).toContain(UNSET);
+  });
+
+  it('keeps keys for key-bearing backends', () => {
+    expect(generateRunScript(agent({ type: 'perplexity' }))).not.toContain(UNSET);
+    expect(generateRunScript(agent({ type: 'gemini-api' }))).not.toContain(UNSET);
+    expect(generateRunScript(agent({ type: 'auto' }))).not.toContain(UNSET);
+  });
+
+  it('never unsets non-secret config', () => {
+    const s = generateRunScript(agent({ type: 'cli', cli: 'codex' }));
+    expect(s).not.toMatch(/unset[^\n]*LOCAL_LLM/);
+    expect(s).not.toMatch(/unset[^\n]*OBSIDIAN/);
+  });
+});

--- a/docs/superpowers/specs/2026-06-16-hermes-secretary-mvp-phase0.md
+++ b/docs/superpowers/specs/2026-06-16-hermes-secretary-mvp-phase0.md
@@ -1,0 +1,106 @@
+# MVP Spec — AI Secretary Phase 0 (say-it → it self-registers → it acts)
+
+Status: **Ready to build** (GO-WITH-CHANGES, agent-reviewed 2026-06-16)
+Created: 2026-06-16
+North Star: [2026-06-16-hermes-secretary-north-star.md](./2026-06-16-hermes-secretary-north-star.md)
+
+> This spec is the **thin slice that ships first**. Anything not listed here is out of scope — see §7 Parked. If a feature would make the slice thicker, it belongs in the North Star, not here.
+
+---
+
+## 1. The one outcome this MVP delivers
+
+> The user types, in natural language, *"毎日8時にXの下書きを作って"* — Shelly parses it into a **structured agent**, shows a **confirmation card**, and on confirm the agent **registers itself and runs on schedule**, producing a draft and **notifying** the user. The user can **list / pause / delete** it at any time.
+
+That's it. NL → preview → confirm → scheduled run → action → approval. The existing SNS draft agents are the **first scheduled skill** that exercises this end-to-end (draft-only, no publish).
+
+## 2. Scope (the six things we build)
+
+### 2.1 NL self-registration **with a confirmation/preview card** `[EXTEND]`
+- NL parser extracts `{name, schedule, tool, action}` from a user utterance.
+- **The parse produces a reviewable preview card, NOT a live agent.** Card shows: *"I'll run **\<action\>** **\<schedule\>** using **\<route/tool\>**."* with `[Confirm] [Edit] [Cancel]`. First registration ALWAYS requires one human confirm.
+- The preview card **doubles as the edit UI** (reused in §2.5).
+- Back-half is already wired: feed the confirmed struct into `createAgent` ([agent-manager.ts:130](../../../lib/agent-manager.ts)) → `installAgent` (:163); chat entry already exists at [TerminalPane.tsx:1312](../../../components/panes/TerminalPane.tsx). The net-new part is the **JP/EN NL→fields parser** + the card.
+- **Schedule constraint (hard requirement):** cron support is a 3-pattern whitelist — `*/N * * * *`, `M H * * *` (daily), `M H * * D` (weekly) ([agent-scheduler.ts:9-29](../../../lib/agent-scheduler.ts)). The parser MUST emit only these shapes. If it can't, the card shows the schedule field as **unset and requires manual selection** — never silently register an agent that will never fire.
+
+### 2.2 Execution via `codex exec` one-shot `[REUSE — not net-new]`
+- MVP uses the **existing** `codex exec "$prompt"` one-shot path ([agent-executor.ts:867](../../../lib/agent-executor.ts)). `codex exec` is already agentic *within its single invocation* (it uses tools in that turn). We capture final stdout → result.
+- **We do NOT build Shelly-side multi-step orchestration in the MVP.** That (sub-agents, agent-to-agent handoff, intermediate-step surfacing) is the single most expensive item and is North Star / Phase 4.
+
+### 2.3 Action layer — 3 capability types `[NET-NEW type, small]`
+- Add an `action` field to the `Agent` type ([store/types.ts:458](../../../store/types.ts)). Today the only output is `outputPath` (file write).
+- Three action types for MVP:
+  - **`draft`** — write result to `outputPath` (+ Obsidian mirror). This is today's behavior, made explicit.
+  - **`notify`** — push notification with the result (reuse `notifyAgentResult` [agent-manager.ts:232](../../../lib/agent-manager.ts)).
+  - **`webhook`** — HTTP POST the result (reuse `http_post_json` already emitted into every run script, [agent-executor.ts:128](../../../lib/agent-executor.ts)).
+  - **`cli`** — run a command with the result. **(highest privilege — see §2.6 approval tiering)**
+- **`draft` and `publish` are distinct capabilities. Ship `draft` only.** The "no publish" guarantee lives in the action-layer capability boundary, NOT as a Codex-prompt convention — a future NL-parsed "post to X" must not silently inherit publish.
+
+### 2.4 Routing — hard-guards + keyword + manual pin `[MIXED]`
+- **Default route = on-device** (Codex/Qwen). One explicit line in code/config: local-first.
+- Reuse the existing keyword router `suggestTool` ([agent-tool-router.ts:33](../../../lib/agent-tool-router.ts)).
+- **Hard guards for MVP (minimal set):**
+  - **secrets/PII guard** — a regex scanner over the task text; if it matches key/credential/PII patterns → force local. (Net-new; small. `command-safety.ts` is danger-detection, not secret-detection.)
+  - **offline** — MVP relies on the **existing reactive fallback** (cloud call fails → `local_context_fallback`, [agent-executor.ts:678](../../../lib/agent-executor.ts)). *Proactive* offline detection (needs `expo-network`, not currently a dep) is **parked** — default-is-local already makes offline mostly a non-event.
+- **Manual pin (per agent):** `Run on: [Auto] [On-device] [Cloud]` surfaced in the preview/edit card (§2.1). Stored as a field on the agent. This is the user's escape hatch for bad local quality — do not widen the default, widen control.
+- **Reason log:** every routing decision records why (which guard/keyword fired) into run history.
+
+### 2.5 Agent lifecycle + kill-switch `[NET-NEW — table stakes]`
+Autonomy without a stop button is not shippable. MVP must include:
+- **List view** of registered agents (reuse `@agent list` data path).
+- **Pause / disable** and **delete** per agent (`enabled` field already exists on `Agent`).
+- **Global "stop all agents"** kill-switch (single toggle).
+- **Circuit breaker:** auto-disable an agent after **N consecutive failed runs** (default N=3) so a misfiring self-registered agent can't loop forever (e.g. a bad webhook = self-inflicted DoS).
+- **Minimal run log** per agent (last run, last result, last error) — reuse `runHistory` ([agent-store.ts:11](../../../store/agent-store.ts), last 30 logs).
+
+### 2.6 Push approval — **tiered by action privilege** `[EXTEND]`
+Reuse the notification action-button + PendingIntent pattern ([NotificationDispatcher.kt:163-215](../../../modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/NotificationDispatcher.kt)). **But** the existing Allow handler writes `y\r` to a *live Codex PTY*; a scheduled draft has no live PTY, so the Allow handler that dispatches the **stored action** is net-new (bridge via the existing `$HOME/.shelly-deep-link-queue` poll, [app/_layout.tsx](../../../app/_layout.tsx)).
+
+Approval tiers (blast-radius control):
+| Action | Approval |
+|---|---|
+| `draft`, `notify` | one-tap from notification |
+| `webhook` | one-tap **only with destination host + payload preview shown** |
+| `cli` | **never one-tap** — open app, explicit in-app confirm showing the exact command string, routed through `command-safety.ts` 5-level check; non-auto-approvable above a safety threshold |
+
+Approvals are **single-use, bound to a specific pending run-id, and expire** after a short window (no replay / stale-notification re-fire).
+
+## 3. Degraded path (Codex is the load-bearing brain)
+
+Codex agentic execution on-device is fragile (it's a termux ELF fork; Claude re-enable unfinished). MVP must define failure behavior — **silence is the worst outcome for a secretary:**
+- **Per-run timeout + crash detection** → mark the run failed (feeds the §2.5 circuit breaker), never hang forever.
+- **Registration parse fallback:** if Codex can't parse the NL, fall back to a **deterministic template grammar** (e.g. `remind me <X> at <time>` regex) OR surface the raw text in the preview card with empty structured fields for the user to fill. NL parse must never hard-block registration.
+- **Execution failure:** notify *"agent X couldn't run"*. A degraded honest failure is acceptable; silent non-execution is not.
+- **Never** fall back to cloud secretly (breaks the offline promise and may leak the §2.4 secret guard's protected input).
+
+## 4. Build order within the MVP
+
+1. `Agent.action` type + action dispatch (`draft`/`notify`/`webhook`) after result is ready ([agent-executor.ts:788](../../../lib/agent-executor.ts)).
+2. NL→fields parser (constrained to the 3 cron shapes) + deterministic fallback grammar.
+3. Confirmation/preview card (also the edit UI) + manual-pin field.
+4. Lifecycle: list / pause / delete / global stop / circuit breaker / run log.
+5. Tiered push approval (notify→webhook→cli) + run-id-bound single-use approvals.
+6. Secret-guard regex + reason log; wire the SNS draft agents through the new action layer as the validation vertical.
+
+## 5. Done = (acceptance)
+
+- [ ] Typing *"毎日8時に〜して"* yields a preview card with correct schedule `0 8 * * *`, an action, and a route; Cancel discards, Confirm registers.
+- [ ] A registered agent fires on its AlarmManager schedule and runs via `codex exec`.
+- [ ] `draft`/`notify`/`webhook` actions all execute; `cli` requires in-app confirm.
+- [ ] User can list, pause, delete agents and hit a global stop.
+- [ ] An agent failing 3× auto-disables and notifies.
+- [ ] Codex unavailable → registration still possible (template/manual), execution failure notifies (never silent, never secret cloud fallback).
+- [ ] Existing SNS draft agents run through the new action layer, draft-only (no publish capability present).
+
+## 6. Verification note
+
+Per project rule, changes touching native (notification handler, deep-link bridge, AlarmManager) and the routing/execution path need an **on-device smoke test** before merge — registering a real agent, confirming it fires, and confirming a real notification→approve→action round-trip. `-p`/`--version`-style checks are insufficient for the agentic path.
+
+## 7. Parked — explicitly NOT in this MVP
+
+- **Layer-2 local Qwen routing classifier** — per-task small-model inference = latency + battery + no model-selection UI. MVP routing is hard-guard + keyword + pin. Add when it demonstrably helps.
+- **A/B-eval self-learning routing loop** — research-grade (delayed/noisy reward, "good routing" hard to define). North Star §6.
+- **Proactive offline detection** (`expo-network`/NetInfo) — MVP uses the existing reactive cloud→local fallback.
+- **Shelly-side multi-step agentic orchestration / parallel sub-agents** — North Star Phase 4.
+- **Persistent memory layer, skill auto-generation, inbound messaging gateway, browser automation** — North Star Phases 1–4.
+- **`publish` action capability** — distinct type, deliberately not shipped.

--- a/docs/superpowers/specs/2026-06-16-hermes-secretary-north-star.md
+++ b/docs/superpowers/specs/2026-06-16-hermes-secretary-north-star.md
@@ -1,0 +1,98 @@
+# North Star — Shelly On-Device Autonomous AI Secretary
+
+Status: **Vision / aspirational** (not a build order — see the MVP spec for what ships first)
+Created: 2026-06-16
+Companion: [2026-06-16-hermes-secretary-mvp-phase0.md](./2026-06-16-hermes-secretary-mvp-phase0.md)
+
+---
+
+## 1. The product in one sentence
+
+A **fully on-device, offline-capable autonomous AI secretary** living inside Shelly — you tell it (in natural language) what you want done and when, and it registers itself, runs on schedule, takes real actions, remembers across sessions, and gets better the more you use it.
+
+Reference product: **Nous Research "Hermes Agent"** (hermes-agent.org) — a self-improving autonomous agent. We are building the **pocket / offline** analog of it.
+
+## 2. The wedge — why Shelly, not Hermes
+
+Hermes runs on a **server/PC and is reached via messaging apps** (Telegram/Discord/Slack). Shelly's differentiator is the inverse:
+
+- **The phone IS the always-on host.** No server to rent, no cloud dependency to stay alive.
+- **Offline-capable.** The reasoning brain (Codex CLI / local Qwen) runs on-device. The secretary still works on a train with no signal.
+- **The hardest infra is already built.** Shelly already bundles a terminal runtime, on-device CLIs with tool-use loops (Codex working; Claude in progress), multi-backend LLM access, cron→AlarmManager scheduling, a notification system, and an Obsidian Vault on `/sdcard`.
+
+Design consequence: **do NOT copy Hermes 1:1** (server + messaging gateway). The notification system + terminal + (optional) Telegram inbound is the gateway; the device is the host.
+
+## 3. The six pillars (Hermes parity) vs Shelly today
+
+| Pillar | Shelly today | Gap to close |
+|---|---|---|
+| **Scheduled automation** | ✅ cron→AlarmManager ([agent-scheduler.ts](../../../lib/agent-scheduler.ts), [AgentAlarmReceiver.kt](../../../modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmReceiver.kt)). Cron is a **3-pattern whitelist** (every-N-min / daily / weekly). | Richer cron / one-shot timers / event triggers |
+| **Multi-backend LLM** | ✅ local Qwen / Perplexity / Codex / Gemini ([agent-executor.ts](../../../lib/agent-executor.ts)) | — (strong) |
+| **Reasoning loop (agentic)** | ⚠️ `codex exec` **one-shot** only; no Shelly-side multi-step orchestration | Multi-step orchestration, sub-agent spawning |
+| **Parallel sub-agents** | ⚠️ multiple agents exist but isolated | Orchestration + agent-to-agent handoff |
+| **Messaging gateway** | ⚠️ outbound notifications + anyclaw relay; **no inbound** | Inbound (notification-tap → Telegram → others) |
+| **Browser automation + vision** | ⚠️ BrowserPane (WebView) exists, not agent-driven | Programmatic browser control + vision |
+| **Persistent memory** | ❌ runHistory = logs only; **but Obsidian Vault is the substrate** | Memory write/recall, semantic retrieval |
+| **Automatic skill generation** | ❌ none | Skill-doc generation + registry + recall |
+
+**Honest framing:** the built ~40% is the *hardest* 40% (on-device runtime, scheduling, multi-backend). But the remaining 60% (memory, skills, gateway, orchestration) is the **"secretary-ness" itself** and is not light. MVP (Phase 0) is cheap; full Hermes parity is a different, much larger thing. Keep those two mentally separate.
+
+## 4. The brain: hybrid, on-device-first
+
+**Default = on-device (Codex CLI / local Qwen). Cloud (Perplexity/Gemini) only when a hard signal fires** (freshness, vision, heavy reasoning). Not 50/50 — a 50/50 default quietly sends half of everything to the cloud and erodes the offline differentiator.
+
+**The routing principle (load-bearing):** the *routing decision itself must be cheap and offline*. Never call the cloud to decide whether to use the cloud — that breaks offline operation and wastes cost/latency. Two layers:
+
+```
+Layer 1 — HARD GUARDS (rules; the LLM cannot override)
+  offline            → local (forced)
+  secrets/PII/keys   → local (forced)
+  needs fresh web    → cloud Perplexity (forced)
+  cloud quota empty  → local (degrade)
+Layer 2 — SCORING (a small local model judges the remainder)
+  reasoning weight · code/prose/search · capability · cost · latency
+Execution — fallback chain
+  cloud fail/timeout → degrade to local (never silent)
+```
+
+100% correct auto-routing is impossible. Ship **smart default + manual pin (per agent) + a visible reason log** so a wrong route is shallow, not catastrophic.
+
+## 5. Phased roadmap (leverage order)
+
+```
+Phase 0  MVP — say-it-and-it-self-registers + action layer + approval   ← MVP spec
+            (SNS draft agents = first scheduled skill / draft-only vertical)
+   ↓
+Phase 1  Persistent memory     — Obsidian Vault as the memory substrate.
+            The core of "it grows with you." Cheapest here because the
+            physical substrate (Vault on /sdcard) already exists.
+   ↓
+Phase 2  Skill registry + hybrid auto-router (Layer 2 + scoring).
+            Auto-generate reusable skill docs (Hermes' signature move).
+   ↓
+Phase 3  Inbound gateway       — notification-tap → Telegram inbound →
+            (later) more messaging platforms. "Direct it from anywhere."
+   ↓
+Phase 4  Orchestration         — Codex/Claude as the reasoning loop;
+            parallel sub-agents + agent-to-agent chaining.
+```
+
+Phase 1 (memory) is placed before everything fancy on purpose: without it the secretary stays a stateless bot. Shelly's Obsidian Vault makes it the cheapest high-leverage step.
+
+### Cross-cutting hardening track — Autonomous Mode (A/B/C)
+
+Once agents run multi-step **without per-step approval**, they must be made *narrower than the manual terminal, never wider*. This is a security track that cuts across Phase 0's action layer and Phase 4's orchestration, specced separately (agent-reviewed 2026-06-17):
+
+- **[A — Policy gate & sandbox](./2026-06-17-autonomous-mode-A-policy-gate.md)** (the autonomous-mode MVP): L1/L2/L3 autonomy levels, canonical workspace-root boundary, policy-first allow/deny/gray approval gate (wires the existing unused `command-safety.ts` into the exec path), OAuth/local-only tool allowlist, kill-switch + audit log.
+- **[B — Process persistence](./2026-06-17-autonomous-mode-B-process-persistence.md)**: FGS run + serialized fan-out; **honest finding — FGS is not a phantom-killer shield for codex children, "flat tree" is impossible (LD_PRELOAD wrapper), so long local tasks are refused/queued pending C.**
+- **[C — Cloud Codex offload](./2026-06-17-autonomous-mode-C-cloud-offload.md)** (own phase, gated behind A): the only real escape from the Android phantom-process ceiling for long tasks. Quota-aware routing with a defer/queue dead-cell fix; offload = boundary op with payload-fingerprint approval; `codex cloud exec` only (no SSH), OAuth only (no API keys).
+
+Governing invariant for the whole track: **"silent" (L3) only ever relaxes prompt *frequency* — never secret-scan, diff-review, command-safety, or boundary hard-denies.** That is what keeps auto-routing from becoming auto-exfiltration.
+
+## 6. Self-improvement loop (Hermes' "grows with you")
+
+Long-term, every routing/skill decision is logged as `{task, route, reason, confidence, outcome}` into the memory layer (Vault), and the existing A/B-eval infra (`ab-article-eval`) scores whether the choice was good → the router and skill set improve over time. **This is research-grade (delayed, noisy reward; hard to define "good")** and is explicitly *parked* out of the MVP. It lives here, in the North Star.
+
+## 7. What this doc is NOT
+
+This is the destination, not the build order. Nothing here is a commitment to build in this form or sequence. The only thing being built now is the **MVP (Phase 0)** — see the companion spec. When in doubt, the MVP spec wins; this doc bends to it.

--- a/docs/superpowers/specs/2026-06-17-autonomous-mode-A-policy-gate.md
+++ b/docs/superpowers/specs/2026-06-17-autonomous-mode-A-policy-gate.md
@@ -1,0 +1,119 @@
+# Autonomous Mode — Spec A: Policy Gate & Sandbox (MVP, write first)
+
+Status: **Ready to build (MVP of autonomous mode)** — agent-reviewed 2026-06-17, GO-WITH-CHANGES
+Created: 2026-06-17
+Series: A (this) → [B process-persistence](./2026-06-17-autonomous-mode-B-process-persistence.md) → [C cloud-offload](./2026-06-17-autonomous-mode-C-cloud-offload.md). **C is gated behind A.**
+Related: [Hermes secretary north-star](./2026-06-16-hermes-secretary-north-star.md), [MVP Phase-0](./2026-06-16-hermes-secretary-mvp-phase0.md)
+
+> Autonomous mode = an agent runs multi-step **without per-step human approval**. It must be **NARROWER than the manual terminal, never wider.** Manual terminal behavior is unchanged. This doc is the foundation: neither B nor C is safe without A.
+
+---
+
+## 0. Threat model (Android reality)
+
+Shelly runs Codex CLI natively at **app uid**, no container, no Termux, no on-device VM/gVisor (infeasible on Android — documented as out-of-scope). The only isolation available is Linux process-group + Android FGS. Therefore safety is enforced at the **tool-invocation layer** (the commands the agent emits), not at the syscall layer. Reference policy model: OpenClaw "auto mode" — policy runs first, low-risk passes, gray → human-in-the-loop, full access is opt-in.
+
+## 1. Ground-truth inventory (verified 2026-06-17 — what we build ON)
+
+| Capability | Reality |
+|---|---|
+| Background-agent approval gate | **NONE.** Scheduled agents run silently; no approval, no safety check before `codex exec` ([agent-executor.ts:867](../../../lib/agent-executor.ts)). The only existing gate is for **live interactive Codex PTY y/n prompts** (NotificationDispatcher → ScouterWidgetPromptActivity writes `y\r`/`n\r`). "Approval Proxy" is a README/feature-gate name, not a runtime class. → **Background gate = NET-NEW** (but reuse the PTY-approval + push infra). |
+| `command-safety.ts` | **EXISTS & comprehensive** (5 levels, detects rm -rf/dd/mkfs/git push --force/chmod -R) **but is imported NOWHERE in the agent exec path.** ([command-safety.ts](../../../lib/command-safety.ts)) |
+| Workspace-root / canonical-path / symlink+`..` boundary | **DOES NOT EXIST anywhere.** NET-NEW. |
+| Secret redaction | **EXISTS** ([redact-secrets.ts](../../../lib/redact-secrets.ts): sk-/sk-ant-/AIza/JWT/`*_API_KEY=`; Kotlin `redactForScouter`). |
+| Codex auth | **OAuth (ChatGPT subscription)**, `~/.codex/auth.json` (`auth_mode="chatgpt"`, `OPENAI_API_KEY:null`). Read **ambiently** via `$HOME`, no access control. |
+| API keys in agent path | **VIOLATION EXISTS:** `perplexity`/`gemini-api` tool types inject `PERPLEXITY_API_KEY`/`GEMINI_API_KEY` into the run env via `~/.shelly/agents/.env` ([agent-executor.ts:907,1099](../../../lib/agent-executor.ts)). The `auto` router **prefers** the Gemini API-key branch *before* falling back to OAuth-Codex ([agent-executor.ts:928](../../../lib/agent-executor.ts)). |
+
+## 2. The cross-cutting invariant (governs A, B, and C)
+
+> **"Silent" (L3) ever only relaxes *prompt frequency*. It NEVER relaxes secret-scan, diff-review, command-safety, or boundary hard-denies.**
+
+This single rule is what keeps "auto-routing" from sliding into "auto-exfiltration." Every level, every phase, obeys it.
+
+## 3. Autonomy levels (user-chosen, persisted, shown in Scouter)
+
+- **L1 read-only** — reads auto; every write/exec → approval.
+- **L2 workspace (default)** — r/w/exec **inside the canonical workspace root** auto; crossing the boundary → approval.
+- **L3 full** — explicit opt-in only, one-time warning on first enable, never the default.
+
+The level is **set by the human out-of-band (ConfigTUI)** and passed into the run as **immutable input** — never read from a file the run can mutate (see §6).
+
+## 4. Tool-set allowlist — **autonomous = OAuth/local only** `[MUST-FIX #1]`
+
+Autonomous execution tool set = **`cli` (OAuth-Codex) + `local` (Qwen) ONLY.** `perplexity` and `gemini-api` are **excluded** from autonomous runs (they carry long-lived plaintext API keys in env — a silent autonomous loop with an ambient Google key is a worse exfil channel than the gated cloud offload in C). They remain available in **manual/foreground** agent runs where a human is present.
+
+Implementation: when `autonomous === true`, the `auto` router **drops the `GEMINI_API_KEY`-first branch** ([agent-executor.ts:928](../../../lib/agent-executor.ts)) and resolves only to `cli`/`local`. Enforced as an allowlist, not a comment.
+
+## 5. Canonical workspace-root boundary `[NET-NEW]`
+
+- At session start, resolve a **canonical workspace root** (realpath, fully resolved).
+- Every agent-emitted file op: resolve **symlinks and `..` FIRST**, then compare against root. Outside root = **boundary event**.
+- This logic does not exist today — it is the core net-new primitive of A.
+
+## 6. Policy-first approval gate (the heart) `[NET-NEW, reuse approval infra]`
+
+Classify **each agent-emitted operation**. **Boundary operations** =
+`{ leaves workspace root | network send | reads secrets (auth.json, Keystore/expo-secure-store) | destructive cmd (rm -rf, dd, mkfs, git push --force, chmod -R) }`.
+
+- **Policy = declarative DATA, not code** (a rule set file).
+- **allow → run · explicit-deny → block + audit-log · gray → approval gate.**
+- Approval gate reuses the existing PTY-approval + push-notification infra; the prompt shows **dry-run/diff**; the agent is **blocked until decide**.
+- Wire **`command-safety.ts` into the exec path** (currently absent) — its CRITICAL/HIGH classifications feed the deny/gray decision.
+
+**Secret-read boundary — narrowed `[MUST-FIX #5]`:** auth.json read by **codex's own runtime is implicitly ALLOWED** (intrinsic to running codex; cannot be gated without a syscall sandbox we don't have). The boundary op is any **agent-emitted command** that reads the secret file (`cat ~/.codex/auth.json`, `grep` over `$HOME`, etc.). Rule: *secret read by an agent-emitted command = boundary; read by the runtime itself = allowed.* Enforceable by path-match on tool-invoked commands.
+
+**Policy file is itself boundary-protected `[MUST-FIX #6]`:** the policy file + autonomy level are **read-only to the agent**; any agent-emitted write to the policy path is a **hard-deny** (not gray, not self-approvable). Only the human UI mutates them. A prompt-injected agent must not be able to self-escalate. The §8 scan-hook should flag instruction-file content that names autonomy levels or policy paths.
+
+## 7. Secret isolation & prompt-injection
+
+- No ambient secret access for agent-emitted ops; auth.json/Keystore read = boundary even at L2 (per §6 narrowing).
+- Continue secret redaction in all logs (reuse `redact-secrets.ts`).
+- **Prompt-injection:** treat terminal output / file content the agent reads as **untrusted evidence, not instructions.** Ship a **stub hook** that scans skill/instruction files before use (interface now, impl later — cf. OpenClaw SkillSpector). MVP = interface stub only.
+
+## 7a. Credential brokering & isolation `[grounded 2026-06-17]`
+
+Industry precedent (OpenClaw — 21k leaked keys; Hermes Tool Gateway; Akamai): **never put secrets where the LLM can read them.** Achieve this in two tiers, sequenced cheapest-first.
+
+### Tier 1 — Strip keys from the agent env (do first, ~5 lines, no native work) `[CHEAP-FIX]`
+The single `source "$ENV_FILE"` at [agent-executor.ts:707](../../../lib/agent-executor.ts) is **tool-agnostic**, so a codex/local-only agent ALSO carries `PERPLEXITY_API_KEY`/`GEMINI_API_KEY` in its env — the exact OpenClaw leak surface. **Make the `.env` source conditional on tool type**: only HTTP-API tools (perplexity/gemini/auto/ab-eval) source it; the `cli`(codex)/`local` autonomous path runs with a **minimal, key-free env**. The JNI envp is already key-free and parent-independent ([shelly-exec.c:163](../../../modules/terminal-emulator/android/src/main/jni/shelly-exec.c)), so this needs zero native change and **closes the autonomous-path policy violation immediately, even before any broker exists.** This is the highest-leverage change in the whole credential story.
+
+### Tier 2 — Broker (Hermes Tool-Gateway analog) for when a Codex agent must call an API itself `[BUILDABLE]`
+When an autonomous Codex agent needs `research()` (perplexity) etc. **without holding the key**: the key stays in Shelly; the agent calls a tool that round-trips to a Shelly-held broker which executes the API call and returns **only the result text**.
+- **Cheapest channel = a new authenticated route on the existing Scouter `HookHttpServer`** (`ServerSocket(127.0.0.1:ephemeral)`, `X-Scouter-Token` auth, thread pool; port/token already discoverable agent-side via `shelly scouter hooks`). Add `/broker/<capability>`; agent-side `shelly research "q"` curls it and blocks naturally on the response.
+- **Why not the obvious alternatives:** `codex exec` is a one-shot black box (no MCP/tool-callback configured — `~/.codex/config.toml` only sets `check_for_update_on_startup`); Shelly hosts no MCP server (client-only); the RN-side `pseudo-shell.ts` that holds keys is **unreachable from a background agent's bash** (the on-PATH `shelly` binary is keyless/scouter-only). A local MCP server is the "most Hermes-correct" path but by far the most work and has unverified codex-exec-drives-MCP assumptions.
+- **Open design decision:** `HookHttpServer` on/off is gear-menu controlled; a credential broker probably wants a **decoupled always-on listener** (or to guarantee the broker route survives Scouter being disabled). Also: keys are read RN-side today ([secure-store.ts](../../../lib/secure-store.ts)), so either move the brokered API call to RN (Kotlin enqueues → RN handles → responds) or expose the key to the Kotlin server process. Decide before building Tier 2.
+
+### Hardening that applies to every surface that keeps a key `[NET-NEW, extend existing primitives]`
+- **Lock agent-controlled loader overrides:** today `exec-wrapper.c` manages `LD_*` for its own redirection but does **not** reject agent-set `LD_PRELOAD`/`LD_LIBRARY_PATH`. Extend the existing `scrub_*_envp` primitives to reject agent-origin `LD_*`/`DYLD_*` (OpenClaw parity).
+- **Enforced workspace-`.env` guard:** the script sources only `~/.shelly/agents/.env` and cwd=`$HOME` today, so a repo `.env` can't auto-inject — but this is *incidental*, not enforced. Add an explicit guard so a future `cd`-into-repo can't let a workspace `.env` override broker/gateway credentials.
+- **Reader-agent isolation (prompt-injection blast-radius):** implement the §7 untrusted-evidence rule concretely as a **second restricted `codex exec`** (tools-disabled pass) that summarizes untrusted web/file content; only the summary feeds the main agent loop. Pure script orchestration (BUILDABLE); needs a one-line probe of whether codex-termux honors a no-tools flag. MVP = interface stub (per §7); real impl later.
+
+## 8. Kill-switch + audit log `[MUST-FIX #4 — missing entirely from original]`
+
+- **Kill-switch / mid-run abort:** a user-triggered hard-stop from the FGS notification that kills the codex **process group** (`kill -TERM -<pgid>`; children are in a `setsid` group, [shelly-exec.c:115](../../../modules/terminal-emulator/android/src/main/jni/shelly-exec.c)) and tears down children. Today the only bound is `timeout … || true` — there is no brake. Net-new, required.
+- **Audit log:** every boundary-op decision (allow/deny/gray→approved/denied), every command run, timestamped, **redacted via `redact-secrets`**. An autonomous agent with no tamper-evident action log is unauditable after an incident.
+
+## 9. MVP scope (Spec A = shippable autonomous mode for SHORT local tasks)
+
+Build: canonical workspace-root + symlink/`..` resolution (§5) · `command-safety.ts` wired into exec path + allow/deny/gray gate reusing PTY-approval infra (§6) · tool-type allowlist (§4) · secret-read-boundary scoped to agent-emitted reads (§6) · policy-as-data, agent-read-only (§6) · L1/L2/L3 levels in ConfigTUI + Scouter display (§3) · kill-switch + audit log (§8) · prompt-injection scan = **interface stub** (§7).
+
+**Out of MVP:** long-running task persistence (→ B), cloud offload (→ C), real prompt-injection scanner impl.
+
+## 10. Acceptance / tests
+
+- [ ] Symlink/`..` escape out of workspace root is detected and gated (boundary test).
+- [ ] A `rm -rf` / `git push --force` emitted by the agent hits command-safety and is denied/gated.
+- [ ] Approval gate blocks the agent until decide; deny is logged.
+- [ ] An agent-emitted `cat ~/.codex/auth.json` is a boundary op; codex's own token read still works.
+- [ ] Agent-emitted write to the policy file is hard-denied; level cannot be self-escalated.
+- [ ] perplexity/gemini-api are unreachable in an autonomous run; `auto` resolves to cli/local only.
+- [ ] Kill-switch terminates the whole process group mid-run.
+- [ ] Audit log records every boundary decision, secrets redacted.
+
+## 11. Docs to update (per task)
+
+SECURITY.md + README "Runtime, permissions & execution": autonomy levels, threat model, "cloud Codex is the only external execution path (see C), no SSH, no API keys — OAuth subscription only." Note on-device container/VM and isolatedProcess are out-of-scope (with reasons).
+
+## 12. Verification rule
+
+Touches native (kill-switch process-group signaling, approval bridge) + the exec path → **on-device smoke test before merge** (boundary escape, gate block/resume, secret-read block, kill-switch). `-p`/`--version` checks are insufficient for the agentic path.

--- a/docs/superpowers/specs/2026-06-17-autonomous-mode-B-process-persistence.md
+++ b/docs/superpowers/specs/2026-06-17-autonomous-mode-B-process-persistence.md
@@ -1,0 +1,54 @@
+# Autonomous Mode — Spec B: Process Persistence (depends on A)
+
+Status: **MVP-thin, but scoped to SHORT tasks only** — agent-reviewed 2026-06-17
+Created: 2026-06-17
+Series: [A policy-gate](./2026-06-17-autonomous-mode-A-policy-gate.md) → B (this) → [C cloud-offload](./2026-06-17-autonomous-mode-C-cloud-offload.md)
+
+> **Headline finding (do not soften):** the foreground service keeps the *app* process alive, but it is **NOT a phantom-process shield for codex's child processes.** "Flat process tree" is **structurally unachievable** while the `libexec_wrapper.so` LD_PRELOAD design exists. Therefore **long autonomous tasks cannot be made survivable locally — cloud offload (C) is the only real escape from the phantom-killer ceiling.** B makes *short* tasks robust; it does not make *long* tasks safe.
+
+---
+
+## 1. Ground-truth inventory (verified 2026-06-17)
+
+**The two killers (don't conflate):** (1) ordinary cached/empty reclaim; (2) **Phantom Process Killer (Android 12+)** — kills when a process's children exceed **32**, and kills CPU-heavy phantoms regardless of fore/background.
+
+**Process model of one `codex exec` run:**
+- Launch chain: `AgentAlarmReceiver` → `startForegroundService` → `TerminalSessionService.runAgentInBackground` (daemon thread + 35-min `PARTIAL_WAKE_LOCK`) → `AgentRuntime.runAgent` → `ShellyJNI.execSubprocess` → single `fork()` + `setsid()` + `execve(linker64, …)` ([shelly-exec.c:102,115,184](../../../modules/terminal-emulator/android/src/main/jni/shelly-exec.c)).
+- **`LD_PRELOAD=libexec_wrapper.so` re-execs EVERY tool through `/system/bin/linker64`** → each leaf tool = **2 phantom-pool entries** (`linker64` + tool). Persistent chain ≈ **5–7 processes**; every codex helper (`git`, `apply_patch`) adds a `linker64+tool` pair. Local-LLM agents fork a persistent `llama-server` sibling. Confirmed on real hardware (logcat `PhantomProcessRecord` entries).
+- **The doubling actively pushes runs toward the 32 cap.** You cannot remove the wrapper — it is the bionic open()/exec fix.
+
+**FGS:** EXISTS — `TerminalSessionService`, `foregroundServiceType="specialUse"`, persistent notification (id 7734), 35-min wakelock, execution on an in-process daemon thread ([TerminalSessionService.kt:210](../../../modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalSessionService.kt)). **But** the forked codex children are separate `setsid` Linux process groups the phantom killer counts independently — the FGS does **not** shield them.
+
+**Phantom mitigation today:** ZERO runtime. Only [process-guard.ts](../../../lib/process-guard.ts) detects SIGKILL and shows a wizard telling the user to run an adb command. The agent-executor's `llama-server` launch even **lacks the `nice -n 5`** that the TS autostart path has ([agent-executor.ts:601](../../../lib/agent-executor.ts) vs [llamacpp-setup.ts:550](../../../lib/llamacpp-setup.ts)).
+
+**isolatedProcess:** does not exist (NET-NEW; deferred — note IPC cost).
+
+## 2. What B delivers (honest scope)
+
+1. **Run the autonomous loop inside the FGS** (already the case for scheduled agents — keep it, ensure the autonomous loop also uses it, proper type + ongoing notification). This IS a native advantage Termux can't cleanly hold; implement it properly.
+2. **Serialize tool fan-out to 1** `[MUST-FIX #2 / #5]`: the agent runs **at most one tool subprocess at a time**, so peak phantom count = the persistent chain + one `linker64+tool` pair. This keeps a **short** task safely under 32. It does **not** make a long task safe.
+3. **Throttle local-LLM CPU** so the agent isn't flagged as a CPU-heavy phantom: add the missing `nice` to the agent-executor `llama-server` launch (parity with [llamacpp-setup.ts:550](../../../lib/llamacpp-setup.ts)); bound `--threads`; intermittent/duty-cycle execution where feasible.
+4. **Phantom budget accounting:** track an estimated live-phantom count during a run (chain + active tool pair + llama-server) and surface it; refuse to spawn a new tool when near a conservative ceiling (well under 32).
+
+## 3. The load-bearing position (state plainly in spec & docs)
+
+- **"Flat tree" → reframed as "serialized, fan-out = 1, peak ≤ N phantoms."** True flatness is impossible with the wrapper.
+- **FGS ≠ phantom shield for children.** Say so explicitly.
+- **Long autonomous tasks are OUT of local execution.** They are **refused or queued pending C** (cloud offload). Do not write B as if FGS solves long-run persistence — it does not.
+- **Do NOT depend on the user disabling the phantom killer** via adb/developer options — OEM-fragile, reverts. Document only as an optional power-user note, never the strategy.
+
+## 4. Routing consequence (feeds C)
+
+The phantom ceiling is *why* duration is a routing axis in C: **long → cloud** is not a preference, it's the only way a long task survives. The quota-tight + long-task **dead cell** (can't cloud, can't survive locally) is handled in C via **defer/queue** — see [C §quota](./2026-06-17-autonomous-mode-C-cloud-offload.md).
+
+## 5. Acceptance / tests
+
+- [ ] Autonomous loop runs inside the FGS with the ongoing notification; survives app backgrounding for a short task.
+- [ ] Fan-out is serialized: assert ≤1 active tool subprocess; assert peak phantom count stays under the conservative ceiling.
+- [ ] `llama-server` launched by the agent path carries `nice`; CPU duty-cycle keeps it off the CPU-heavy-phantom flag.
+- [ ] A task estimated as "long" is refused/queued locally (not silently run into a phantom-kill).
+- [ ] Kill-switch (from A §8) tears down the whole process group including llama-server.
+
+## 6. Out of scope (documented)
+
+isolatedProcess split (future; note IPC cost), on-device container/VM (infeasible on Android), removing the linker64 wrapper (it's the bionic exec fix — can't).

--- a/docs/superpowers/specs/2026-06-17-autonomous-mode-C-cloud-offload.md
+++ b/docs/superpowers/specs/2026-06-17-autonomous-mode-C-cloud-offload.md
@@ -1,0 +1,76 @@
+# Autonomous Mode — Spec C: Cloud Codex Offload (own phase — NOT MVP)
+
+Status: **Own phase, write LAST, gated behind A** — agent-reviewed 2026-06-17. **Do not call this MVP.**
+Created: 2026-06-17
+Series: [A policy-gate](./2026-06-17-autonomous-mode-A-policy-gate.md) → [B process-persistence](./2026-06-17-autonomous-mode-B-process-persistence.md) → C (this)
+
+> Offload long / persistence-risky tasks to **cloud Codex** (OpenAI-hosted isolated container) so they survive device sleep; keep short / interactive tasks local-native. This is the direct answer to B's phantom-killer ceiling. **It is 100% net-new (no cloud-Codex path exists today) and carries the single most important safety interlock: auto-routing must never become auto-exfiltration.**
+
+---
+
+## 1. Ground-truth inventory (verified 2026-06-17)
+
+- **No cloud-Codex path exists anywhere.** `case 'cli'` runs `codex exec` purely **local on-device** ([agent-executor.ts:867](../../../lib/agent-executor.ts)). Repo search for `codex cloud`/`cloud exec`/offload = zero execution code; existing specs list cloud execution as a **non-goal**. Net-new end-to-end.
+- **Quota data exists but only Kotlin-side.** Parsed from codex session JSONL `rate_limits` (`JsonlSessionParser.parseCodexRateLimits`), rendered in the Scouter widget (5-cell remaining-quota bar + reset Chronometer). `agent-tool-router.ts` (TS) has **no access** — quota-as-routing-input is **net-new** (needs a JS bridge of those fields).
+- **Auth** = `~/.codex` device-code OAuth (ChatGPT subscription). Use it; **never an API key in the agent path.**
+
+## 2. Why C is load-bearing (not optional)
+
+From [B](./2026-06-17-autonomous-mode-B-process-persistence.md): the phantom killer makes **long local autonomous tasks unsurvivable**, and "flat tree" is structurally impossible. **Cloud offload is the only real escape from the 32-process ceiling for long tasks.** So C is required for "autonomous mode handles long tasks" to exist at all — but it is sequenced as its own phase because of the safety machinery below.
+
+## 3. Routing (extend the router with risk + quota axes) `[NET-NEW]`
+
+Add axes (none exist today — current router is keyword→backend only):
+- estimated duration (**long → cloud**), git self-containment (**self-contained → cloud**), interactivity (**interactive → local**), network-need (**heavy → cloud**).
+- **Show the REASON per decision in Scouter/notifications.** No black-box routing.
+
+### Quota-aware routing + the dead-cell fix `[MUST-FIX #4]`
+Local burns phone CPU but **no subscription quota**; cloud burns **ChatGPT-subscription quota**. So quota/rate-limit state is a routing input (reuse the Scouter rate-limit gauge data): quota ample → heavy tasks cloud; quota tight → stay local, don't burn it.
+
+**But** quota-tight + long-task is a **dead cell** — can't cloud (quota), can't survive locally (phantom killer, per B). A third outcome is **mandatory**:
+
+| | quota ample | quota tight |
+|---|---|---|
+| short | local | local |
+| long | **cloud** | **defer / queue** ← not "stay local" |
+
+- **`defer/queue` (the required third option):** hold the task, notify *"quota tight — queued until quota resets, or approve burning it,"* let the user force-cloud. Never silently route long+quota-tight into a guaranteed local phantom-kill.
+- **Split** (decompose into checkpointable sub-tasks) is **phase-2** — requires task-checkpointing infra we don't have. Do not promise it.
+
+## 4. THE critical safety interlock — offload = boundary op `[MUST-FIX #3]`
+
+Offloading = code leaves the device (repo checked out into an OpenAI container with full network access). **Auto-routing must not become auto-exfiltration.**
+
+**Approval granularity = payload fingerprint, NOT per-session-once.** Per-session-once approves a *channel*; the *payload* is what leaks, and it mutates between offloads (a new `.env`, a freshly-staged secret, a different repo).
+- Gate on a **hash of the offload payload manifest** = {file set + content hashes + target repo identity}.
+- Approve once per **unchanged fingerprint**; **re-prompt whenever the fingerprint changes** (file added/modified since last approved offload, or repo identity change).
+- **Secret-scan the payload** with [redact-secrets.ts](../../../lib/redact-secrets.ts) before every offload: a **new** secret hit → **hard-block even at L3** (silent ≠ ship credentials to OpenAI).
+- L1/L2: **every** offload prompts. L3: silent allowed **only** for an unchanged, secret-clean fingerprint — L3 relaxes *prompt frequency only*, never the secret/diff safety (the [A §2 invariant](./2026-06-17-autonomous-mode-A-policy-gate.md)).
+- Approval notice is explicit: *"This task will be sent to cloud Codex = your repository goes to OpenAI."*
+
+## 5. Command surface & diff recovery `[NET-NEW]`
+
+- Use **`codex cloud exec`** (GitHub-repo-scoped container). **No SSH** — never add/maintain/re-enable SSH-based remote execution in autonomous mode.
+- Recover the **result diff** to the workspace; **review the diff before applying locally.**
+- **Diff-apply review is NON-bypassable for any offload that touched the network**, regardless of level `[MUST-FIX #8]` — L3 relaxes prompt frequency, never the diff review where the risk (full cloud round-trip of the repo) is highest.
+
+## 6. Auth & token expiry `[NET-NEW behavior]`
+
+- Auth = existing `~/.codex` device-code OAuth. **No API key in the agent path, ever** (hard constraint; also see [A §4](./2026-06-17-autonomous-mode-A-policy-gate.md)).
+- **In-flight OAuth token expiry:** a multi-hour cloud run whose token expires mid-flight needs a defined outcome — **re-auth-and-resume** if possible, else **fail-and-recover-partial-diff** (surface what completed, never silently drop). Spec the exact behavior before build.
+
+## 7. Acceptance / tests
+
+- [ ] Offload interlock: first offload prompts; an unchanged fingerprint doesn't re-prompt (L3); a changed fingerprint **re-prompts** even mid-session.
+- [ ] Payload secret-scan: a new secret in the payload **hard-blocks at L3**.
+- [ ] Quota-tight + long task → **defer/queue** with notification + force-cloud option (never silent local).
+- [ ] Routing reason is shown in Scouter/notification for every decision.
+- [ ] Diff-apply review cannot be bypassed for a network-touched offload at any level.
+- [ ] OAuth token expiry mid-offload → defined re-auth/recover path, no silent drop.
+- [ ] No API key is ever present in the offload execution env; no SSH path exists.
+
+## 8. Out of scope (documented, with reasons)
+
+- On-device container/VM/gVisor — infeasible on Android.
+- SSH / arbitrary remote — policy-excluded; cloud `codex exec` is the **only** external execution path.
+- Task-splitting/checkpointing — phase-2.

--- a/lib/agent-credential-policy.ts
+++ b/lib/agent-credential-policy.ts
@@ -1,0 +1,85 @@
+/**
+ * lib/agent-credential-policy.ts — SINGLE SOURCE OF TRUTH for "how does this
+ * tool authenticate, and may it run in autonomous mode?".
+ *
+ * Both of the parallel work-streams MUST import from here so their judgements
+ * cannot diverge:
+ *   - Tier-1 (conditional `.env` sourcing in agent-executor) → `requiresApiKeyEnv()`
+ *   - Spec A tool-set allowlist (autonomous mode) → `isAutonomousAllowed()` / `resolveForAutonomous()`
+ *
+ * Grounded facts (verified 2026-06-17):
+ *   - `cli` (codex) authenticates via ChatGPT-subscription device-code OAuth
+ *     (~/.codex/auth.json, OPENAI_API_KEY:null) — NO API key in env.
+ *   - `local` hits a loopback llama-server — NO API key.
+ *   - `ab-article-eval` = local Qwen + codex (OAuth) — NO API key.
+ *   - `perplexity` / `gemini-api` inject PERPLEXITY_API_KEY / GEMINI_API_KEY into
+ *     the run env (agent-executor.ts:907,1099) — these are the API-key backends.
+ *   - `auto` resolves at runtime and PREFERS the GEMINI_API_KEY branch before
+ *     OAuth-codex (agent-executor.ts:928), so as-written it may bear an API key.
+ *
+ * Policy (autonomous mode = agent runs multi-step WITHOUT per-step approval):
+ * autonomous execution is OAuth/local only. API-key backends are excluded from
+ * the autonomous path (their key would sit in an LLM-readable env — the exact
+ * OpenClaw leak surface). They remain available in manual/foreground runs where
+ * a human is present. See specs/2026-06-17-autonomous-mode-A-policy-gate.md §4, §7a.
+ */
+import { ToolChoice } from '@/store/types';
+
+export type CredentialClass = 'oauth' | 'local' | 'api-key';
+
+/**
+ * How a CONCRETE tool authenticates. `auto` is classified conservatively as
+ * `api-key` because it may resolve to gemini-api; callers that care about the
+ * autonomous path should `resolveForAutonomous()` first so `auto` never reaches
+ * here unresolved.
+ */
+export function credentialClass(tool: ToolChoice): CredentialClass {
+  switch (tool.type) {
+    case 'cli':
+      return 'oauth';
+    case 'ab-article-eval':
+      return 'oauth'; // local Qwen + codex OAuth; no API key
+    case 'local':
+      return 'local';
+    case 'perplexity':
+    case 'gemini-api':
+      return 'api-key';
+    case 'auto':
+      return 'api-key'; // conservative: may resolve to gemini-api (key-bearing)
+  }
+}
+
+/**
+ * TIER-1 predicate. Should the run script `source ~/.shelly/agents/.env`
+ * (which holds PERPLEXITY_API_KEY / GEMINI_API_KEY) for this tool?
+ *
+ * Only the API-key backends need it. A codex/local agent sourcing it pulls keys
+ * into an env it never uses — the leak surface Tier-1 closes. In autonomous mode
+ * the tool is `resolveForAutonomous()`-ed first, so this returns false there.
+ */
+export function requiresApiKeyEnv(tool: ToolChoice): boolean {
+  return credentialClass(tool) === 'api-key';
+}
+
+/**
+ * SPEC-A predicate. May this tool run in autonomous mode (no human in the loop)?
+ * OAuth/local only. `auto` is allowed but MUST be `resolveForAutonomous()`-ed to
+ * a concrete OAuth/local tool before execution.
+ */
+export function isAutonomousAllowed(tool: ToolChoice): boolean {
+  if (tool.type === 'auto') return true; // allowed via resolution below
+  return credentialClass(tool) !== 'api-key';
+}
+
+/**
+ * SPEC-A resolver. Map a tool to the concrete tool that should run in autonomous
+ * mode. `auto` collapses to OAuth-codex (drops the GEMINI_API_KEY-first branch).
+ * API-key backends have no autonomous form WITHOUT a credential broker
+ * (Spec A §7a Tier-2) and return null — caller must reject or route to the broker.
+ */
+export function resolveForAutonomous(tool: ToolChoice): ToolChoice | null {
+  if (tool.type === 'auto') {
+    return { type: 'cli', cli: 'codex' };
+  }
+  return isAutonomousAllowed(tool) ? tool : null;
+}

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -4,12 +4,13 @@
  */
 import { Agent, ToolChoice } from '@/store/types';
 import { toolChoiceToLabel } from './agent-tool-router';
+import { requiresApiKeyEnv } from './agent-credential-policy';
 import { getHomePath } from '@/lib/home-path';
 
 const MAX_CONCURRENT = 2;
 
 const DEFAULT_TIMEOUT_SEC = 600; // 10 minutes
-const AGENT_SCRIPT_VERSION = 3;
+const AGENT_SCRIPT_VERSION = 4;
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
@@ -44,6 +45,9 @@ export function generateRunScript(agent: Agent): string {
   const lockFile = `${locksDir}/${agentId}.pid`;
   const logDir = `${logsDir}/${agentId}`;
   const toolLabel = toolChoiceToLabel(agent.tool);
+  const apiKeyEnvScrub = requiresApiKeyEnv(agent.tool)
+    ? ''
+    : 'unset PERPLEXITY_API_KEY GEMINI_API_KEY\n';
 
   const slug = agent.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
   const outputDir = agent.outputPath.replace(/^~/, home).replace(/^\$HOME/, home);
@@ -705,6 +709,7 @@ trap finish EXIT
 
 # Source environment
 [ -f "$ENV_FILE" ] && source "$ENV_FILE"
+${apiKeyEnvScrub}
 
 PROJECT_DIR="\${SHELLY_CONTENT_PROJECT:-$HOME/projects/shelly-content-studio}"
 SOURCE_REGISTRY_FILE="\${SOURCE_REGISTRY_FILE:-$PROJECT_DIR/sources/source-registry.tsv}"


### PR DESCRIPTION
## What

Closes the OpenClaw-style credential leak surface for the autonomous/codex agent path.

- **lib/agent-credential-policy.ts** — single source of truth for tool→credential classification (`requiresApiKeyEnv`, `isAutonomousAllowed`, `resolveForAutonomous`).
- **lib/agent-executor.ts** — `generateRunScript` now conditionally emits `unset PERPLEXITY_API_KEY GEMINI_API_KEY` for OAuth/local tools (`cli`/`local`/`ab-article-eval`), so codex/local agents run key-free. Non-secret config (`LOCAL_LLM_*`, `OBSIDIAN_*`) is preserved. `AGENT_SCRIPT_VERSION` bumped 3→4.
- **specs** — Hermes-secretary north-star/MVP + autonomous-mode A/B/C design docs.
- **regression test** — locks the scrub behavior (scrub for OAuth/local, keep for key-bearing backends, never unset config).

## Review (CC pre-merge gate)

- Reviewed against HEAD diff (not prose): import + conditional unset confined to `agent-executor.ts`, placed right after `source $ENV_FILE`, before tool dispatch.
- Regression test verified green locally (3/3) on real branch code; full suite 116 tests + `pnpm check` + lint passed.

## Known residuals (covered elsewhere, not Tier-1 defects)

- The `~/.shelly/agents/.env` **file** still holds the keys and is readable (cwd=$HOME) — covered by Spec A's secret-read boundary (`.shelly/agents/.env` is in the boundary policy's secret-path list) + the future Tier-2 broker.
- `auto` keeps keys (correct: may resolve to gemini in manual mode); autonomous mode resolves `auto→cli` via `resolveForAutonomous` before script generation (Spec A responsibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)