### PR TITLE
Spec A: autonomous policy-gate TS core (boundary classifier + policy engine)

### DIFF
--- a/__tests__/agent-boundary-policy.test.ts
+++ b/__tests__/agent-boundary-policy.test.ts
@@ -1,0 +1,78 @@
+import {
+  normalizePath,
+  isWithinRoot,
+  extractPaths,
+  classifyProposedCommand,
+  GateContext,
+} from '@/lib/agent-boundary-policy';
+
+const ROOT = '/data/user/0/dev.shelly.terminal/files/home/projects/app';
+const ctx = (level: GateContext['level']): GateContext => ({
+  workspaceRoot: ROOT,
+  level,
+  policyPath: '.shelly/agents/policy.json',
+});
+
+describe('normalizePath / isWithinRoot', () => {
+  it('collapses . and ..', () => {
+    expect(normalizePath('/a/b/../c/./d')).toBe('/a/c/d');
+    expect(normalizePath('a/./b/../c')).toBe('a/c');
+  });
+  it('keeps in-root paths inside', () => {
+    expect(isWithinRoot(ROOT, `${ROOT}/src/index.ts`)).toBe(true);
+    expect(isWithinRoot(ROOT, 'src/index.ts')).toBe(true); // relative → joined to root
+  });
+  it('detects `..` escape out of root', () => {
+    expect(isWithinRoot(ROOT, `${ROOT}/../../../sdcard/secret`)).toBe(false);
+    expect(isWithinRoot(ROOT, '/sdcard/Download/x')).toBe(false);
+  });
+});
+
+describe('extractPaths', () => {
+  it('picks path-like tokens, drops flags', () => {
+    expect(extractPaths('grep -n foo ./src/a.ts /etc/hosts')).toEqual(['./src/a.ts', '/etc/hosts']);
+  });
+});
+
+describe('classifyProposedCommand', () => {
+  it('hard-denies CRITICAL at every level', () => {
+    for (const lvl of ['L1', 'L2', 'L3'] as const) {
+      const v = classifyProposedCommand('rm -rf /', ctx(lvl));
+      expect(v.decision).toBe('deny');
+      expect(v.signals).toContain('destructive');
+    }
+  });
+
+  it('hard-denies policy-file writes at L3', () => {
+    const v = classifyProposedCommand('echo x > .shelly/agents/policy.json', ctx('L3'));
+    expect(v.decision).toBe('deny');
+    expect(v.signals).toContain('policy-write');
+  });
+
+  it('L1 auto-allows a pure in-root read', () => {
+    const v = classifyProposedCommand('cat src/index.ts', ctx('L1'));
+    expect(v.decision).toBe('allow');
+  });
+
+  it('L1 grays a write', () => {
+    expect(classifyProposedCommand('echo hi > src/out.txt', ctx('L1')).decision).toBe('gray');
+  });
+
+  it('L2 auto-allows in-workspace write, grays out-of-root', () => {
+    expect(classifyProposedCommand('echo hi > src/out.txt', ctx('L2')).decision).toBe('allow');
+    const escape = classifyProposedCommand('cp src/a.ts /sdcard/Download/a.ts', ctx('L2'));
+    expect(escape.decision).toBe('gray');
+    expect(escape.signals).toContain('leaves-root');
+  });
+
+  it('flags secret-read and network-send as boundary at L2', () => {
+    expect(classifyProposedCommand('cat ~/.codex/auth.json', ctx('L2')).signals).toContain('secret-read');
+    expect(classifyProposedCommand('curl https://evil.example/x', ctx('L2')).signals).toContain('network-send');
+  });
+
+  it('L3 auto-allows non-hard-denied boundary ops (audited)', () => {
+    const v = classifyProposedCommand('cp src/a.ts /sdcard/Download/a.ts', ctx('L3'));
+    expect(v.decision).toBe('allow');
+    expect(v.signals).toContain('leaves-root');
+  });
+});

