### PR TITLE
fix(agent+updater): delete actually deletes, updater download works; agent detail popup

### DIFF
--- a/components/layout/BuildsModal.tsx
+++ b/components/layout/BuildsModal.tsx
@@ -198,6 +198,9 @@ function sleep(ms: number): Promise<void> {
 const NETWORK_TIMEOUT_MS = 15_000;
 const APK_DOWNLOAD_TIMEOUT_MS = 1_800_000;
 const APK_DOWNLOAD_PAUSED_TIMEOUT_MS = 60_000;
+// Kill a running/pending download whose bytes never advance (phantom enqueue)
+// instead of spinning to the 30-min hard timeout.
+const APK_DOWNLOAD_STALL_TIMEOUT_MS = 45_000;
 
 // fetch() in React Native has no default timeout: a stalled TLS/connection
 // (or a throttled GitHub response held open) never settles, which hangs the
@@ -520,6 +523,23 @@ async function downloadReleaseApk(
   }
 
   let downloadId = matchingPending?.downloadId;
+  if (downloadId) {
+    // A persisted id can be dead (downloads cleared, reboot, prior failed enqueue).
+    // Probe it; if it isn't a live download, drop it and enqueue fresh instead of
+    // polling a ghost id (which would only throw a "failed" alert a second later).
+    const probe = await TerminalEmulator.getApkDownloadStatus(downloadId).catch(() => null);
+    const live =
+      probe != null &&
+      (probe.status === 'pending' ||
+        probe.status === 'running' ||
+        probe.status === 'paused' ||
+        probe.status === 'successful');
+    if (!live) {
+      await TerminalEmulator.removeApkDownload(downloadId).catch(() => undefined);
+      await clearPendingApkDownload();
+      downloadId = undefined;
+    }
+  }
   if (!downloadId) {
     const started = await TerminalEmulator.enqueueApkDownload(
       update.apkUrl,
@@ -554,6 +574,8 @@ async function downloadReleaseApk(
   let lastBytes = 0;
   let lastAt = startedAt;
   let pausedSince: number | null = null;
+  let maxBytes = 0;
+  let lastProgressAt = startedAt;
   while (true) {
     await sleep(1000);
     const status = await TerminalEmulator.getApkDownloadStatus(downloadId);
@@ -590,6 +612,18 @@ async function downloadReleaseApk(
       }
     } else {
       pausedSince = null;
+    }
+    // Stall watchdog: a 'running'/'pending' download whose bytes never advance
+    // (e.g. a phantom enqueue) would otherwise spin until the 30-min hard timeout
+    // with the UI frozen at 0 B. Surface a retryable error after a bounded window.
+    if (downloadedBytes > maxBytes) {
+      maxBytes = downloadedBytes;
+      lastProgressAt = now;
+    }
+    if (downloadStatus !== 'paused' && now - lastProgressAt > APK_DOWNLOAD_STALL_TIMEOUT_MS) {
+      await TerminalEmulator.removeApkDownload(downloadId).catch(() => undefined);
+      await clearPendingApkDownload();
+      throw new Error('APK download stalled (no progress). Tap update again to retry.');
     }
     if (Date.now() - startedAt > APK_DOWNLOAD_TIMEOUT_MS) {
       await TerminalEmulator.removeApkDownload(downloadId).catch(() => undefined);
@@ -670,7 +704,11 @@ function downloadManagerFailureMessage(status: string, reason?: number): string 
 }
 
 function releaseApkDir(): string {
-  return '/sdcard/Download';
+  // App-specific external files dir — must stay string-identical to the native
+  // enqueueApkDownload destination (getExternalFilesDir(DIRECTORY_DOWNLOADS)), so
+  // the post-download verify/install path comparison matches. The public
+  // /sdcard/Download throws SecurityException in DownloadManager on targetSdk>=29.
+  return '/storage/emulated/0/Android/data/dev.shelly.terminal/files/Download';
 }
 
 function releaseApkPath(update: AndroidUpdateManifest): string {

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -434,8 +434,15 @@ export function Sidebar() {
                             text: t('common.delete'),
                             style: 'destructive',
                             onPress: async () => {
-                              await deleteAgent(agent.id);
-                              useAgentStore.getState().removeAgent(agent.id);
+                              // deleteAgent removes the store entry only on a
+                              // confirmed on-disk delete; surface failures instead
+                              // of dropping the row while the json survives (which
+                              // would reappear on restart).
+                              try {
+                                await deleteAgent(agent.id);
+                              } catch (e) {
+                                Alert.alert(t('sidebar.delete_agent_failed'), String(e));
+                              }
                             },
                           },
                         ],

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -23,14 +23,13 @@ import { useAgentStore } from '@/store/agent-store';
 import type { Agent, ToolChoice } from '@/store/types';
 import { deleteAgent, installAgent, runAgentNow, syncAgentRunLogsFromDisk, setAgentEnabled, haltAllAgents, resumeAllAgents } from '@/lib/agent-manager';
 import { toolChoiceToLabel } from '@/lib/agent-tool-router';
-import { useBrowserStore } from '@/store/browser-store';
 import { SidebarSection } from './SidebarSection';
 import { FileTree } from './FileTree';
 import { ProfilesSection } from './ProfilesSection';
 import { WorktreesSection } from './WorktreesSection';
 import { QuickLaunchSection } from './QuickLaunchSection';
 import { CodexSessionsSection } from './CodexSessionsSection';
-import { colors as C, fonts as F, sizes as S, padding as P, radii as R, icons as I } from '@/theme.config';
+import { colors as C, fonts as F, sizes as S, padding as P, radii as R } from '@/theme.config';
 import { withAlpha } from '@/lib/theme-utils';
 import { usePanelBackground } from '@/hooks/use-panel-background';
 import { useTranslation } from '@/lib/i18n';
@@ -59,7 +58,6 @@ export function Sidebar() {
   const { mode, openSections, toggleSection, activeRepoPath, repoPaths, setActiveRepo, setMode, addRepo, removeRepo } =
     useSidebarStore();
   const agents = useAgentStore((s) => s.agents);
-  const runHistory = useAgentStore((s) => s.runHistory);
   const agentsHalted = useAgentStore((s) => s.halted);
   const [runningAgentIds, setRunningAgentIds] = useState<Set<string>>(new Set());
   const [pendingAgentIds, setPendingAgentIds] = useState<Set<string>>(new Set());

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -200,6 +200,29 @@ export function Sidebar() {
     }
   }, [runCommandForAgentSync, t]);
 
+  // Tap an agent row → full detail popup (the row only has room for the name).
+  const showAgentDetail = React.useCallback((agent: Agent) => {
+    const lastLog = useAgentStore.getState().getRunHistory(agent.id).at(-1);
+    const meta = [
+      agent.schedule || t('sidebar.agent_manual'),
+      agent.action?.type ?? 'draft',
+      toolChoiceToLabel(agent.tool),
+      agent.autonomous ? t('sidebar.agent_autonomous') : null,
+      agent.enabled ? null : t('sidebar.agent_paused'),
+    ].filter(Boolean).join(' · ');
+    const body = [
+      (agent.prompt || agent.description || '').trim(),
+      '',
+      meta,
+      lastLog ? `${t('sidebar.agent_last')}: ${lastLog.status}${lastLog.outputPreview ? ` — ${lastLog.outputPreview.slice(0, 160)}` : ''}` : '',
+    ].filter(Boolean).join('\n');
+    Alert.alert(agent.name, body, [
+      { text: t('sidebar.agent_run_now'), onPress: () => void handleRunScheduledAgent(agent.id, agent.name) },
+      { text: agent.enabled ? t('sidebar.agent_pause') : t('sidebar.agent_resume'), onPress: () => void handleTogglePause(agent) },
+      { text: t('common.close'), style: 'cancel' },
+    ]);
+  }, [t, handleRunScheduledAgent, handleTogglePause]);
+
   const persistAgentUpdate = React.useCallback(async (agent: Agent, partial: Partial<Agent>) => {
     const updated = { ...agent, ...partial };
     useAgentStore.getState().updateAgent(agent.id, partial);
@@ -362,14 +385,19 @@ export function Sidebar() {
                   style={[styles.taskRow, styles.agentRow, (!agent.enabled || agentsHalted) && styles.agentRowDisabled]}
                 >
                   <View style={[styles.taskDot, { backgroundColor: agent.autonomous ? C.accent : C.text3 }]} />
-                  <View style={styles.taskInfo}>
+                  <Pressable
+                    style={styles.taskInfo}
+                    onPress={() => showAgentDetail(agent)}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('sidebar.agent_detail_a11y', { name: agent.name })}
+                  >
                     <Text style={styles.taskName} numberOfLines={1}>
                       {agent.name.toUpperCase()}
                     </Text>
                     <Text style={styles.taskMeta} numberOfLines={1}>
-                      {agent.schedule || 'manual'} · {toolChoiceToLabel(agent.tool)}
+                      {agent.autonomous ? '⛓ ' : ''}{agent.schedule || t('sidebar.agent_manual')} · {agent.action?.type ?? 'draft'}
                     </Text>
-                  </View>
+                  </Pressable>
                   <Pressable
                     onPress={() => void handleRunScheduledAgent(agent.id, agent.name)}
                     hitSlop={8}
@@ -396,15 +424,6 @@ export function Sidebar() {
                     ]}>
                       AUTO
                     </Text>
-                  </Pressable>
-                  <Pressable
-                    onPress={() => void handleTogglePause(agent)}
-                    hitSlop={8}
-                    style={styles.tasksAction}
-                    accessibilityRole="button"
-                    accessibilityLabel={t(agent.enabled ? 'sidebar.pause_agent_a11y' : 'sidebar.resume_agent_a11y', { name: agent.name })}
-                  >
-                    <MaterialIcons name={agent.enabled ? 'pause' : 'play-circle-outline'} size={12} color={C.text2} />
                   </Pressable>
                   <Pressable
                     onPress={() => {

--- a/components/panes/AgentConfirmCard.tsx
+++ b/components/panes/AgentConfirmCard.tsx
@@ -344,7 +344,7 @@ function Segmented({
   onChange,
   colors,
 }: {
-  options: Array<{ key: string; label: string }>;
+  options: { key: string; label: string }[];
   value: string;
   onChange: (key: string) => void;
   colors: any;

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -286,6 +286,28 @@ export async function deleteAgent(agentId: string): Promise<void> {
   useAgentStore.getState().removeAgent(agentId);
 }
 
+/**
+ * Remove orphan agent artifacts — run scripts (`run-agent-<id>.sh`) and log dirs
+ * whose `<id>.json` no longer exists (e.g. left by an interrupted deleteAgent whose
+ * rm threw and was swallowed). Best-effort; called on load so a stray script can't
+ * accumulate or zombie-fire. The schedule is already cancelled at delete time, but
+ * removing the script also neutralises any leftover alarm (missing-script no-op).
+ */
+export async function cleanupOrphanAgentFiles(
+  runCommand: (cmd: string) => Promise<string>
+): Promise<void> {
+  const dir = agentsDir();
+  const cmd =
+    `cd ${shellQuote(dir)} 2>/dev/null || exit 0\n` +
+    `for s in run-agent-*.sh; do [ -e "\$s" ] || continue; id="\${s#run-agent-}"; id="\${id%.sh}"; [ -f "\$id.json" ] || rm -f "\$s"; done\n` +
+    `for d in logs/*/; do [ -e "\$d" ] || continue; id="\$(basename "\$d")"; [ -f "\$id.json" ] || rm -rf "\$d"; done`;
+  try {
+    await runCommand(cmd);
+  } catch {
+    // best-effort cleanup; never block startup
+  }
+}
+
 const haltSentinelPath = () => `${agentsDir()}/.halted`;
 
 /**
@@ -420,6 +442,8 @@ export async function loadAgentsFromDisk(
 
     if (agents.length === 0) {
       useAgentStore.getState().setAgents([]);
+      // Still sweep — "deleted every agent" can leave orphan scripts/logs.
+      if (syncLogs) void cleanupOrphanAgentFiles(runCommand);
       return;
     }
     const runHistory = syncLogs
@@ -440,6 +464,10 @@ export async function loadAgentsFromDisk(
       useAgentStore.getState().setRunHistory(runHistory);
     }
     useAgentStore.getState().setAgents(agentsWithStatus);
+    if (syncLogs) {
+      // Sweep orphan scripts/logs left by past deletes (best-effort, non-blocking).
+      void cleanupOrphanAgentFiles(runCommand);
+    }
     if (repairSchedules) {
       scheduleAgentStartupRepair(agentsWithStatus, runCommand, repairDelayMs, shouldRepair);
     }

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -270,18 +270,31 @@ export async function stopAgent(
  * Delete an agent and clean up.
  */
 export async function deleteAgent(agentId: string): Promise<void> {
+  // ids are generated slugs (`agent-<ts>`) or sanitized names; refuse anything
+  // with shell metacharacters so the $HOME-relative rm below is injection-safe.
+  if (!/^[A-Za-z0-9._-]+$/.test(agentId)) {
+    throw new Error(`refusing to delete agent with unsafe id: ${agentId}`);
+  }
   await uninstallSchedule(agentId);
-  const dir = agentsDir();
-  const command = [
-    `rm -f ${shellQuote(`${dir}/${agentId}.json`)}`,
-    `rm -f ${shellQuote(`${dir}/run-agent-${agentId}.sh`)}`,
-    `rm -f ${shellQuote(`${dir}/locks/${agentId}.pid`)}`,
-    `rm -rf ${shellQuote(`${dir}/logs/${agentId}`)}`,
-  ].join(' && ');
-  try {
-    await TerminalEmulator.execCommand(command, 30_000);
-  } catch {
-    // Deleting store state should not be blocked by filesystem cleanup.
+  // Delete via the live shell $HOME — NOT the JS getHomePath() cache. The cache
+  // can hold an unresolved /data/user/0 alias that doesn't resolve to the real
+  // files dir on some OEM builds, so `rm -f <alias>` silently exits 0 while the
+  // real <id>.json survives and the agent resurrects on next loadAgentsFromDisk
+  // (bug: deleted agents reappear after restart). `$HOME` is the same home the
+  // interactive shell uses, so it always hits the real files. `set -e` + a
+  // post-rm existence check + an exitCode assertion make a failed delete LOUD
+  // instead of swallowed, so the store entry is only dropped on confirmed removal.
+  const command =
+    `set -e\n` +
+    `d="$HOME/.shelly/agents"\n` +
+    `rm -f "$d/${agentId}.json" "$d/run-agent-${agentId}.sh" "$d/locks/${agentId}.pid"\n` +
+    `rm -rf "$d/logs/${agentId}"\n` +
+    `[ ! -e "$d/${agentId}.json" ] || { echo "delete failed: ${agentId}.json still present" >&2; exit 1; }`;
+  const result = await TerminalEmulator.execCommand(command, 30_000);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `deleteAgent(${agentId}) failed (exit ${result.exitCode}): ${(result.stderr || result.stdout || '').trim()}`
+    );
   }
   useAgentStore.getState().removeAgent(agentId);
 }
@@ -493,6 +506,9 @@ function scheduleAgentStartupRepair(
       for (const agent of scheduledAgents) {
         if (shouldRun && !shouldRun()) return;
         if (useAgentStore.getState().halted) return;
+        // Skip agents deleted during the repair-delay window — re-materializing a
+        // captured snapshot would rewrite its <id>.json + alarm and resurrect it.
+        if (!useAgentStore.getState().agents.some((a) => a.id === agent.id)) continue;
         try {
           await materializeAgent(agent, runCommand, true);
           await new Promise((resolve) => setTimeout(resolve, 250));

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -113,6 +113,7 @@ const en: Record<string, string> = {
 
   // ── Common UI ───────────────────────────────────────────────────
   'common.cancel': 'Cancel',
+  'common.close': 'Close',
   'common.add': 'ADD',
   'common.clear': 'Clear',
   'common.cannot_undo': 'This cannot be undone.',
@@ -167,7 +168,7 @@ const en: Record<string, string> = {
   // ── Agent confirm/preview card (Phase 0 §2.1) ────────────────────
   'agentcard.title': 'Register this agent?',
   'agentcard.summary': "I'll run {{action}} {{schedule}} via {{route}}.",
-  'agentcard.name': 'Name',
+  'agentcard.name': 'Project name',
   'agentcard.schedule': 'Schedule',
   'agentcard.schedule_unset': '(not set)',
   'agentcard.schedule_required': 'Pick a schedule — this agent won’t run until you do.',
@@ -1129,6 +1130,14 @@ const en: Record<string, string> = {
   'sidebar.log': 'LOG',
   'sidebar.scheduled': 'SCHEDULED',
   'sidebar.agents': 'AGENTS',
+  'sidebar.agent_manual': 'manual',
+  'sidebar.agent_autonomous': 'autonomous',
+  'sidebar.agent_paused': 'paused',
+  'sidebar.agent_last': 'Last',
+  'sidebar.agent_run_now': 'Run now',
+  'sidebar.agent_pause': 'Pause',
+  'sidebar.agent_resume': 'Resume',
+  'sidebar.agent_detail_a11y': 'Open {{name}} details',
   'sidebar.repositories': 'REPOSITORIES',
   'sidebar.file_tree': 'FILE TREE',
   'sidebar.device': 'DEVICE',

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -1161,6 +1161,7 @@ const en: Record<string, string> = {
   'sidebar.resume_agent_a11y': 'Resume agent {{name}}',
   'sidebar.delete_agent_title': 'Delete agent',
   'sidebar.delete_agent_body': 'Delete "{{name}}"?',
+  'sidebar.delete_agent_failed': 'Delete failed',
   'sidebar.delete_agent_a11y': 'Delete agent {{name}}',
   'sidebar.agent_update_failed_title': 'Could not update agent',
   'sidebar.autonomous_toggle_a11y': 'Toggle autonomous mode for {{name}}',

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -1160,6 +1160,7 @@ const ja: Record<string, string> = {
   'sidebar.resume_agent_a11y': 'エージェント {{name}} を再開',
   'sidebar.delete_agent_title': 'エージェントを削除',
   'sidebar.delete_agent_body': '"{{name}}" を削除しますか？',
+  'sidebar.delete_agent_failed': '削除に失敗しました',
   'sidebar.delete_agent_a11y': 'エージェント {{name}} を削除',
   'sidebar.agent_update_failed_title': 'エージェントを更新できません',
   'sidebar.autonomous_toggle_a11y': '{{name}} の自律モードを切り替え',

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -113,6 +113,7 @@ const ja: Record<string, string> = {
 
   // ── Common UI ───────────────────────────────────────────────────
   'common.cancel': 'キャンセル',
+  'common.close': '閉じる',
   'common.add': '追加',
   'common.clear': 'クリア',
   'common.cannot_undo': 'この操作は元に戻せません。',
@@ -167,7 +168,7 @@ const ja: Record<string, string> = {
   // ── エージェント確認/プレビューカード (Phase 0 §2.1) ────────────
   'agentcard.title': 'このエージェントを登録しますか？',
   'agentcard.summary': '{{schedule}}に{{action}}を{{route}}で実行します。',
-  'agentcard.name': '名前',
+  'agentcard.name': 'プロジェクト名',
   'agentcard.schedule': 'スケジュール',
   'agentcard.schedule_unset': '（未設定）',
   'agentcard.schedule_required': 'スケジュールを選択してください — 選ぶまでこのエージェントは実行されません。',
@@ -1128,6 +1129,14 @@ const ja: Record<string, string> = {
   'sidebar.log': 'ログ',
   'sidebar.scheduled': '予約済み',
   'sidebar.agents': 'エージェント',
+  'sidebar.agent_manual': '手動',
+  'sidebar.agent_autonomous': '自律',
+  'sidebar.agent_paused': '一時停止中',
+  'sidebar.agent_last': '直近',
+  'sidebar.agent_run_now': '今すぐ実行',
+  'sidebar.agent_pause': '一時停止',
+  'sidebar.agent_resume': '再開',
+  'sidebar.agent_detail_a11y': '{{name}} の詳細を開く',
   'sidebar.repositories': 'リポジトリ',
   'sidebar.file_tree': 'ファイルツリー',
   'sidebar.device': 'デバイス',

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
@@ -98,17 +98,24 @@ class TerminalEmulatorModule : Module() {
         }
     }
 
-    private fun validateDownloadPath(downloadSubdir: String, fileName: String): java.io.File {
+    private fun validateDownloadPath(context: Context, downloadSubdir: String, fileName: String): java.io.File {
         val subdirRe = Regex("^[A-Za-z0-9._-]+$")
         val apkNameRe = Regex("^[A-Za-z0-9._-]+\\.apk$", RegexOption.IGNORE_CASE)
         require(subdirRe.matches(downloadSubdir)) { "Invalid download directory: $downloadSubdir" }
         require(apkNameRe.matches(fileName)) { "Invalid APK file name: $fileName" }
 
-        val downloadsRoot = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        // App-specific external files dir — DownloadManager can always write here
+        // with NO storage permission. The public Downloads dir throws
+        // SecurityException on targetSdk>=29 (legacy WRITE_EXTERNAL_STORAGE is
+        // ineffective and DownloadManager does NOT honor MANAGE_EXTERNAL_STORAGE),
+        // so enqueue() created zero download rows and the updater hung. Must stay
+        // string-identical to BuildsModal.releaseApkDir().
+        val downloadsRoot = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+            ?: throw IllegalStateException("External files dir unavailable")
         val target = java.io.File(downloadsRoot, fileName).canonicalFile
         val root = downloadsRoot.canonicalFile
         require(target.path == root.path || target.path.startsWith(root.path + java.io.File.separator)) {
-            "Download path escapes Downloads directory"
+            "Download path escapes app download directory"
         }
         return target
     }
@@ -854,7 +861,7 @@ class TerminalEmulatorModule : Module() {
 
         AsyncFunction("enqueueApkDownload") { url: String, downloadSubdir: String, fileName: String ->
             val context = requireReactContext()
-            val target = validateDownloadPath(downloadSubdir, fileName)
+            val target = validateDownloadPath(context, downloadSubdir, fileName)
             target.parentFile?.mkdirs()
             if (target.exists() && !target.delete()) {
                 throw IllegalStateException("Could not replace existing APK: ${target.absolutePath}")
@@ -867,13 +874,21 @@ class TerminalEmulatorModule : Module() {
                 setAllowedOverMetered(true)
                 setAllowedOverRoaming(true)
                 setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE)
-                setDestinationInExternalPublicDir(
+                setDestinationInExternalFilesDir(
+                    context,
                     Environment.DIRECTORY_DOWNLOADS,
                     fileName,
                 )
             }
             val manager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-            val downloadId = manager.enqueue(request)
+            val downloadId = try {
+                manager.enqueue(request)
+            } catch (e: Exception) {
+                // Surface a precise error instead of a silent no-op enqueue that
+                // leaves the JS poll loop spinning with no DownloadManager row.
+                Log.e("TerminalEmulator", "enqueueApkDownload: enqueue failed", e)
+                throw IllegalStateException("DownloadManager.enqueue failed: ${e.message}", e)
+            }
             Log.i("TerminalEmulator", "enqueueApkDownload: id=$downloadId target=${target.absolutePath}")
             mapOf(
                 "downloadId" to downloadId,


### PR DESCRIPTION
Four commits, all CC-reviewed (no blockers). Branch CI green (build 1583).

### `583097aa` agent detail popup + project-name + orphan-sweep
Sidebar agent row → tap opens a detail popup (purpose/schedule/action/autonomy/last result + Run now / Pause / Close). Card NAME relabeled "Project name". `cleanupOrphanAgentFiles` sweeps run-agent-*.sh / logs whose `<id>.json` is gone. **On-device: detail popup verified (smoke5 showed prompt + webhook + last error).**

### `7e9fb3e0` clear lint warnings from the sidebar trim
Dead code from the PORTS/recent-tasks removal (useBrowserStore, icons-as-I, runHistory) + Array<T>→T[].

### `b7691533` delete actually removes the agent (no resurrection on restart)
agent-store has no persist → the list is rebuilt from `~/.shelly/agents/<id>.json` each launch. deleteAgent built the rm path from the JS getHomePath() cache (which can hold an unresolved /data/user/0 alias) and ran it via execCommand ignoring exitCode + swallowing the catch — so `rm -f` exited 0 on a wrong path and the json survived, resurrecting the agent. Ground truth: after "delete all", `ls ~/.shelly/agents/*.json | wc -l` still showed 7. Fix: rm via live shell `$HOME`, assert exitCode + verify json is gone before dropping the store entry (fail loud); Sidebar surfaces the error. Also: scheduleAgentStartupRepair now skips agents deleted within the repair-delay window.

### `f6e35540` updater APK download writes to app-specific dir
The in-app updater download never progressed — DownloadManager created zero rows. enqueueApkDownload used setDestinationInExternalPublicDir, which throws SecurityException on targetSdk 36 (WRITE_EXTERNAL_STORAGE ineffective; DownloadManager ignores MANAGE_EXTERNAL_STORAGE). Fix: setDestinationInExternalFilesDir (no permission needed); JS releaseApkDir() string-matched; enqueue try/catch; stall watchdog + stale-id probe as defense. FileProvider paths already cover the app-specific dir (verified). Install path unchanged.

### Verification
tsc + eslint clean on every commit. delete-fix + updater-fix CC-reviewed (FileProvider + $HOME-vs-getHomePath both definitively assessed). On-device smoke of the two fixes pending (self-install from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)