### PR TITLE
A2/B1: extract the gate-decide node helper to $HOME

### DIFF
--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
@@ -1165,6 +1165,18 @@ patchCodex(libDir);
             android.util.Log.e("HomeInitializer", "shelly-codex-auth.js extract failed: ${e.message}")
         }
 
+        // A2/B1: bundled node helper for autonomous approval-gate decisions.
+        // Invoked via node, so it only needs to be readable, matching the
+        // shelly-codex-auth.js helper above.
+        val gateDecideScript = File(home, ".shelly-gate-decide.js")
+        try {
+            context.assets.open("shelly-gate-decide.js").use { input ->
+                gateDecideScript.outputStream().use { output -> input.copyTo(output) }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("HomeInitializer", "shelly-gate-decide.js extract failed: ${e.message}")
+        }
+
         // v78–v80: extracted a node-based shelly-xdg-open.js helper that
         // a bash shim shell-script invoked. v81 abandoned that approach
         // (kernel binfmt_script `file{read}` is denied on app_data_file


### PR DESCRIPTION
## What

Phase 2 / B1: extract `shelly-gate-decide.js` so Kotlin can invoke the autonomous-gate decision via `node`. Approach-independent foundation (needed for BOTH the PTY-injection and the app-server B2 routes).

- `HomeInitializer.kt` (+12): copy `shelly-gate-decide.js` from assets → `$HOME/.shelly-gate-decide.js`, mirroring the existing `shelly-codex-auth.js` extraction right above it (try/catch + `copyTo`, no chmod — node-invoked, read is enough). Runs every `initialize()` like the other helpers, so updates ship the new bundle.

## Review (CC merge gate)

- Diff verified from HEAD: 12 lines, confined to HomeInitializer, **identical pattern to the proven `shelly-codex-auth.js` copy** (works in production).
- Local: `pnpm check` + full suite (162) pass.

## bionic-node-runs-bundle — de-risked by analysis (the load-bearing unknown)

On-device run-as forensics were blocked (installed Shelly is a **release build, not debuggable**; Codex's proot is a different package, `gptos.intelligence.assistant`). Resolved by analysis instead:
- Shelly bundles **libnode v24.14.1** (arm64-v8a); node provably runs on-device (codex auth / HTTP helpers use it daily).
- The bundle is trivial CJS (stdin/stdout + JSON; `?.`/`??` → needs Node 14+, satisfied by 24).
- Verified under host node v22 and Codex's host node (y/n/escalate + fail-closed).

→ Node 24 + trivial CJS = runs. A literal in-Shelly-terminal confirmation can follow on the next installed build, but it is **not a merge blocker**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)