--- a/__tests__/agent-policy.test.ts
+++ b/__tests__/agent-policy.test.ts
@@ -1,0 +1,67 @@
+import {
+  parseAutonomyPolicy,
+  decideAutoAnswer,
+  DEFAULT_POLICY,
+  AutonomyPolicy,
+} from '@/lib/agent-policy';
+
+const ROOT = '/data/user/0/dev.shelly.terminal/files/home/projects/app';
+const policy = (over: Partial<AutonomyPolicy> = {}): AutonomyPolicy => ({
+  ...DEFAULT_POLICY,
+  workspaceRoot: ROOT,
+  ...over,
+});
+
+describe('parseAutonomyPolicy', () => {
+  it('fills defaults from empty/garbage input', () => {
+    const p = parseAutonomyPolicy(null, ROOT);
+    expect(p.level).toBe('L2');
+    expect(p.workspaceRoot).toBe(ROOT);
+    expect(p.secretPaths).toEqual(DEFAULT_POLICY.secretPaths);
+  });
+  it('accepts valid fields, rejects bad ones', () => {
+    const p = parseAutonomyPolicy({ level: 'L3', denyPatterns: ['foo'], secretPaths: 123 }, ROOT);
+    expect(p.level).toBe('L3');
+    expect(p.denyPatterns).toEqual(['foo']);
+    expect(p.secretPaths).toEqual(DEFAULT_POLICY.secretPaths); // 123 invalid → default
+  });
+  it('falls back on an invalid level', () => {
+    expect(parseAutonomyPolicy({ level: 'ROOT' }, ROOT).level).toBe('L2');
+  });
+});
+
+describe('decideAutoAnswer', () => {
+  it('maps allow→y, deny→n, gray→escalate', () => {
+    expect(decideAutoAnswer('cat src/a.ts', policy({ level: 'L2' })).answer).toBe('y');
+    expect(decideAutoAnswer('rm -rf /', policy({ level: 'L2' })).answer).toBe('n');
+    expect(decideAutoAnswer('cp src/a.ts /sdcard/x', policy({ level: 'L2' })).answer).toBe('escalate');
+  });
+
+  it('operator denyPattern hard-denies even an otherwise-allowed command', () => {
+    const o = decideAutoAnswer('git push origin feature', policy({ level: 'L3', denyPatterns: ['git\\s+push'] }));
+    expect(o.answer).toBe('n');
+    expect(o.verdict.decision).toBe('deny');
+  });
+
+  it('operator allowPattern upgrades a gray to allow', () => {
+    const o = decideAutoAnswer('cp src/a.ts /sdcard/x', policy({ level: 'L2', allowPatterns: ['/sdcard/x'] }));
+    expect(o.answer).toBe('y');
+  });
+
+  it('allowPattern NEVER overrides a hard-deny (the invariant)', () => {
+    const o = decideAutoAnswer('rm -rf /', policy({ level: 'L3', allowPatterns: ['rm'] }));
+    expect(o.answer).toBe('n');
+  });
+
+  it('redacts secrets in the audit entry', () => {
+    const o = decideAutoAnswer('export SOME_SECRET=topsecretvalue123', policy({ level: 'L2' }));
+    expect(o.audit.command).not.toContain('topsecretvalue123');
+  });
+
+  it('audit records decision, signals, level', () => {
+    const o = decideAutoAnswer('cp src/a.ts /sdcard/x', policy({ level: 'L2' }));
+    expect(o.audit.decision).toBe('gray');
+    expect(o.audit.signals).toContain('leaves-root');
+    expect(o.audit.level).toBe('L2');
+  });
+});

--- a/docs/superpowers/specs/2026-06-17-autonomous-mode-A-policy-gate.md
+++ b/docs/superpowers/specs/2026-06-17-autonomous-mode-A-policy-gate.md
@@ -64,6 +64,16 @@ Classify **each agent-emitted operation**. **Boundary operations** =
 
 **Policy file is itself boundary-protected `[MUST-FIX #6]`:** the policy file + autonomy level are **read-only to the agent**; any agent-emitted write to the policy path is a **hard-deny** (not gray, not self-approvable). Only the human UI mutates them. A prompt-injected agent must not be able to self-escalate. The §8 scan-hook should flag instruction-file content that names autonomy levels or policy paths.
 
