### PR TITLE
Spec B: nice the agent llama-server autostart (phantom-killer mitigation)

### DIFF
--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -602,7 +602,7 @@ ensure_local_llm_server() {
   pid_file="\${LLAMA_SERVER_PID:-$HOME/models/llama-server.pid}"
   mkdir -p "$(dirname "$log_file")" "$(dirname "$pid_file")"
 
-  nohup "$server_bin" --model "$model_path" --host 127.0.0.1 --port "$port" --ctx-size "\${LOCAL_LLM_CTX_SIZE:-4096}" --threads "\${LOCAL_LLM_THREADS:-6}" --log-disable \${LLAMA_SERVER_EXTRA_ARGS:-} > "$log_file" 2>&1 &
+  nohup /system/bin/nice -n 5 "$server_bin" --model "$model_path" --host 127.0.0.1 --port "$port" --ctx-size "\${LOCAL_LLM_CTX_SIZE:-4096}" --threads "\${LOCAL_LLM_THREADS:-6}" --log-disable \${LLAMA_SERVER_EXTRA_ARGS:-} > "$log_file" 2>&1 &
   echo $! > "$pid_file"
 
   ready_seconds="\${LOCAL_LLM_START_TIMEOUT_SECONDS:-90}"


### PR DESCRIPTION
## What

Spec B (process persistence) first fix: add the missing `nice -n 5` to the **agent-executor** llama-server autostart, for parity with `lib/llamacpp-setup.ts` (which already uses `nohup /system/bin/nice -n 5`). Un-niced local-LLM agents risk being flagged as CPU-heavy phantoms by Android's Phantom Process Killer (Step-0 inventory finding).

- `lib/agent-executor.ts` `ensure_local_llm_server()`: `nohup "$server_bin" …` → `nohup /system/bin/nice -n 5 "$server_bin" …`. `--threads`/model/log/PID/redirect preserved.

## Review (CC pre-merge gate)

- Diff verified from HEAD (not prose): one line, confined to `agent-executor.ts`, mirrors the proven `llamacpp-setup.ts` pattern. PID handling intact (nohup→nice→server collapse to a single exec'd PID, so `echo $!` still records the server PID).
- Local: `pnpm check` + full suite (15 suites / 119 tests) pass.

## ⚠️ On-device verification PENDING (low-risk)

Codex's device wasn't reachable (adb none, Shizuku off), so the nice value / phantom-killer behavior was **not** verified on hardware. `nice` is a priority hint on an already-proven launch path, so this is low-risk — but confirm `ps -o pid,ni,comm` shows the llama-server at ni=5 on a real local-LLM agent run when a device is next available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)