### PR TITLE
fix(sidebar): guard agent/skill name against undefined before toUpperCase

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -598,7 +598,7 @@ export function Sidebar() {
                     accessibilityLabel={t('sidebar.agent_detail_a11y', { name: agent.name })}
                   >
                     <Text style={styles.taskName} numberOfLines={1}>
-                      {agent.name.toUpperCase()}
+                      {(agent.name || '').toUpperCase()}
                     </Text>
                     <Text style={styles.taskMeta} numberOfLines={1}>
                       {agent.autonomous ? '⛓ ' : ''}{agent.schedule || t('sidebar.agent_manual')} · {agent.action?.type ?? 'draft'}
@@ -693,7 +693,7 @@ export function Sidebar() {
                   accessibilityRole="button"
                   accessibilityLabel={t('sidebar.skill_detail_a11y', { name: skill.name })}
                 >
-                  <Text style={styles.taskName} numberOfLines={1}>{skill.name.toUpperCase()}</Text>
+                  <Text style={styles.taskName} numberOfLines={1}>{(skill.name || '').toUpperCase()}</Text>
                   <Text style={styles.taskMeta} numberOfLines={1}>
                     {t('sidebar.skill_uses', { count: skill.successCount })} · {skill.toolLabel}
                   </Text>


### PR DESCRIPTION
## Summary
- Root-caused via on-device logcat capture (Android Device Access, live-monitored `console.error` output — tag `ReactNativeJS`, not `Shelly`, since `[Shelly]` is only a message-text prefix): build 1864 crashed with `Cannot read property 'toUpperCase' of undefined` inside `Sidebar`'s render, right after `Settings loaded`.
- `origin/main`'s `Sidebar.tsx` has two unguarded `.toUpperCase()` calls (`agent.name.toUpperCase()` line 601, `skill.name.toUpperCase()` line 696) that crash whenever an agent/skill entry has an undefined `name`.
- A guard for exactly this (`(x || '').toUpperCase()`) already exists on `claude/work-handoff-2qb1xd` from an earlier same-session fix (SKILL-001 rows) but was never merged to `main` — this PR ports that fix.
- A third `.toUpperCase()` call (repo name, line 784) was checked and left untouched: it's structurally safe (`name = p.replace(...) || p`, which can only be undefined if `p` itself is, and that would throw earlier with a different message at the `.replace()` call).

## Test plan
- [ ] Pattern-matches the already-tested fix from `claude/work-handoff-2qb1xd` (task "Fix toUpperCase crash in Sidebar SKILL-001 rows")
- [ ] Reproduce on-device: open Sidebar's Agents/Skills sections after this build, confirm no crash