### PR TITLE
feat(agent): dispatch scheduled action results (Phase 0 B1)

### DIFF
--- a/__tests__/agent-executor-autonomous.test.ts
+++ b/__tests__/agent-executor-autonomous.test.ts
@@ -28,7 +28,7 @@ const UNSET = 'unset PERPLEXITY_API_KEY GEMINI_API_KEY';
 describe('generateRunScript — autonomous tool resolution (Spec A §4/§5)', () => {
   it('resolves autonomous auto → codex (OAuth), key-free env', () => {
     const s = generateRunScript(agent({ type: 'auto' }, true));
-    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=7');
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=8');
     expect(s).toContain('.shelly-agent-driver.js'); // resolved to cli/codex via the approval driver
     expect(s).toContain('--prompt-file "$PROMPT_FILE"');
     expect(s).toContain('if node_usable && [ -f "$HOME/.shelly-agent-driver.js" ]; then');
@@ -139,5 +139,35 @@ describe('generateRunScript — autonomous tool resolution (Spec A §4/§5)', ()
 
     const nonAutonomousCli = generateRunScript(agent({ type: 'cli', cli: 'codex' }, false));
     expect(nonAutonomousCli).toContain('AUDIT_MIRROR_SDCARD_ELIGIBLE=0');
+  });
+
+  it('dispatches saved results by action without auto-running cli actions', () => {
+    const notifyAgent: Agent = { ...agent({ type: 'local' }, true), action: { type: 'notify' } };
+    const webhookAgent: Agent = {
+      ...agent({ type: 'local' }, true),
+      action: { type: 'webhook', webhookUrl: 'https://example.com/hook' },
+    };
+    const cliAgent: Agent = {
+      ...agent({ type: 'local' }, true),
+      action: { type: 'cli', command: 'rm -rf ~/tmp/example' },
+    };
+
+    const notify = generateRunScript(notifyAgent);
+    expect(notify).toContain("ACTION_TYPE='notify'");
+    expect(notify).toContain('native-result-notification.json');
+    expect(notify).toContain('write_native_notification_request "success" "$preview"');
+
+    const webhook = generateRunScript(webhookAgent);
+    expect(webhook).toContain("ACTION_TYPE='webhook'");
+    expect(webhook).toContain("ACTION_WEBHOOK_URL='https://example.com/hook'");
+    expect(webhook).toContain('Webhook action requires an https URL.');
+    expect(webhook).toContain('http_post_json "$ACTION_WEBHOOK_URL" "$webhook_payload"');
+    expect(webhook).toContain('write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true');
+
+    const cli = generateRunScript(cliAgent);
+    expect(cli).toContain("ACTION_TYPE='cli'");
+    expect(cli).toContain("ACTION_COMMAND='rm -rf ~/tmp/example'");
+    expect(cli).toContain('CLI action requires in-app confirmation and was not auto-executed');
+    expect(cli).not.toContain('eval "$ACTION_COMMAND"');
   });
 });

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -10,7 +10,7 @@ import { getHomePath } from '@/lib/home-path';
 const MAX_CONCURRENT = 2;
 
 const DEFAULT_TIMEOUT_SEC = 600; // 10 minutes
-const AGENT_SCRIPT_VERSION = 7;
+const AGENT_SCRIPT_VERSION = 8;
 const LOCAL_MODEL_LIGHT = 'Qwen3.5-0.8B-Q4_K_M';
 const LOCAL_MODEL_BALANCED = 'Qwen3.5-2B-Q4_K_M';
 const LOCAL_MODEL_QUALITY = 'Qwen3.5-4B-Q4_K_M';
@@ -91,6 +91,9 @@ export function generateRunScript(agent: Agent): string {
 
   const slug = agent.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
   const outputDir = agent.outputPath.replace(/^~/, home).replace(/^\$HOME/, home);
+  const actionType = agent.action?.type ?? 'draft';
+  const actionWebhookUrl = actionType === 'webhook' ? agent.action?.webhookUrl ?? '' : '';
+  const actionCommand = actionType === 'cli' ? agent.action?.command ?? '' : '';
 
   const escapedPrompt = agent.prompt.replace(/'/g, "'\\''");
 
@@ -118,6 +121,12 @@ LOCKS_DIR=${shellQuote(locksDir)}
 TMP_DIR=${shellQuote(tmpDir)}
 MAX_CONCURRENT=${MAX_CONCURRENT}
 AUDIT_MIRROR_SDCARD_ELIGIBLE=${auditMirrorSdcardEligible ? '1' : '0'}
+ACTION_TYPE=${shellQuote(actionType)}
+ACTION_WEBHOOK_URL=${shellQuote(actionWebhookUrl)}
+ACTION_COMMAND=${shellQuote(actionCommand)}
+ACTION_NOTIFY_FILE="$LOG_DIR/native-result-notification.json"
+ACTION_DISPATCH_STATUS=""
+ACTION_DISPATCH_MESSAGE=""
 REGISTRY_LOCK=""
 REGISTRY_LOCK_ACQUIRED=0
 BACKEND_ERROR_FILE="$RESULT_FILE.backend-error"
@@ -262,6 +271,171 @@ json_string_file() {
     printf '%s\\\\n' "$line"
   done < "$file"
   printf '"'
+}
+
+write_native_notification_request() {
+  status="$1"
+  preview="$2"
+  status_json=$(json_escape_text "$status")
+  preview_json=$(json_escape_text "$preview")
+  agent_json=$(json_escape_text "$AGENT_ID")
+  tmp="$ACTION_NOTIFY_FILE.tmp"
+  cat > "$tmp" << NOTIFYEOF
+{"agentId":"$agent_json","status":"$status_json","preview":"$preview_json","timestamp":$(date +%s)}
+NOTIFYEOF
+  mv "$tmp" "$ACTION_NOTIFY_FILE"
+}
+
+write_webhook_payload() {
+  out_file="$1"
+  status="$2"
+  preview="$3"
+  result_file="$4"
+  agent_json=$(json_escape_text "$AGENT_ID")
+  status_json=$(json_escape_text "$status")
+  preview_json=$(json_escape_text "$preview")
+  tool_json=$(json_escape_text "$TOOL_LABEL")
+  result_json=$(json_string_file "$result_file")
+  cat > "$out_file" << PAYLOADEOF
+{"agentId":"$agent_json","status":"$status_json","preview":"$preview_json","toolUsed":"$tool_json","timestamp":$(date +%s),"result":$result_json}
+PAYLOADEOF
+}
+
+webhook_destination_host() {
+  url="$1"
+  if node_usable; then
+    if SHELLY_WEBHOOK_URL="$url" shelly_node -e 'try { const u = new URL(process.env.SHELLY_WEBHOOK_URL || ""); if (u.protocol !== "https:" || !u.hostname) process.exit(1); process.stdout.write(u.host || u.hostname); } catch (_) { process.exit(1); }' 2>/dev/null; then
+      return 0
+    fi
+  fi
+  case "$url" in
+    https://*) ;;
+    *) return 1 ;;
+  esac
+  host=$(printf '%s' "$url" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#/.*$##')
+  [ -n "$host" ] || return 1
+  printf '%s' "$host"
+}
+
+register_source_urls() {
+  result_file="$1"
+  REGISTRY_LOCK="$SOURCE_REGISTRY_FILE.lock"
+  REGISTRY_LOCK_ACQUIRED=0
+  lock_attempt=0
+  until mkdir "$REGISTRY_LOCK" 2>/dev/null; do
+    lock_attempt=$((lock_attempt + 1))
+    if [ "$lock_attempt" -ge 30 ]; then
+      break
+    fi
+    sleep 1
+  done
+  if [ "$lock_attempt" -lt 30 ]; then
+    REGISTRY_LOCK_ACQUIRED=1
+  fi
+  { grep -Eo 'https?://[^][ )<>"'"'"']+' "$result_file" 2>/dev/null || true; } | sed 's/[.,;)]$//' | sort -u | while read -r url; do
+    [ -n "$url" ] || continue
+    if ! awk -F '\\t' -v url="$url" '$4 == url { found=1 } END { exit found ? 0 : 1 }' "$SOURCE_REGISTRY_FILE"; then
+      printf '%s\\t%s\\t%s\\t%s\\n' "$(date -Iseconds)" "$AGENT_ID" "$TOOL_LABEL" "$url" >> "$SOURCE_REGISTRY_FILE"
+    fi
+  done
+  if [ "$REGISTRY_LOCK_ACQUIRED" = "1" ] && [ -d "$REGISTRY_LOCK" ]; then
+    rmdir "$REGISTRY_LOCK" 2>/dev/null || true
+    REGISTRY_LOCK_ACQUIRED=0
+    REGISTRY_LOCK=""
+  fi
+}
+
+save_draft_result() {
+  result_file="$1"
+  mkdir -p "$OUTPUT_DIR"
+  DATE=$(date +%Y-%m-%d)
+  SAVED_FILE="$OUTPUT_DIR/$DATE-$SLUG.md"
+  cp "$result_file" "$SAVED_FILE"
+
+  if [ -n "\${OBSIDIAN_VAULT_PATH:-}" ] && [ -d "$OBSIDIAN_VAULT_PATH" ]; then
+    OBSIDIAN_TARGET="90_Log/Agent_Output"
+    case "$OUTPUT_DIR" in
+      *drafts/substack*) OBSIDIAN_TARGET="50_Drafts/Substack" ;;
+      *drafts/x*) OBSIDIAN_TARGET="50_Drafts/X" ;;
+      *drafts/articles*) OBSIDIAN_TARGET="50_Drafts/Substack" ;;
+      *sources*) OBSIDIAN_TARGET="20_Literature/Papers" ;;
+      *images/prompts*) OBSIDIAN_TARGET="60_Experiments/Image_Prompts" ;;
+      *evals*) OBSIDIAN_TARGET="90_Log/Agent_Evals" ;;
+    esac
+    mkdir -p "$OBSIDIAN_VAULT_PATH/$OBSIDIAN_TARGET"
+    cp "$SAVED_FILE" "$OBSIDIAN_VAULT_PATH/$OBSIDIAN_TARGET/$DATE-$SLUG.md"
+  fi
+
+  register_source_urls "$result_file"
+}
+
+dispatch_agent_action() {
+  result_file="$1"
+  preview="$2"
+  ACTION_DISPATCH_STATUS=""
+  ACTION_DISPATCH_MESSAGE=""
+
+  case "$ACTION_TYPE" in
+    ""|draft)
+      save_draft_result "$result_file"
+      return 0
+      ;;
+    notify)
+      write_native_notification_request "success" "$preview"
+      return 0
+      ;;
+    webhook)
+      if [ -z "$ACTION_WEBHOOK_URL" ]; then
+        ACTION_DISPATCH_STATUS="error"
+        ACTION_DISPATCH_MESSAGE="Webhook action is missing an https URL."
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
+      case "$ACTION_WEBHOOK_URL" in
+        https://*) ;;
+        *)
+          ACTION_DISPATCH_STATUS="error"
+          ACTION_DISPATCH_MESSAGE="Webhook action requires an https URL."
+          write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+          return 1
+          ;;
+      esac
+      if ! webhook_host="$(webhook_destination_host "$ACTION_WEBHOOK_URL" 2>/dev/null)"; then
+        ACTION_DISPATCH_STATUS="error"
+        ACTION_DISPATCH_MESSAGE="Webhook action URL is invalid."
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
+      webhook_payload="$LOG_DIR/webhook-payload-$(date +%s).json"
+      webhook_response="$LOG_DIR/webhook-response-$(date +%s).txt"
+      webhook_error="$LOG_DIR/webhook-error-$(date +%s).txt"
+      write_webhook_payload "$webhook_payload" "success" "$preview" "$result_file"
+      set +e
+      HTTP_TIMEOUT_SECONDS="\${WEBHOOK_TIMEOUT_SECONDS:-30}" http_post_json "$ACTION_WEBHOOK_URL" "$webhook_payload" "$webhook_response" "$webhook_error"
+      webhook_rc=$?
+      set -e
+      if [ "$webhook_rc" -ne 0 ]; then
+        ACTION_DISPATCH_STATUS="error"
+        ACTION_DISPATCH_MESSAGE="Webhook dispatch failed with exit $webhook_rc: $(head -c 240 "$webhook_error" 2>/dev/null | tr '\\n' ' ')"
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
+      ACTION_DISPATCH_MESSAGE="Webhook delivered to $webhook_host"
+      return 0
+      ;;
+    cli)
+      ACTION_DISPATCH_STATUS="skipped"
+      ACTION_DISPATCH_MESSAGE="CLI action requires in-app confirmation and was not auto-executed: $(printf '%s' "$ACTION_COMMAND" | head -c 240 | tr '\\n' ' ')"
+      write_native_notification_request "skipped" "$ACTION_DISPATCH_MESSAGE" || true
+      return 1
+      ;;
+    *)
+      ACTION_DISPATCH_STATUS="error"
+      ACTION_DISPATCH_MESSAGE="Unknown agent action: $ACTION_TYPE"
+      write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+      return 1
+      ;;
+  esac
 }
 
 http_post_json() {
@@ -1293,49 +1467,10 @@ if [ -f "$RESULT_FILE" ] && [ -s "$RESULT_FILE" ] && [ ! -f "$BACKEND_ERROR_FILE
   STATUS="success"
   ERROR_MESSAGE=""
 
-  # Copy to output directory
-  mkdir -p "$OUTPUT_DIR"
-  DATE=$(date +%Y-%m-%d)
-  SAVED_FILE="$OUTPUT_DIR/$DATE-$SLUG.md"
-  cp "$RESULT_FILE" "$SAVED_FILE"
-
-  if [ -n "\${OBSIDIAN_VAULT_PATH:-}" ] && [ -d "$OBSIDIAN_VAULT_PATH" ]; then
-    OBSIDIAN_TARGET="90_Log/Agent_Output"
-    case "$OUTPUT_DIR" in
-      *drafts/substack*) OBSIDIAN_TARGET="50_Drafts/Substack" ;;
-      *drafts/x*) OBSIDIAN_TARGET="50_Drafts/X" ;;
-      *drafts/articles*) OBSIDIAN_TARGET="50_Drafts/Substack" ;;
-      *sources*) OBSIDIAN_TARGET="20_Literature/Papers" ;;
-      *images/prompts*) OBSIDIAN_TARGET="60_Experiments/Image_Prompts" ;;
-      *evals*) OBSIDIAN_TARGET="90_Log/Agent_Evals" ;;
-    esac
-    mkdir -p "$OBSIDIAN_VAULT_PATH/$OBSIDIAN_TARGET"
-    cp "$SAVED_FILE" "$OBSIDIAN_VAULT_PATH/$OBSIDIAN_TARGET/$DATE-$SLUG.md"
-  fi
-
-  REGISTRY_LOCK="$SOURCE_REGISTRY_FILE.lock"
-  REGISTRY_LOCK_ACQUIRED=0
-  lock_attempt=0
-  until mkdir "$REGISTRY_LOCK" 2>/dev/null; do
-    lock_attempt=$((lock_attempt + 1))
-    if [ "$lock_attempt" -ge 30 ]; then
-      break
-    fi
-    sleep 1
-  done
-  if [ "$lock_attempt" -lt 30 ]; then
-    REGISTRY_LOCK_ACQUIRED=1
-  fi
-  { grep -Eo 'https?://[^][ )<>"'"'"']+' "$RESULT_FILE" 2>/dev/null || true; } | sed 's/[.,;)]$//' | sort -u | while read -r url; do
-    [ -n "$url" ] || continue
-    if ! awk -F '\\t' -v url="$url" '$4 == url { found=1 } END { exit found ? 0 : 1 }' "$SOURCE_REGISTRY_FILE"; then
-      printf '%s\\t%s\\t%s\\t%s\\n' "$(date -Iseconds)" "$AGENT_ID" "$TOOL_LABEL" "$url" >> "$SOURCE_REGISTRY_FILE"
-    fi
-  done
-  if [ "$REGISTRY_LOCK_ACQUIRED" = "1" ] && [ -d "$REGISTRY_LOCK" ]; then
-    rmdir "$REGISTRY_LOCK" 2>/dev/null || true
-    REGISTRY_LOCK_ACQUIRED=0
-    REGISTRY_LOCK=""
+  if ! dispatch_agent_action "$RESULT_FILE" "$PREVIEW"; then
+    STATUS="\${ACTION_DISPATCH_STATUS:-error}"
+    ERROR_MESSAGE="\${ACTION_DISPATCH_MESSAGE:-agent action dispatch failed}"
+    PREVIEW="$ERROR_MESSAGE"
   fi
 else
   if [ -f "$RESULT_FILE" ] && [ -s "$RESULT_FILE" ]; then
