### PR TITLE
Autonomous: per-agent autonomy level + buildAgentPolicy (B2 input spec)

### DIFF
--- a/__tests__/agent-policy.test.ts
+++ b/__tests__/agent-policy.test.ts
@@ -1,9 +1,11 @@
 import {
   parseAutonomyPolicy,
   decideAutoAnswer,
+  buildAgentPolicy,
   DEFAULT_POLICY,
   AutonomyPolicy,
 } from '@/lib/agent-policy';
+import { Agent } from '@/store/types';
 
 const ROOT = '/data/user/0/dev.shelly.terminal/files/home/projects/app';
 const policy = (over: Partial<AutonomyPolicy> = {}): AutonomyPolicy => ({
@@ -63,5 +65,25 @@ describe('decideAutoAnswer', () => {
     expect(o.audit.decision).toBe('gray');
     expect(o.audit.signals).toContain('leaves-root');
     expect(o.audit.level).toBe('L2');
+  });
+});
+
+describe('buildAgentPolicy', () => {
+  const mkAgent = (over: Partial<Agent> = {}): Agent => ({
+    id: 'a', name: 'A', description: '', prompt: 'p', schedule: null,
+    tool: { type: 'cli', cli: 'codex' }, outputPath: '~/out', outputTemplate: null,
+    enabled: true, lastRun: null, lastResult: null, createdAt: 0, version: 1, ...over,
+  });
+
+  it('uses the agent level + canonical root, defaults elsewhere', () => {
+    const p = buildAgentPolicy(mkAgent({ autonomyLevel: 'L3' }), ROOT);
+    expect(p.level).toBe('L3');
+    expect(p.workspaceRoot).toBe(ROOT);
+    expect(p.secretPaths).toEqual(DEFAULT_POLICY.secretPaths);
+    expect(p.policyPath).toBe(DEFAULT_POLICY.policyPath);
+  });
+
+  it('defaults to L2 when the agent has no level', () => {
+    expect(buildAgentPolicy(mkAgent(), ROOT).level).toBe('L2');
   });
 });

--- a/lib/agent-policy.ts
+++ b/lib/agent-policy.ts
@@ -12,6 +12,7 @@
  * (route to the human via the existing notification approval). This delivers "no
  * per-step HUMAN approval" while keeping hard-denies and boundary gates intact.
  */
+import type { Agent } from '@/store/types';
 import { redactSecrets } from '@/lib/redact-secrets';
 import {
   AutonomyLevel,
@@ -58,6 +59,17 @@ export function parseAutonomyPolicy(raw: unknown, workspaceRoot: string): Autono
     denyPatterns: strArr(r.denyPatterns, DEFAULT_POLICY.denyPatterns),
     allowPatterns: strArr(r.allowPatterns, DEFAULT_POLICY.allowPatterns),
   };
+}
+
+/**
+ * Build the AutonomyPolicy the B2 driver feeds to the gate for an autonomous
+ * agent run. Level comes from the agent's stored config (human-set; default L2);
+ * `canonicalRoot` is the workspace root resolved at run start; the rest are the
+ * global defaults. The driver holds this object — it is NEVER written to codex's
+ * workspace, so the running agent cannot read or tamper with it (the §6 invariant).
+ */
+export function buildAgentPolicy(agent: Agent, canonicalRoot: string): AutonomyPolicy {
+  return parseAutonomyPolicy({ level: agent.autonomyLevel }, canonicalRoot);
 }
 
 export type AutoAnswer = 'y' | 'n' | 'escalate';

--- a/store/types.ts
+++ b/store/types.ts
@@ -465,6 +465,12 @@ export interface Agent {
   /** true = runs in autonomous mode (no per-step human approval): OAuth/local only,
    *  gated by the policy engine. Optional; absent/false = today's manual behaviour. */
   autonomous?: boolean;
+  /** autonomy level for autonomous runs: L1 read-only / L2 workspace / L3 full.
+   *  Set by the human (ConfigTUI); absent = L2 default. The B2 driver builds the
+   *  AutonomyPolicy from this and holds it driver-side — never passed to codex. */
+  autonomyLevel?: 'L1' | 'L2' | 'L3';
+  /** workspace root the autonomous run operates in (canonicalised at run start). */
+  workspaceRoot?: string;
   outputPath: string;
   outputTemplate: string | null;
   enabled: boolean;


### PR DESCRIPTION
## What

The policy-storage input that the B2 driver will consume — small, additive, backward-compatible.

- **store/types.ts** — `Agent.autonomyLevel?` (`L1`/`L2`/`L3`, default L2) + `Agent.workspaceRoot?` (the autonomous run's root, canonicalised at start). Both optional → no change to existing agents.
- **lib/agent-policy.ts** — `buildAgentPolicy(agent, canonicalRoot)`: builds the `AutonomyPolicy` the B2 driver feeds to the gate (level from the agent's stored config, root from the resolved start path, rest from `DEFAULT_POLICY`). `import type { Agent }` so the gate-decide bundle is unaffected.

## Design note (tamper-resistance)

The policy is **held driver-side** (Kotlin/RN, outside the codex process) and **never written to codex's workspace** — so the running agent cannot read or tamper with it. codex only *proposes* commands; the driver decides. `policyPath` hard-deny stays as defense-in-depth.

## Tests
`buildAgentPolicy` cases (agent level + default) added; full suite 19 suites / 164 green; `tsc` clean; gate-decide bundle drift test still green (change tree-shaken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)