### PR TITLE
B2 fix: launch codex app-server via login-shell wrapper (on-device EACCES)

### DIFF
--- a/modules/terminal-emulator/android/src/main/assets/shelly-agent-driver.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-agent-driver.js
@@ -167,6 +167,17 @@ function ensureConfig(args) {
   };
 }
 
+function codexAppServerSpawnSpec(config) {
+  const codexArgs = [config.codexBin, 'app-server', '--listen', 'stdio://'];
+  return {
+    // Android Shelly launches Codex through the login shell so $HOME/bin/codex
+    // can select linker64/codex_exec safely. Keep NDJSON on stdio via exec.
+    command: 'bash',
+    args: ['-lc', 'exec "$@"', 'shelly-agent-driver-codex', ...codexArgs],
+    display: ['bash', '-lc', 'exec "$@"', 'shelly-agent-driver-codex', ...codexArgs],
+  };
+}
+
 function redact(value) {
   if (typeof value !== 'string') return value;
   return value
@@ -566,7 +577,8 @@ async function waitForEscalation(config, request, audit) {
 
 async function runDriver(config) {
   const audit = createAuditWriter(config.auditLog);
-  const child = spawn(config.codexBin, ['app-server', '--listen', 'stdio://'], {
+  const codexSpawn = codexAppServerSpawnSpec(config);
+  const child = spawn(codexSpawn.command, codexSpawn.args, {
     stdio: ['pipe', 'pipe', 'pipe'],
     cwd: config.cwd,
   });
@@ -1009,6 +1021,7 @@ async function runDriver(config) {
     cwd: config.cwd,
     gateScript: config.gateScript,
     codexBin: config.codexBin,
+    codexSpawn: codexSpawn.display,
     nodeBin: config.nodeBin,
     approvalPolicy: config.approvalPolicy,
     runId: config.runId,

--- a/scripts/shelly-agent-driver.js
+++ b/scripts/shelly-agent-driver.js
@@ -167,6 +167,17 @@ function ensureConfig(args) {
   };
 }
 
+function codexAppServerSpawnSpec(config) {
+  const codexArgs = [config.codexBin, 'app-server', '--listen', 'stdio://'];
+  return {
+    // Android Shelly launches Codex through the login shell so $HOME/bin/codex
+    // can select linker64/codex_exec safely. Keep NDJSON on stdio via exec.
+    command: 'bash',
+    args: ['-lc', 'exec "$@"', 'shelly-agent-driver-codex', ...codexArgs],
+    display: ['bash', '-lc', 'exec "$@"', 'shelly-agent-driver-codex', ...codexArgs],
+  };
+}
+
 function redact(value) {
   if (typeof value !== 'string') return value;
   return value
@@ -566,7 +577,8 @@ async function waitForEscalation(config, request, audit) {
 
 async function runDriver(config) {
   const audit = createAuditWriter(config.auditLog);
-  const child = spawn(config.codexBin, ['app-server', '--listen', 'stdio://'], {
+  const codexSpawn = codexAppServerSpawnSpec(config);
+  const child = spawn(codexSpawn.command, codexSpawn.args, {
     stdio: ['pipe', 'pipe', 'pipe'],
     cwd: config.cwd,
   });
@@ -1009,6 +1021,7 @@ async function runDriver(config) {
     cwd: config.cwd,
     gateScript: config.gateScript,
     codexBin: config.codexBin,
+    codexSpawn: codexSpawn.display,
     nodeBin: config.nodeBin,
     approvalPolicy: config.approvalPolicy,
     runId: config.runId,


### PR DESCRIPTION
## What

Fixes the on-device `spawn codex EACCES` caught in the first device verification. The driver spawned `codex` via bare execvp; on Android `$HOME/bin/codex` is a **bash wrapper script** (not directly execvp-able under Knox), while `$HOME/bin/bash` is a native shim. Fix: launch codex through the login shell so the $HOME/bin wrapper + PATH resolve.

```
spawn('bash', ['-lc', 'exec "$@"', 'shelly-agent-driver-codex', codexBin, 'app-server', '--listen', 'stdio://'])
```

- Args passed via argv (`exec "$@"`) — no shell-string quoting. `exec` keeps the app-server NDJSON on stdio direct.
- `--codex-bin` override preserved. `codexSpawn` added to the `driver_start` audit.
- Verified path (HEAD grep): HomeInitializer generates the `$HOME/bin/codex` wrapper (linker64 + LD_PRELOAD + codex_exec); `.profile` sources `.bashrc`, so `bash -lc` rides the PATH/wrapper.

## Review (CC merge gate)

Diff is clean vs current main: 28 insertions / 2 deletions, scripts + asset only, **byte-identical (parity test green)**. Spawn pattern correct (argv passthrough, exec stdio direct). `node --check` + `pnpm check` + host E2E full loop (allow→accept / read-audit / deny→decline / gray→escalate→decline) pass — the audit shows the new `bash -lc` codexSpawn.

**On-device confirmation pending:** host E2E can't test that `bash -lc` (non-interactive login) loads `$HOME/bin` into PATH on the device. That's the one thing the on-device re-verify checks (re-run the driver, pull `/sdcard` log, confirm EACCES is gone and the gate loop completes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)