+### Enforcement substrate on Android — the gate runs on codex's approval stream, NOT a syscall sandbox `[grounded 2026-06-17 — corrects the original per-op assumption]`
+
+Hard platform fact (already documented in [HomeInitializer.kt:1030-1035](../../../modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt), bashrc v216): **Codex's native `--sandbox` enforcement does not work on Android** — codex relies on macOS seatbelt / Linux Landlock / Windows sandbox, none of which Android exposes, so codex *rejects* `workspace-write` and the on-device wrapper forces **`--sandbox danger-full-access`**. Consequently `codex exec` (non-interactive, `approval=never`, danger-full-access) is a **black box with ZERO per-op gating**, and with `MANAGE_EXTERNAL_STORAGE` the Android app sandbox spans all of `/sdcard` — too wide to be the workspace boundary. So the original "policy-first gate classifying each agent-emitted operation" is **not enforceable at the syscall level on this platform.**
+
+**The enforceable design — drive INTERACTIVE codex with an approval policy, gate it with the EXISTING approval bridge:**
+- Autonomous execution uses **interactive codex** (codex_tui) with `--ask-for-approval` (untrusted/on-request) + cwd/`--add-dir` roots set to the workspace — **not** `codex exec`. Interactive codex **pauses and emits an approval prompt before each command**, which Shelly's existing bridge already reads (NotificationDispatcher detects `WAITING_PERMISSION`, ScouterWidgetPromptActivity writes `y\r`/`n\r` to the live PTY — verified in the Step-0 audit).
+- The autonomy of "no per-step *human* approval" is delivered by a **policy classifier auto-answering those prompts**: classify the proposed command (command-safety + boundary + credential policy) → allow→inject `y`, hard-deny→inject `n` + audit, gray→route to the human via the existing notification-approval. This is exactly OpenClaw's auto-mode (policy first, gray → human) realized on the bridge that already exists.
+- **The boundary check operates on the command surfaced at each approval prompt** (which IS visible), not on invisible syscalls — that is how the §5 workspace-root module plugs in despite the black-box problem.
+- `codex exec` (danger-full-access, no gating) is therefore **NOT used for autonomous mode**; it stays the manual/foreground path. Trade-off: interactive-codex driving is more work than one-shot exec, but it is the only path that delivers a real per-op gate on Android.
+
 ## 7. Secret isolation & prompt-injection
 
 - No ambient secret access for agent-emitted ops; auth.json/Keystore read = boundary even at L2 (per §6 narrowing).

