### PR TITLE
fix(ci): gate stable/dev release channel on ref, not trigger event

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -836,18 +836,29 @@ jobs:
           CODEX_RUNTIME_MANIFEST_NAME: codex-runtime.json
         run: |
           set -euo pipefail
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            update_tag="${DEV_UPDATE_TAG}"
-            update_title="Shelly Android dev"
-            release_note_heading="Workflow dispatch Android dev build."
-            android_release_extra_args=(--prerelease)
-            publish_codex_runtime=0
-          else
+          # Gate stable-vs-dev on the ref being built, not on how the run was
+          # triggered. Before this fix, every workflow_dispatch run — including
+          # ones explicitly dispatched with --ref main (the daily Bump Codex
+          # Runtime job does exactly this in bump-codex-runtime.yml's "Commit
+          # bump to main and trigger release build" step, since a push made
+          # with GITHUB_TOKEN cannot retrigger workflows and must fall back to
+          # `gh workflow run ... --ref main`) — was misclassified as a
+          # dev/pre-release build. That silently starved android-latest and
+          # codex-runtime-latest of every automated Codex version bump, while
+          # feature-branch workflow_dispatch test builds correctly stayed on
+          # the dev channel. Branching on the ref instead fixes both cases.
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             update_tag="${STABLE_UPDATE_TAG}"
             update_title="Shelly Android latest"
             release_note_heading="Rolling Android update build."
             android_release_extra_args=()
             publish_codex_runtime=1
+          else
+            update_tag="${DEV_UPDATE_TAG}"
+            update_title="Shelly Android dev"
+            release_note_heading="Workflow dispatch Android dev build."
+            android_release_extra_args=(--prerelease)
+            publish_codex_runtime=0
           fi
 
           apk="$(ls android/app/build/outputs/apk/release/*.apk | head -1)"


### PR DESCRIPTION
## Summary
- android-latest / codex-runtime-latest haven't advanced since 06-27 (APK 1652, Codex 0.142.0) despite the daily "Bump Codex Runtime" cron job repeatedly landing real version bumps on main.
- Root cause: the publish step branched on `GITHUB_EVENT_NAME == workflow_dispatch` to pick stable-vs-dev channel. A push made with `GITHUB_TOKEN` can't retrigger workflows, so `bump-codex-runtime.yml`'s trigger step falls back to `gh workflow run build-android.yml --ref main`, which fires as `workflow_dispatch` even though the ref is `main` — every automated Codex bump was silently classified as a dev/pre-release build and never republished the stable channel.
- Fix: branch on `GITHUB_REF == refs/heads/main` instead, which correctly distinguishes "a main-branch build, however triggered" from "a feature-branch test build."

Verified via `gh run list`/`gh run view` against the real repo that every recent main-branch run was `workflow_dispatch` and android-latest's release body still shows the stale 06-27 commit.

## Test plan
- [ ] Merge, then trigger `bump-codex-runtime.yml` (workflow_dispatch) and confirm the resulting build-android.yml run classifies as stable (publishes android-latest + codex-runtime-latest) rather than dev/pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)