@@ -1345,6 +1480,7 @@ else
   fi
   ERROR_MESSAGE="$PREVIEW"
   STATUS="error"
+  write_native_notification_request "error" "$PREVIEW" || true
 fi
 
 # Log run result

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -2,7 +2,9 @@ package expo.modules.terminalemulator
 
 import android.content.Context
 import android.util.Log
+import expo.modules.terminalemulator.scouter.NotificationDispatcher
 import expo.modules.terminalemulator.scouter.AgentEscalationBridge
+import org.json.JSONObject
 import java.io.File
 
 data class AgentRunResult(
@@ -24,7 +26,7 @@ data class AgentRunResult(
 object AgentRuntime {
     private const val TAG = "AgentRuntime"
     private const val DEFAULT_TIMEOUT_MS = 30 * 60 * 1000
-    private const val CURRENT_SCRIPT_VERSION = 6
+    private const val CURRENT_SCRIPT_VERSION = 8
 
     fun runAgent(context: Context, agentId: String): AgentRunResult {
         val appContext = context.applicationContext
@@ -53,6 +55,11 @@ object AgentRuntime {
             val message = "stale script: $scriptPath version=$scriptVersion expected=$CURRENT_SCRIPT_VERSION. Open Shelly or run the agent manually once to regenerate it."
             Log.e(TAG, message)
             writeReceiverLog(homeDir, agentId, "error", message)
+            NotificationDispatcher(appContext).notifyAgentResult(
+                agentId = agentId,
+                status = "error",
+                preview = message
+            )
             return AgentRunResult(agentId, 126, "", message)
         }
 
@@ -89,10 +96,18 @@ object AgentRuntime {
         val exitCode = result.getOrNull(0)?.toIntOrNull() ?: 1
         val stdout = result.getOrNull(1).orEmpty()
         val stderr = result.getOrNull(2).orEmpty()
+        val notificationPosted = postAgentResultNotificationIfRequested(appContext, homeDir, agentId)
         if (exitCode == 0) {
             Log.i(TAG, "Agent $agentId completed via Shelly runtime")
         } else {
             Log.e(TAG, "Agent $agentId failed via Shelly runtime: exit=$exitCode stderr=${stderr.take(300)}")
+            if (!notificationPosted) {
+                NotificationDispatcher(appContext).notifyAgentResult(
+                    agentId = agentId,
+                    status = "error",
+                    preview = "Agent script failed. exit=$exitCode stderr=${stderr.take(300)}"
+                )
+            }
             writeReceiverLog(
                 homeDir,
                 agentId,
@@ -102,6 +117,25 @@ object AgentRuntime {
         }
 
         return AgentRunResult(agentId, exitCode, stdout, stderr)
+    }
+
+    private fun postAgentResultNotificationIfRequested(context: Context, homeDir: File, agentId: String): Boolean {
+        val request = File(homeDir, ".shelly/agents/logs/$agentId/native-result-notification.json")
+        if (!request.isFile) return false
+        try {
+            val json = JSONObject(request.readText())
+            NotificationDispatcher(context).notifyAgentResult(
+                agentId = json.optString("agentId", agentId).ifBlank { agentId },
+                status = json.optString("status", "success"),
+                preview = json.optString("preview", "")
+            )
+            return true
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to post agent result notification for $agentId", e)
+            return false
+        } finally {
+            runCatching { request.delete() }
+        }
     }
 
     private fun readScriptVersion(script: File): Int {

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/NotificationDispatcher.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/NotificationDispatcher.kt
@@ -59,6 +59,7 @@ class NotificationDispatcher(private val context: Context) {
         ID_REPLY -> CH_COMPLETED
         ID_LONG_RUNNING -> CH_RUNNING
         in 9400 until 9900 -> CH_APPROVAL
+        in 9900 until 9950 -> CH_COMPLETED
         else -> CH_RATE
     }
 
@@ -96,6 +97,24 @@ class NotificationDispatcher(private val context: Context) {
 
     fun notifyLongRunning(snapshot: SessionSnapshot) {
         notify(ID_LONG_RUNNING, "Agent still running", "${snapshot.currentTool ?: "Tool"} · ${snapshot.projectName}")
+    }
+
+    fun notifyAgentResult(agentId: String, status: String, preview: String) {
+        val normalizedStatus = status.trim().lowercase(Locale.US).ifBlank { "success" }
+        val title = when (normalizedStatus) {
+            "success" -> "Agent completed"
+            "skipped" -> "Agent skipped"
+            else -> "Agent failed"
+        }
+        val body = preview.ifBlank { "No preview" }
+        val id = ID_AGENT_RESULT_BASE + (agentId.hashCode() and 0x7fffffff) % ID_AGENT_RESULT_SPAN
+        notify(
+            id = id,
+            title = title,
+            text = truncate(body, REPLY_MAX_CHARS),
+            bigText = truncate(body, APPROVAL_MAX_CHARS),
+            subText = shorten(agentId, 40)
+        )
     }
 
     // --- Live-poll entry points (additive) -----------------------------------
@@ -588,6 +607,8 @@ class NotificationDispatcher(private val context: Context) {
         private const val REQ_CHOICE_BASE = 9320
         private const val REQ_AGENT_ESCALATION_BASE = 9400
         private const val REQ_AGENT_ESCALATION_SPAN = 500
+        private const val ID_AGENT_RESULT_BASE = 9900
+        private const val ID_AGENT_RESULT_SPAN = 50
 
         // Dedup pref keys.
         private const val KEY_LAST_APPROVAL = "last_approval_at"


### PR DESCRIPTION
## Phase 0 B1 — scheduled action dispatch

A scheduled agent's run-script now dispatches its result by `action` type instead of always writing a draft (builds on the A1–A3 action layer + confirm card in #79).

- **draft** (default / legacy) — save to outputPath + Obsidian mirror (+ URL extraction). Absent action ⇒ draft.
- **notify** — native/headless notification with the result preview (sidecar → AgentRuntime → NotificationDispatcher; works on AlarmManager headless runs).
- **webhook** — POST to an **https** URL (double-gated: `case https://*` glob + node `URL` protocol check); payload JSON-encoded via `JSON.stringify` (no raw interpolation); failure → notification.
- **cli** — **never auto-executed** (fail-closed): falls to a "requires in-app confirmation" skipped notification. Full in-app confirm UI + signed-reply approval round-trip = B5, separate PR.
- Old script version rejection and backend errors also surface a native notification (no silent failure).
- `AGENT_SCRIPT_VERSION` 7→**8**, synced with `AgentRuntime.CURRENT_SCRIPT_VERSION=8`.

### CC review — no blockers / High
Native Kotlin symbols resolve, webhook payload JSON-safe, all failure paths notify, no B2/driver regression, draft default preserved, sidecar consume-once (no replay). Action vars (`ACTION_TYPE`/`ACTION_WEBHOOK_URL`/`ACTION_COMMAND`) injected via `shellQuote` (no script breakout).

### On-device smoke — ALL action types verified (build 1578, e17faae6)
- **draft**: `success`, draft saved
- **notify**: "Agent completed — # Local Context Fallback…" (result preview notification)
- **webhook**: "Agent failed — Webhook dispatch failed with exit 1: connect ECONNREFUSED 127.0.0.1:1" (dispatch ran, https gate passed, failure→notification)
- **cli**: "Agent skipped — CLI action requires in-app confirmation and was not auto-executed: echo hello" (command NOT executed)
- **backend error**: "Agent failed — Gemini API key is not set"
- §3 degraded path: local LLM unavailable → fallback digest, never silent

### Follow-ups (not in this PR)
- B5: webhook/cli full approval round-trip + in-app CLI confirm UI.
- Observations from smoke (minor): (1) AI-pane local LLM and agent run-script contend on `local-llm-server-start.lock` (concurrent local use → agents fall to fallback); (2) cli emits both a generic "Agent completed: <id>" and the specific "Agent skipped" notification — generic one contradicts the skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)