--- a/lib/agent-boundary-policy.ts
+++ b/lib/agent-boundary-policy.ts
@@ -1,0 +1,146 @@
+/**
+ * lib/agent-boundary-policy.ts — the core of Spec A's policy-first gate.
+ *
+ * Classifies a PROPOSED command (the one codex surfaces at an approval prompt)
+ * into a gate decision: allow / deny / gray. The autonomous loop drives
+ * interactive codex with `--ask-for-approval`; this classifier auto-answers the
+ * existing PTY-approval bridge (allow→`y`, deny→`n`+audit, gray→human), so "no
+ * per-step human approval" holds while hard-denies and boundary crossings are
+ * still enforced. See specs/2026-06-17-autonomous-mode-A-policy-gate.md §5/§6.
+ *
+ * Why command-string classification (not a syscall sandbox): on Android codex's
+ * native --sandbox does not work (HomeInitializer.kt:1030-1035), so `codex exec`
+ * runs danger-full-access with zero gating. The enforceable surface is the
+ * command codex shows at each approval prompt — visible, classifiable here.
+ *
+ * Scope note (MVP): path extraction + `..` resolution is LEXICAL. Full symlink
+ * resolution needs an fs `realpath` (native exec / bridge) and is a follow-up —
+ * a symlink whose target escapes root is NOT yet caught here; flagged below.
+ */
+import { checkCommandSafety, DangerLevel } from '@/lib/command-safety';
+
+export type AutonomyLevel = 'L1' | 'L2' | 'L3';
+export type GateDecision = 'allow' | 'deny' | 'gray';
+
+export type BoundarySignal =
+  | 'destructive'        // command-safety CRITICAL/HIGH
+  | 'leaves-root'        // a referenced path escapes the workspace root
+  | 'network-send'       // outbound network (curl/wget/nc/ssh/scp …)
+  | 'secret-read'        // reads a protected secret path (auth.json, keystore)
+  | 'policy-write'       // writes the policy file / autonomy config (hard-deny)
+  | 'write-or-exec';     // mutating/executing op (vs a pure read) — heuristic
+
+export interface GateVerdict {
+  decision: GateDecision;
+  /** ordered signals that drove the decision (for the audit log) */
+  signals: BoundarySignal[];
+  /** human-readable reason, surfaced in Scouter/approval UI and the audit log */
+  reason: string;
+  /** command-safety level, when relevant */
+  dangerLevel?: DangerLevel;
+}
+
+export interface GateContext {
+  /** canonical workspace root resolved at session start */
+  workspaceRoot: string;
+  level: AutonomyLevel;
+  /** protected secret paths an agent-emitted read must not touch (boundary) */
+  secretPaths?: string[];
+  /** the policy/autonomy config path the agent must never write (hard-deny) */
+  policyPath?: string;
+}
+
+const DEFAULT_SECRET_PATHS = ['.codex/auth.json', '.shelly/agents/.env'];
+
+/** Lexically normalise a path: collapse `.`/`..`, dedupe slashes. NOT symlink-resolved. */
+export function normalizePath(p: string): string {
+  const isAbs = p.startsWith('/');
+  const out: string[] = [];
+  for (const seg of p.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      if (out.length && out[out.length - 1] !== '..') out.pop();
+      else if (!isAbs) out.push('..');
+    } else out.push(seg);
+  }
+  return (isAbs ? '/' : '') + out.join('/');
+}
+
+/** True if `target` is inside (or equal to) `root` after lexical normalisation. */
+export function isWithinRoot(root: string, target: string): boolean {
+  if (target.startsWith('~')) return false; // home-relative = outside the project workspace
+  const r = normalizePath(root).replace(/\/$/, '');
+  const t = normalizePath(target.startsWith('/') ? target : `${r}/${target}`);
+  return t === r || t.startsWith(`${r}/`);
+}
+
+/** Best-effort extraction of path-like argument tokens from a shell command. */
+export function extractPaths(command: string): string[] {
+  return command
+    .split(/\s+/)
+    .map((t) => t.replace(/^[<>|&]+/, '').replace(/[;,]+$/, '')) // strip redirection ops / trailing punct
+    .filter(
+      (t) =>
+        t.length > 0 &&
+        !t.startsWith('-') &&
+        (t.includes('/') || t.startsWith('~') || t === '.' || t.startsWith('./') || t.startsWith('../')),
+    );
+}
+
+const NETWORK_RE = /\b(curl|wget|nc|ncat|netcat|scp|sftp|ssh|rsync|telnet)\b/;
+const READ_ONLY_RE = /^\s*(cat|less|more|head|tail|grep|rg|ls|find|stat|file|wc|diff|git\s+(status|log|diff|show))\b/;
+
+/**
+ * Classify a proposed command into a gate decision under the given context.
+ * The autonomous gate calls this for every approval prompt codex raises.
+ */
+export function classifyProposedCommand(command: string, ctx: GateContext): GateVerdict {
+  const signals: BoundarySignal[] = [];
+  const secretPaths = ctx.secretPaths ?? DEFAULT_SECRET_PATHS;
+  const safety = checkCommandSafety(command);
+
+  // 1. Hard-deny: policy/autonomy self-mutation (no level may override — §6).
+  if (ctx.policyPath && new RegExp(`>\\s*\\S*${escapeRe(ctx.policyPath)}|\\b(tee|cp|mv)\\b[^|]*${escapeRe(ctx.policyPath)}`).test(command)) {
+    return { decision: 'deny', signals: ['policy-write'], reason: 'agent attempted to write the policy/autonomy file', dangerLevel: safety.level };
+  }
+
+  // 2. Hard-deny: CRITICAL destructive — denied at EVERY level (the §2 invariant:
+  //    L3 relaxes prompt frequency, never command-safety hard-denies).
+  if (safety.level === 'CRITICAL') {
+    return { decision: 'deny', signals: ['destructive'], reason: safety.reason, dangerLevel: safety.level };
+  }
+  if (safety.level === 'HIGH') signals.push('destructive');
+
+  // 3. Boundary signals.
+  const paths = extractPaths(command);
+  if (paths.some((p) => secretPaths.some((s) => normalizePath(p).includes(s)))) signals.push('secret-read');
+  if (paths.some((p) => !isWithinRoot(ctx.workspaceRoot, p))) signals.push('leaves-root');
+  if (NETWORK_RE.test(command)) signals.push('network-send');
+  const isPureRead = READ_ONLY_RE.test(command) && !signals.includes('network-send');
+  if (!isPureRead) signals.push('write-or-exec');
+
+  // 4. Decide by autonomy level. `write-or-exec` is a descriptor, not a boundary:
+  //    an in-root mutating op is exactly what L2 permits. Boundary signals are
+  //    the ones that force a human gate (leaves-root / secret-read / network /
+  //    HIGH-destructive).
+  const boundarySignals = signals.filter((s) => s !== 'write-or-exec');
+  const reason = signals.length ? `boundary: ${signals.join(', ')}` : 'within policy';
+  switch (ctx.level) {
+    case 'L1': // read-only: reads auto, anything mutating/leaving/secret → human
+      if (isPureRead && boundarySignals.length === 0) {
+        return { decision: 'allow', signals, reason: 'L1 read', dangerLevel: safety.level };
+      }
+      return { decision: 'gray', signals, reason, dangerLevel: safety.level };
+    case 'L2': // workspace: in-root r/w/exec auto; boundary → human
+      if (boundarySignals.length === 0) {
+        return { decision: 'allow', signals, reason: 'L2 in-workspace', dangerLevel: safety.level };
+      }
+      return { decision: 'gray', signals, reason, dangerLevel: safety.level };
+    case 'L3': // full opt-in: auto-allow everything not hard-denied (audited upstream)
+      return { decision: 'allow', signals, reason: signals.length ? `L3 (audited): ${reason}` : 'L3', dangerLevel: safety.level };
+  }
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/lib/agent-policy.ts
+++ b/lib/agent-policy.ts
@@ -1,0 +1,120 @@
+/**
+ * lib/agent-policy.ts — declarative autonomy policy (DATA, not code) + the gate
+ * engine that turns a proposed command into an auto-answer for the approval
+ * bridge. Spec A §3/§6.
+ *
+ * The human sets the level + rule toggles out-of-band (ConfigTUI); the running
+ * agent must NEVER mutate the policy — that is enforced as a boundary hard-deny
+ * (classifyProposedCommand → 'policy-write'), not here. This module only reads it.
+ *
+ * decideAutoAnswer() maps the boundary classifier's verdict to how Shelly should
+ * answer codex's `--ask-for-approval` prompt: allow→'y', deny→'n', gray→'escalate'
+ * (route to the human via the existing notification approval). This delivers "no
+ * per-step HUMAN approval" while keeping hard-denies and boundary gates intact.
+ */
+import { redactSecrets } from '@/lib/redact-secrets';
+import {
+  AutonomyLevel,
+  GateContext,
+  GateVerdict,
+  classifyProposedCommand,
+} from '@/lib/agent-boundary-policy';
+
+/** The declarative policy the gate consumes. Persisted/edited only via the human UI. */
+export interface AutonomyPolicy {
+  level: AutonomyLevel;
+  /** canonical workspace root resolved at session start */
+  workspaceRoot: string;
+  /** secret paths an agent-emitted read must not touch (boundary) */
+  secretPaths: string[];
+  /** the policy/autonomy file the agent must never write (hard-deny) */
+  policyPath: string;
+  /** extra command patterns (regex source) that always hard-deny */
+  denyPatterns: string[];
+  /** patterns the operator pre-approved: upgrade gray→allow (never overrides a deny) */
+  allowPatterns: string[];
+}
+
+export const DEFAULT_POLICY: Omit<AutonomyPolicy, 'workspaceRoot'> = {
+  level: 'L2',
+  secretPaths: ['.codex/auth.json', '.shelly/agents/.env'],
+  policyPath: '.shelly/agents/policy.json',
+  denyPatterns: [],
+  allowPatterns: [],
+};
+
+const LEVELS: readonly AutonomyLevel[] = ['L1', 'L2', 'L3'];
+
+/** Validate + normalise raw policy data (e.g. parsed JSON). Unknown/invalid fields fall back to defaults. */
+export function parseAutonomyPolicy(raw: unknown, workspaceRoot: string): AutonomyPolicy {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const strArr = (v: unknown, d: string[]): string[] =>
+    Array.isArray(v) && v.every((x) => typeof x === 'string') ? (v as string[]) : d;
+  return {
+    level: LEVELS.includes(r.level as AutonomyLevel) ? (r.level as AutonomyLevel) : DEFAULT_POLICY.level,
+    workspaceRoot,
+    secretPaths: strArr(r.secretPaths, DEFAULT_POLICY.secretPaths),
+    policyPath: typeof r.policyPath === 'string' ? r.policyPath : DEFAULT_POLICY.policyPath,
+    denyPatterns: strArr(r.denyPatterns, DEFAULT_POLICY.denyPatterns),
+    allowPatterns: strArr(r.allowPatterns, DEFAULT_POLICY.allowPatterns),
+  };
+}
+
+export type AutoAnswer = 'y' | 'n' | 'escalate';
+
+export interface AuditEntry {
+  /** redacted command (secrets stripped via redact-secrets) */
+  command: string;
+  decision: GateVerdict['decision'];
+  answer: AutoAnswer;
+  signals: GateVerdict['signals'];
+  reason: string;
+  level: AutonomyLevel;
+}
+
+export interface GateOutcome {
+  answer: AutoAnswer;
+  verdict: GateVerdict;
+  audit: AuditEntry;
+}
+
+/**
+ * Decide how the approval bridge should answer codex's prompt for `command`.
+ * Operator denyPatterns hard-deny (any level); allowPatterns upgrade a gray to
+ * allow but NEVER override a hard-deny — the §2 invariant.
+ */
+export function decideAutoAnswer(command: string, policy: AutonomyPolicy): GateOutcome {
+  const ctx: GateContext = {
+    workspaceRoot: policy.workspaceRoot,
+    level: policy.level,
+    secretPaths: policy.secretPaths,
+    policyPath: policy.policyPath,
+  };
+  let verdict = classifyProposedCommand(command, ctx);
+
+  if (policy.denyPatterns.some((p) => safeRegex(p)?.test(command))) {
+    verdict = { ...verdict, decision: 'deny', reason: `operator deny-pattern · ${verdict.reason}` };
+  } else if (verdict.decision === 'gray' && policy.allowPatterns.some((p) => safeRegex(p)?.test(command))) {
+    verdict = { ...verdict, decision: 'allow', reason: `operator allow-pattern · ${verdict.reason}` };
+  }
+
+  const answer: AutoAnswer =
+    verdict.decision === 'allow' ? 'y' : verdict.decision === 'deny' ? 'n' : 'escalate';
+  const audit: AuditEntry = {
+    command: String(redactSecrets(command)),
+    decision: verdict.decision,
+    answer,
+    signals: verdict.signals,
+    reason: verdict.reason,
+    level: policy.level,
+  };
+  return { answer, verdict, audit };
+}
+
+function safeRegex(src: string): RegExp | null {
+  try {
+    return new RegExp(src);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

The Spec A (autonomous policy gate) **TS core** — pure logic + tests, **NOT yet wired into execution**. Safe, self-contained increment.

- **lib/agent-boundary-policy.ts** — classify a proposed command (the one codex surfaces at an `--ask-for-approval` prompt) into allow/deny/gray, combining command-safety + canonical workspace-root boundary (symlink/`..` lexical) + secret-read / network-send / policy-write signals, gated by autonomy level L1/L2/L3.
- **lib/agent-policy.ts** — declarative `AutonomyPolicy` (DATA, not code) + `parseAutonomyPolicy` loader + `decideAutoAnswer` mapping the verdict to the approval-bridge answer (allow→`y`, deny→`n`, gray→`escalate`). Operator `denyPatterns` hard-deny any level; `allowPatterns` upgrade gray→allow but NEVER override a hard-deny (the §2 invariant). Redacted audit entry per decision.
- **Spec A §6** — grounded finding: codex's native `--sandbox` is unavailable on Android (HomeInitializer v216 → danger-full-access), so the gate runs on codex's **interactive approval stream via the existing PTY-approval bridge**, NOT `codex exec` (which has zero per-op gating).

## Tests

20 unit tests (11 boundary + 9 policy) pass; `tsc --noEmit` clean.

## NOT in this PR (next — needs on-device, → Codex loop + CC review)

- Kotlin approval-bridge integration: drive interactive codex with `--ask-for-approval`, auto-answer via `decideAutoAnswer` (gray → human via existing notification approval).
- `resolveForAutonomous` wiring into run-script generation (`auto`→`cli` before generation).

This PR is pure logic + tests with no execution wiring — low risk to land as the foundation the wiring builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)