### PR TITLE
feat(agent): port capability broker foundation

### DIFF
--- a/__tests__/agent-executor-autonomous.test.ts
+++ b/__tests__/agent-executor-autonomous.test.ts
@@ -443,7 +443,7 @@ describe('generateRunScript — orchestration suppressAction (Phase 4)', () => {
 describe('generateRunScript — autonomous tool resolution (Spec A §4/§5)', () => {
   it('resolves autonomous auto → codex (OAuth), key-free env', () => {
     const s = generateRunScript(agent({ type: 'auto' }, true));
-    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=8');
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=9');
     expect(s).toContain('.shelly-agent-driver.js'); // resolved to cli/codex via the approval driver
     expect(s).toContain('--prompt-file "$PROMPT_FILE"');
     expect(s).toContain('if node_usable && [ -f "$HOME/.shelly-agent-driver.js" ]; then');

--- a/__tests__/agent-executor-cap-broker.test.ts
+++ b/__tests__/agent-executor-cap-broker.test.ts
@@ -1,0 +1,110 @@
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { generateRunScript } from '@/lib/agent-executor';
+import { Agent, ToolChoice } from '@/store/types';
+
+/** bash -n the script via a temp FILE (a full script exceeds the Windows argv limit for `-c`). */
+function bashParses(script: string): void {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cap-parse-')), 'run.sh');
+  fs.writeFileSync(file, script);
+  execFileSync('bash', ['-n', file]);
+}
+
+const agent = (tool: ToolChoice, autonomous?: boolean): Agent => ({
+  id: 't',
+  name: 'T',
+  description: '',
+  prompt: 'collect the latest news with sources', // needsWeb, but backend is explicit
+  schedule: null,
+  tool,
+  autonomous,
+  outputPath: '~/out',
+  outputTemplate: null,
+  enabled: true,
+  lastRun: null,
+  lastResult: null,
+  createdAt: 0,
+  version: 1,
+});
+
+// Phase 0 床: the capability broker is a STRANGLER seam gated behind
+// SHELLY_CAP_BROKER=1. These assert the wiring is present AND that the legacy
+// (flag-off) path is preserved byte-for-byte where it matters — the regression
+// gate the spec §1/§8.2 requires.
+
+describe('capability broker wiring — http_post_json seam (CAP/HTTP/SECRET-001)', () => {
+  const s = generateRunScript(agent({ type: 'perplexity' }, false));
+
+  it('http_post_json has a flag-gated broker branch that reads the .env itself', () => {
+    expect(s).toContain('if [ "${SHELLY_CAP_BROKER:-0}" = "1" ] && node_usable && [ -f "$HOME/.shelly-capability-broker.js" ]; then');
+    expect(s).toContain('"$HOME/.shelly-capability-broker.js"');
+    expect(s).toContain('--secret-env-file "$ENV_FILE"');
+    expect(s).toContain('--auth-ref "${SHELLY_CAP_AUTH_REF:-}"');
+    expect(s).toContain('--budget-file "$TMP_DIR/cap-budget-$AGENT_ID.json"');
+    expect(s).toContain('--audit-log "$LOG_DIR/agent-driver-audit.jsonl"');
+  });
+
+  it('fails closed when the broker is requested but unavailable (no unbrokered send)', () => {
+    // Regression: with flag ON but the broker asset missing, the call site set an
+    // auth-ref but no raw header; falling through to the legacy path would send an
+    // unauthenticated request. http_post_json must refuse instead.
+    expect(s).toContain('if [ "${SHELLY_CAP_BROKER:-0}" = "1" ]; then');
+    expect(s).toContain('refusing to send unbrokered');
+  });
+
+  it('resets the per-run egress budget at run start', () => {
+    expect(s).toContain('rm -f "$TMP_DIR/cap-budget-$AGENT_ID.json"');
+  });
+
+  it('bumps the script version in lockstep with the native gate', () => {
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=11');
+  });
+});
+
+describe('capability broker wiring — secret-by-reference per backend (SECRET-001)', () => {
+  it('perplexity: broker mode uses auth-ref; legacy mode keeps the raw Bearer header', () => {
+    const s = generateRunScript(agent({ type: 'perplexity' }, false));
+    expect(s).toContain('SHELLY_CAP_AUTH_REF=perplexity HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://api.perplexity.ai/chat/completions"');
+    // Legacy path preserved (regression gate).
+    expect(s).toContain('HTTP_AUTH_HEADER="Bearer $PERPLEXITY_API_KEY" HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://api.perplexity.ai/chat/completions"');
+  });
+
+  it('gemini: broker mode uses auth-ref; legacy mode keeps the x-goog-api-key header', () => {
+    const s = generateRunScript(agent({ type: 'gemini-api' }, false));
+    expect(s).toContain('SHELLY_CAP_AUTH_REF=gemini HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://generativelanguage.googleapis.com');
+    expect(s).toContain('HTTP_EXTRA_HEADERS="x-goog-api-key: $GEMINI_API_KEY"');
+  });
+
+  it('cerebras / groq: broker mode uses the matching auth-ref; legacy Bearer preserved', () => {
+    const cb = generateRunScript(agent({ type: 'cerebras' }, false));
+    expect(cb).toContain('SHELLY_CAP_AUTH_REF=cerebras HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://api.cerebras.ai/v1/chat/completions"');
+    expect(cb).toContain('HTTP_AUTH_HEADER="Bearer $CEREBRAS_API_KEY"');
+
+    const gq = generateRunScript(agent({ type: 'groq' }, false));
+    expect(gq).toContain('SHELLY_CAP_AUTH_REF=groq HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://api.groq.com/openai/v1/chat/completions"');
+    expect(gq).toContain('HTTP_AUTH_HEADER="Bearer $GROQ_API_KEY"');
+  });
+
+  it('webhook egress is marked pre-approved (its human approval gate already ran)', () => {
+    const s = generateRunScript({ ...agent({ type: 'local' }), action: { type: 'webhook', webhookUrl: 'https://hooks.example.com/x' } } as Agent);
+    expect(s).toContain('SHELLY_CAP_APPROVED=1 HTTP_TIMEOUT_SECONDS="${WEBHOOK_TIMEOUT_SECONDS:-30}" http_post_json "$ACTION_WEBHOOK_URL"');
+  });
+});
+
+describe('capability broker wiring — generated shell stays parseable (bash -n)', () => {
+  it('every backend script with the new conditionals parses', () => {
+    for (const t of ['perplexity', 'gemini-api', 'cerebras', 'groq', 'local'] as const) {
+      const s = generateRunScript(agent({ type: t }, false));
+      expect(() => bashParses(s)).not.toThrow();
+    }
+    // webhook action path too
+    const wh = generateRunScript({ ...agent({ type: 'local' }), action: { type: 'webhook', webhookUrl: 'https://hooks.example.com/x' } } as Agent);
+    expect(() => bashParses(wh)).not.toThrow();
+  });
+});

--- a/__tests__/agent-executor-cap-broker.test.ts
+++ b/__tests__/agent-executor-cap-broker.test.ts
@@ -63,7 +63,7 @@ describe('capability broker wiring — http_post_json seam (CAP/HTTP/SECRET-001)
   });
 
   it('bumps the script version in lockstep with the native gate', () => {
-    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=11');
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=9');
   });
 });
 

--- a/__tests__/capability-broker-parity.test.ts
+++ b/__tests__/capability-broker-parity.test.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { AUTH_REFS, EGRESS_ALLOWLIST } from '@/lib/capability-envelope';
+
+// The capability broker ships as an APK asset and is kept in scripts/ for host
+// tests; they MUST stay byte-identical (a drift would let CI test one version
+// while the device ships another — a fail-open hazard for a security-critical
+// file). It also mirrors the classification CONSTANTS from
+// lib/capability-envelope.ts by hand (the broker runs under node in the .sh and
+// cannot import the TS). Guard both here.
+describe('shelly-capability-broker.js parity', () => {
+  const root = path.resolve(__dirname, '..');
+  const scriptCopy = path.join(root, 'scripts', 'shelly-capability-broker.js');
+  const assetCopy = path.join(root, 'modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js');
+  const brokerSrc = fs.readFileSync(scriptCopy, 'utf8');
+
+  it('scripts/ copy and the APK asset are byte-identical', () => {
+    expect(fs.readFileSync(assetCopy, 'utf8')).toBe(brokerSrc);
+  });
+
+  it('the broker allowlist matches lib/capability-envelope.ts', () => {
+    for (const host of EGRESS_ALLOWLIST) {
+      expect(brokerSrc).toContain(`'${host}'`);
+    }
+  });
+
+  it('every auth_ref (name → envVar/header/host) matches the TS registry', () => {
+    for (const [ref, spec] of Object.entries(AUTH_REFS)) {
+      // The broker declares each ref as a key with the same envVar/header/host.
+      const re = new RegExp(
+        `${ref}:\\s*\\{[^}]*envVar:\\s*'${spec.envVar}'[^}]*header:\\s*'${spec.header}'[^}]*host:\\s*'${spec.host}'`,
+      );
+      expect(brokerSrc).toMatch(re);
+    }
+  });
+});

--- a/__tests__/capability-broker.test.ts
+++ b/__tests__/capability-broker.test.ts
@@ -128,6 +128,20 @@ describe('shelly-capability-broker: policy gates (no network)', () => {
     expect(r.code).toBe(43);
   });
 
+  it('blocks tainted input plus a live secret fail-closed when not approved, even on the bound allowlisted host (41)', async () => {
+    const r = await runBroker(dir, {
+      url: 'https://api.perplexity.ai/chat/completions',
+      authRef: 'perplexity',
+      tainted: true,
+      env: { PERPLEXITY_API_KEY: 'pplx-SECRETSECRETSECRETSECRET' },
+    });
+    expect(r.code).toBe(41);
+    expect(r.audit[0].decision).toBe('approve');
+    expect(r.audit[0].signals).toContain('tainted-secret-spend');
+    // The secret must never appear in any output file even though it was loaded.
+    expect(r.err + r.out + JSON.stringify(r.audit)).not.toContain('pplx-SECRET');
+  });
+
   it('fails closed with BUDGET (42) when the call budget is exhausted', async () => {
     const r = await runBroker(dir, {
       url: 'https://api.groq.com/openai/v1/chat/completions',

--- a/__tests__/capability-broker.test.ts
+++ b/__tests__/capability-broker.test.ts
@@ -1,0 +1,187 @@
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const BROKER = path.resolve(__dirname, '..', 'scripts', 'shelly-capability-broker.js');
+
+interface RunResult {
+  code: number;
+  out: string;
+  err: string;
+  audit: any[];
+}
+
+function makeDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cap-broker-'));
+}
+
+/**
+ * Run the broker against a live local http server; returns exit code + files.
+ * Async (execFile, not execFileSync) so an in-process test server can serve the
+ * child request — a synchronous spawn would block jest's event loop and deadlock.
+ */
+function runBroker(
+  dir: string,
+  opts: {
+    url: string;
+    method?: string;
+    body?: string;
+    authRef?: string;
+    tainted?: boolean;
+    approved?: boolean;
+    env?: Record<string, string>;
+    budget?: { calls: number; startedAtMs: number };
+  },
+): Promise<RunResult> {
+  const outFile = path.join(dir, 'out.txt');
+  const errFile = path.join(dir, 'err.txt');
+  const auditFile = path.join(dir, 'audit.jsonl');
+  const budgetFile = path.join(dir, 'budget.json');
+  const envFile = path.join(dir, '.env');
+
+  if (opts.env) {
+    const lines = Object.entries(opts.env).map(([k, v]) => `${k}='${String(v).replace(/'/g, "'\\''")}'`);
+    fs.writeFileSync(envFile, lines.join('\n') + '\n');
+  }
+  if (opts.budget) fs.writeFileSync(budgetFile, JSON.stringify(opts.budget));
+
+  const argv = [
+    BROKER,
+    '--method',
+    opts.method || 'POST',
+    '--url',
+    opts.url,
+    '--auth-ref',
+    opts.authRef || '',
+    '--tainted',
+    opts.tainted ? '1' : '0',
+    '--approved',
+    opts.approved ? '1' : '0',
+    '--secret-env-file',
+    envFile,
+    '--audit-log',
+    auditFile,
+    '--budget-file',
+    budgetFile,
+    '--timeout-seconds',
+    '10',
+    '--out',
+    outFile,
+    '--err',
+    errFile,
+  ];
+  if (opts.method !== 'GET') {
+    const bodyFile = path.join(dir, 'body.json');
+    fs.writeFileSync(bodyFile, opts.body ?? '{}');
+    argv.push('--body-file', bodyFile);
+  }
+
+  return new Promise((resolve) => {
+    execFile('node', argv, { encoding: 'utf8' }, (err: any) => {
+      const code = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
+      const read = (f: string) => (fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : '');
+      const auditText = read(auditFile).trim();
+      const audit = auditText ? auditText.split('\n').map((l) => JSON.parse(l)) : [];
+      resolve({ code, out: read(outFile), err: read(errFile), audit });
+    });
+  });
+}
+
+describe('shelly-capability-broker: policy gates (no network)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeDir();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('DENYs a secret spent against a mismatched host and never sends', async () => {
+    const r = await runBroker(dir, {
+      url: 'https://evil.example.com/steal',
+      authRef: 'perplexity',
+      env: { PERPLEXITY_API_KEY: 'pplx-SECRETSECRETSECRETSECRET' },
+    });
+    expect(r.code).toBe(40);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('ref-host-mismatch');
+    // The secret must never appear in any output file.
+    expect(r.err + r.out + JSON.stringify(r.audit)).not.toContain('pplx-SECRET');
+  });
+
+  it('DENYs plaintext http to a remote host', async () => {
+    const r = await runBroker(dir, { url: 'http://api.groq.com/x' });
+    expect(r.code).toBe(40);
+    expect(r.audit[0].signals).toContain('insecure-scheme');
+  });
+
+  it('blocks a non-allowlist host fail-closed when not approved (41)', async () => {
+    const r = await runBroker(dir, { url: 'https://hooks.example.com/incoming' });
+    expect(r.code).toBe(41);
+    expect(r.audit[0].decision).toBe('approve');
+    expect(r.audit[0].signals).toContain('non-allowlist-host');
+  });
+
+  it('fails closed with NO_SECRET (43) when the auth_ref env var is missing', async () => {
+    const r = await runBroker(dir, { url: 'https://api.perplexity.ai/chat/completions', authRef: 'perplexity' });
+    expect(r.code).toBe(43);
+  });
+
+  it('fails closed with BUDGET (42) when the call budget is exhausted', async () => {
+    const r = await runBroker(dir, {
+      url: 'https://api.groq.com/openai/v1/chat/completions',
+      authRef: 'groq',
+      env: { GROQ_API_KEY: 'gsk_SECRETSECRETSECRETSECRET' },
+      budget: { calls: 40, startedAtMs: Date.now() },
+    });
+    expect(r.code).toBe(42);
+    expect(r.err).toMatch(/budget/);
+  });
+});
+
+describe('shelly-capability-broker: secret injection + send (loopback server)', () => {
+  let dir: string;
+  let server: import('http').Server;
+  let port: number;
+  let lastAuthHeader: string | undefined;
+
+  beforeEach((done) => {
+    dir = makeDir();
+    // A loopback host is allowlisted (127.0.0.1). We register an auth_ref bound to
+    // 127.0.0.1 by monkeypatching via a custom ref is not possible, so instead we
+    // test the un-authed loopback send path AND the budget increment/audit here.
+    const httpMod = require('http');
+    server = httpMod.createServer((req: any, res: any) => {
+      lastAuthHeader = req.headers['authorization'];
+      let body = '';
+      req.on('data', (c: any) => (body += c));
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, echoedLen: body.length }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      port = (server.address() as any).port;
+      done();
+    });
+  });
+  afterEach((done) => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    server.close(() => done());
+  });
+
+  it('allows an un-authed loopback POST, records a redacted audit, and increments the budget', async () => {
+    const r = await runBroker(dir, { url: `http://127.0.0.1:${port}/v1/chat/completions`, body: '{"hi":1}' });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('"ok":true');
+    expect(r.audit[0].decision).toBe('allow');
+    expect(r.audit[0].status).toBe(200);
+    expect(r.audit[0].authRef).toBeNull();
+    // budget file advanced to 1
+    const budget = JSON.parse(fs.readFileSync(path.join(dir, 'budget.json'), 'utf8'));
+    expect(budget.calls).toBe(1);
+    // no auth header was sent for an un-authed call
+    expect(lastAuthHeader).toBeUndefined();
+  });
+});

--- a/__tests__/capability-envelope.test.ts
+++ b/__tests__/capability-envelope.test.ts
@@ -89,6 +89,33 @@ describe('capability-envelope: classifyEgress (CAP-001 §4.3 structural rule)', 
     expect(v.signals).toContain('tainted');
     expect(v.signals).toContain('non-allowlist-host');
   });
+
+  it('requires approval for tainted input plus a live secret, even on its correctly-bound allowlisted host', () => {
+    // Host-binding only guards WHERE a secret can go; it does not guard WHAT
+    // gets said with it. A poisoned notification could still direct the agent
+    // to post attacker-chosen content to a legitimate, allowlisted webhook
+    // using our own valid key — that must not auto-allow.
+    const v = classifyEgress({
+      url: 'https://api.perplexity.ai/chat/completions',
+      authRef: 'perplexity',
+      tainted: true,
+    });
+    expect(v.decision).toBe('approve');
+    expect(v.signals).toContain('tainted');
+    expect(v.signals).toContain('secret-spend');
+    expect(v.signals).toContain('tainted-secret-spend');
+    // Must not also carry non-allowlist-host — the host IS allowlisted here.
+    expect(v.signals).not.toContain('non-allowlist-host');
+  });
+
+  it('untainted secret spend against its bound host still auto-allows (no behavior change for today\'s live callers)', () => {
+    const v = classifyEgress({
+      url: 'https://api.perplexity.ai/chat/completions',
+      authRef: 'perplexity',
+      tainted: false,
+    });
+    expect(v.decision).toBe('allow');
+  });
 });
 
 describe('capability-envelope: checkBudget (CAP-001 fail-closed)', () => {

--- a/__tests__/capability-envelope.test.ts
+++ b/__tests__/capability-envelope.test.ts
@@ -1,0 +1,133 @@
+import {
+  AUTH_REFS,
+  EGRESS_ALLOWLIST,
+  DEFAULT_BUDGET,
+  buildEgressAudit,
+  checkBudget,
+  classifyEgress,
+  hostFromUrl,
+  isAllowlistedHost,
+} from '@/lib/capability-envelope';
+
+describe('capability-envelope: host parsing + allowlist (HTTP-001)', () => {
+  it('extracts and lowercases the host', () => {
+    expect(hostFromUrl('https://API.Perplexity.AI/chat/completions')).toBe('api.perplexity.ai');
+    expect(hostFromUrl('not a url')).toBeNull();
+  });
+
+  it('every backend host is on the allowlist', () => {
+    expect(isAllowlistedHost('api.perplexity.ai')).toBe(true);
+    expect(isAllowlistedHost('generativelanguage.googleapis.com')).toBe(true);
+    expect(isAllowlistedHost('api.cerebras.ai')).toBe(true);
+    expect(isAllowlistedHost('api.groq.com')).toBe(true);
+    expect(isAllowlistedHost('127.0.0.1')).toBe(true);
+    expect(isAllowlistedHost('evil.example.com')).toBe(false);
+  });
+
+  it('every auth_ref host is present in the allowlist', () => {
+    for (const spec of Object.values(AUTH_REFS)) {
+      expect(EGRESS_ALLOWLIST).toContain(spec.host);
+    }
+  });
+});
+
+describe('capability-envelope: classifyEgress (CAP-001 §4.3 structural rule)', () => {
+  it('allows an allowlisted https host with no secret/taint', () => {
+    const v = classifyEgress({ url: 'https://api.groq.com/openai/v1/chat/completions' });
+    expect(v.decision).toBe('allow');
+  });
+
+  it('allows loopback over http', () => {
+    const v = classifyEgress({ url: 'http://127.0.0.1:8080/v1/chat/completions' });
+    expect(v.decision).toBe('allow');
+  });
+
+  it('denies non-loopback plaintext http', () => {
+    const v = classifyEgress({ url: 'http://api.groq.com/x' });
+    expect(v.decision).toBe('deny');
+    expect(v.signals).toContain('insecure-scheme');
+  });
+
+  it('denies an unparseable URL', () => {
+    const v = classifyEgress({ url: 'http://' });
+    expect(v.decision).toBe('deny');
+  });
+
+  it('requires approval for a non-allowlist host (e.g. a webhook)', () => {
+    const v = classifyEgress({ url: 'https://hooks.example.com/incoming' });
+    expect(v.decision).toBe('approve');
+    expect(v.signals).toContain('non-allowlist-host');
+  });
+
+  it('allows a secret spent against its bound host', () => {
+    const v = classifyEgress({ url: 'https://api.perplexity.ai/chat/completions', authRef: 'perplexity' });
+    expect(v.decision).toBe('allow');
+    expect(v.signals).toContain('secret-spend');
+  });
+
+  it('HARD-denies a secret spent against a different host (exfil guard)', () => {
+    const v = classifyEgress({ url: 'https://evil.example.com/steal', authRef: 'perplexity' });
+    expect(v.decision).toBe('deny');
+    expect(v.signals).toContain('ref-host-mismatch');
+  });
+
+  it('HARD-denies a secret spent against ANOTHER allowlisted backend host', () => {
+    // A gemini ref must not be spendable at groq's host even though both are allowlisted.
+    const v = classifyEgress({ url: 'https://api.groq.com/openai/v1/chat/completions', authRef: 'gemini' });
+    expect(v.decision).toBe('deny');
+    expect(v.signals).toContain('ref-host-mismatch');
+  });
+
+  it('denies an unknown auth_ref', () => {
+    const v = classifyEgress({ url: 'https://api.groq.com/x', authRef: 'made-up' });
+    expect(v.decision).toBe('deny');
+  });
+
+  it('flags taint on a non-allowlist send (trifecta case → approve, not auto)', () => {
+    const v = classifyEgress({ url: 'https://hooks.example.com/incoming', tainted: true });
+    expect(v.decision).toBe('approve');
+    expect(v.signals).toContain('tainted');
+    expect(v.signals).toContain('non-allowlist-host');
+  });
+});
+
+describe('capability-envelope: checkBudget (CAP-001 fail-closed)', () => {
+  const t0 = 1_000_000;
+  it('allows an in-budget call', () => {
+    expect(checkBudget({ calls: 0, startedAtMs: t0 }, DEFAULT_BUDGET, t0).ok).toBe(true);
+  });
+  it('fails closed at the call cap', () => {
+    const r = checkBudget({ calls: DEFAULT_BUDGET.maxCalls, startedAtMs: t0 }, DEFAULT_BUDGET, t0);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/call budget/);
+  });
+  it('fails closed past the wall-time cap', () => {
+    const r = checkBudget({ calls: 1, startedAtMs: t0 }, DEFAULT_BUDGET, t0 + DEFAULT_BUDGET.maxWallMs + 1);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/wall-time budget/);
+  });
+});
+
+describe('capability-envelope: buildEgressAudit (CAP-001 redacted audit)', () => {
+  it('records ref NAME and host/path but drops the query string', () => {
+    const entry = buildEgressAudit({
+      ts: '2026-07-01T00:00:00.000Z',
+      method: 'post',
+      url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=AIzaSECRETSECRETSECRETSECRETSECRETSEC',
+      authRef: 'gemini',
+      verdict: classifyEgress({
+        url: 'https://generativelanguage.googleapis.com/v1beta/models/x:generateContent',
+        authRef: 'gemini',
+      }),
+      status: 200,
+      ok: true,
+    });
+    expect(entry.method).toBe('POST');
+    expect(entry.host).toBe('generativelanguage.googleapis.com');
+    expect(entry.authRef).toBe('gemini');
+    expect(entry.status).toBe(200);
+    // The audit must never carry the key that rode in the query string.
+    expect(JSON.stringify(entry)).not.toContain('AIzaSECRET');
+    expect(entry.path).not.toContain('key=');
+  });
+});

--- a/docs/superpowers/DEFERRED.md
+++ b/docs/superpowers/DEFERRED.md
@@ -91,6 +91,15 @@ grep -iE 'escalation|approval|decline|unattended|denied' ~/.shelly/agents/audits
 - ③c: ① インライン `[ローカル]`/`[Codex]` ピン（manual-pin guard 接続）+ ドメインルート + 小キズ（失敗通知の生 ID / fallback の success 偽装）。
 - ゴール例（受け入れテストの北極星）: 「毎週月/金、STEAM×AI の最新論文を Perplexity で検索 → 1 次ソース+要約を Obsidian の日付フォルダへ → X 文字数制限内に再要約」が**完全無人で回る**。**残る解錠は全て実装着地（2026-06-24, branch claude/work-handoff-2qb1xd）**: 自律クラウド opt-in=N1(105fda3) / Vault 内保存の自動承認=N2(b08a608) / 複数曜日スケジュール=N4(c80bb04) / 日付フォルダ出力テンプレ=N4(fa10617) / web-mandatory routing(203428c) / orchestration 昇格=N3(8fb8926)。**残るは実機 end-to-end 検証（web quota 明け待ち）と N1 スケジュール .sh のクラウド完全無人化 follow-up のみ**。
 
+### 🧭 Capability broker Phase 0 — flag-gated foundation
+
+**優先度**: P1 follow-up ／ **状態**: CAP-001/SECRET-001/HTTP-001 の broker 基盤は flag-gated OFF で着地、既存経路は維持。
+
+- `SHELLY_CAP_BROKER=1` のときだけ `http_post_json` を capability broker 経由にし、allowlist、auth-ref の host binding、taint gate、budget、redacted audit を適用する。既定 OFF のため production の既存経路は変えない。
+- SECRET-001 は部分適用: broker は秘密を argv/child environment から外すが、config 読み込みのため `.env` source は残る。完全 de-source は follow-up。
+- 非 allowlist host は承認 UI 未接続のため fail-closed。mid-run approval は nonce/host 束縛を含めて follow-up。
+- policy deny / budget 超過の診断表示改善と、broker opt-in の実機 end-to-end 再検証を follow-up とする。
+
 ### 🔴 Web-mandatory routing — 実機 end-to-end 検証待ち（quota 明けの必須ゲート）
 
 **優先度**: P1（North Star コアの収集経路。実装済みだが実機 end-to-end 未検証）

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -13,7 +13,7 @@ import { buildAgentPolicy } from './agent-policy';
 const MAX_CONCURRENT = 2;
 
 const DEFAULT_TIMEOUT_SEC = 600; // 10 minutes
-const AGENT_SCRIPT_VERSION = 8;
+const AGENT_SCRIPT_VERSION = 9;
 const LOCAL_MODEL_LIGHT = 'Qwen3.5-0.8B-Q4_K_M';
 const LOCAL_MODEL_BALANCED = 'Qwen3.5-2B-Q4_K_M';
 const LOCAL_MODEL_QUALITY = 'Qwen3.5-4B-Q4_K_M';
@@ -825,7 +825,7 @@ dispatch_agent_action() {
       write_action_approval_request "webhook" "$preview" "$result_file" "$webhook_host" "$webhook_payload"
       wait_action_approval "webhook" || return 1
       set +e
-      HTTP_TIMEOUT_SECONDS="\${WEBHOOK_TIMEOUT_SECONDS:-30}" http_post_json "$ACTION_WEBHOOK_URL" "$webhook_payload" "$webhook_response" "$webhook_error"
+      SHELLY_CAP_APPROVED=1 HTTP_TIMEOUT_SECONDS="\${WEBHOOK_TIMEOUT_SECONDS:-30}" http_post_json "$ACTION_WEBHOOK_URL" "$webhook_payload" "$webhook_response" "$webhook_error"
       webhook_rc=$?
       set -e
       if [ "$webhook_rc" -ne 0 ]; then
@@ -883,6 +883,31 @@ http_post_json() {
   body_file="$2"
   out_file="$3"
   err_file="$4"
+  # CAP-001/SECRET-001/HTTP-001 strangler seam. When SHELLY_CAP_BROKER=1, route
+  # the send through the capability broker: it enforces the egress allowlist,
+  # resolves an opaque \${SHELLY_CAP_AUTH_REF} to a real auth header by reading
+  # \$ENV_FILE ITSELF (so no raw "Bearer \$KEY" is built in this shell), caps the
+  # run's egress budget, and appends a redacted audit line. Flag defaults off, so
+  # the live path below is unchanged unless a device operator opts in.
+  if [ "\${SHELLY_CAP_BROKER:-0}" = "1" ] && node_usable && [ -f "$HOME/.shelly-capability-broker.js" ]; then
+    shelly_node "$HOME/.shelly-capability-broker.js" \\
+      --method POST --url "$url" --body-file "$body_file" \\
+      --auth-ref "\${SHELLY_CAP_AUTH_REF:-}" --tainted "\${SHELLY_CAP_TAINTED:-0}" --approved "\${SHELLY_CAP_APPROVED:-0}" \\
+      --secret-env-file "$ENV_FILE" \\
+      --audit-log "$LOG_DIR/agent-driver-audit.jsonl" \\
+      --budget-file "$TMP_DIR/cap-budget-$AGENT_ID.json" \\
+      --timeout-seconds "\${HTTP_TIMEOUT_SECONDS:-30}" \\
+      --out "$out_file" --err "$err_file"
+    return $?
+  fi
+  # Fail-closed: if the broker was REQUESTED (flag on) but is unavailable (node
+  # unusable or the asset failed to extract), do NOT silently fall through to the
+  # legacy path — in broker mode the call site set SHELLY_CAP_AUTH_REF but no raw
+  # auth header, so the legacy send would go out unauthenticated. Refuse instead.
+  if [ "\${SHELLY_CAP_BROKER:-0}" = "1" ]; then
+    echo "capability broker requested (SHELLY_CAP_BROKER=1) but unavailable; refusing to send unbrokered." > "$err_file"
+    return 44
+  fi
   if node_usable; then
     shelly_node - "$url" "$body_file" > "$out_file" 2> "$err_file" <<'NODEEOF'
 const fs = require('fs');
@@ -2119,6 +2144,8 @@ echo $$ > "$LOCK_FILE"
 
 # Execute tool
 rm -f "$BACKEND_ERROR_FILE" "$TRANSIENT_ERROR_FILE"
+# CAP-001: each run opens a fresh egress budget envelope (drop any stale counter).
+rm -f "$TMP_DIR/cap-budget-$AGENT_ID.json"
 ${toolCommand}
 
 # Check result
@@ -2313,7 +2340,11 @@ rm -f "$PROMPT_FILE"`;
 		else
 		printf '{\\"model\\":\\"%s\\",\\"messages\\":[{\\"role\\":\\"user\\",\\"content\\":%s}]}' "$MODEL" "$PROMPT_JSON" > "$REQUEST_FILE"
 		set +e
-		HTTP_AUTH_HEADER="Bearer $PERPLEXITY_API_KEY" HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://api.perplexity.ai/chat/completions" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+		if [ "\${SHELLY_CAP_BROKER:-0}" = "1" ]; then
+			  SHELLY_CAP_AUTH_REF=perplexity HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://api.perplexity.ai/chat/completions" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+			else
+			  HTTP_AUTH_HEADER="Bearer $PERPLEXITY_API_KEY" HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://api.perplexity.ai/chat/completions" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+			fi
 		API_EXIT=$?
 		set -e
 		if [ "$API_EXIT" -ne 0 ] || [ ! -s "$RESULT_FILE.response.json" ]; then
@@ -2335,6 +2366,7 @@ rm -f "$PROMPT_FILE"`;
         url: 'https://api.cerebras.ai/v1/chat/completions',
         model: tool.model || 'qwen-3-235b-a22b-instruct-2507',
         label: 'Cerebras',
+        authRef: 'cerebras',
       });
     case 'groq':
       return openAiCompatApiCommand(escapedPrompt, resultVar, {
@@ -2344,6 +2376,7 @@ rm -f "$PROMPT_FILE"`;
         url: 'https://api.groq.com/openai/v1/chat/completions',
         model: tool.model || 'llama-3.3-70b-versatile',
         label: 'Groq',
+        authRef: 'groq',
       });
     case 'ab-article-eval':
       return articleEvalCommand(rawPrompt, resultVar, tool.localModel, tool.codexCmd);
@@ -2543,7 +2576,7 @@ RESULTEOF`;
 function openAiCompatApiCommand(
   escapedPrompt: string,
   resultVar: string,
-  opts: { keyVar: string; envModelVar: string; keyHint: string; url: string; model: string; label: string },
+  opts: { keyVar: string; envModelVar: string; keyHint: string; url: string; model: string; label: string; authRef: string },
 ): string {
   const model = opts.model.replace(/"/g, '\\"');
   const keyHint = opts.keyHint.replace(/'/g, "'\\''");
@@ -2560,7 +2593,11 @@ function openAiCompatApiCommand(
 	else
 	printf '{\\"model\\":\\"%s\\",\\"messages\\":[{\\"role\\":\\"user\\",\\"content\\":%s}]}' "$MODEL" "$PROMPT_JSON" > "$REQUEST_FILE"
 	set +e
+	if [ "\${SHELLY_CAP_BROKER:-0}" = "1" ]; then
+	SHELLY_CAP_AUTH_REF=${opts.authRef} HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "${url}" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+	else
 	HTTP_AUTH_HEADER="Bearer $${opts.keyVar}" HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "${url}" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+	fi
 	API_EXIT=$?
 	set -e
 	if [ "$API_EXIT" -ne 0 ] || [ ! -s "$RESULT_FILE.response.json" ]; then
@@ -2596,7 +2633,11 @@ if [ -z "\${GEMINI_API_KEY:-}" ]; then
 else
   printf '{\\"contents\\":[{\\"role\\":\\"user\\",\\"parts\\":[{\\"text\\":%s}]}],${toolsFragment}\\"generationConfig\\":{\\"maxOutputTokens\\":8192,\\"temperature\\":0.7}}' "$PROMPT_JSON" > "$REQUEST_FILE"
   set +e
-  HTTP_EXTRA_HEADERS="x-goog-api-key: $GEMINI_API_KEY" HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://generativelanguage.googleapis.com/v1beta/models/$MODEL:generateContent" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+  if [ "\${SHELLY_CAP_BROKER:-0}" = "1" ]; then
+    SHELLY_CAP_AUTH_REF=gemini HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://generativelanguage.googleapis.com/v1beta/models/$MODEL:generateContent" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+  else
+    HTTP_EXTRA_HEADERS="x-goog-api-key: $GEMINI_API_KEY" HTTP_TIMEOUT_SECONDS="$TIMEOUT" http_post_json_retry "https://generativelanguage.googleapis.com/v1beta/models/$MODEL:generateContent" "$REQUEST_FILE" "$RESULT_FILE.response.json" "$RESULT_FILE.stderr"
+  fi
   API_EXIT=$?
   set -e
   if [ "$API_EXIT" -ne 0 ] || [ ! -s "$RESULT_FILE.response.json" ]; then

--- a/lib/capability-envelope.ts
+++ b/lib/capability-envelope.ts
@@ -105,7 +105,8 @@ export type EgressSignal =
   | 'secret-spend' // an auth_ref (secret) is being used on this request
   | 'tainted' // this run consumed untrusted input (§4 taint tracking)
   | 'ref-host-mismatch' // an auth_ref was spent against a host it is not bound to
-  | 'insecure-scheme'; // non-loopback plaintext / unparseable URL
+  | 'insecure-scheme' // non-loopback plaintext / unparseable URL
+  | 'tainted-secret-spend'; // untrusted input + a live secret, even to an allowlisted, correctly-bound host
 
 export interface EgressVerdict {
   decision: EgressDecision;
@@ -124,6 +125,12 @@ export interface EgressVerdict {
  *    host but api.perplexity.ai, regardless of what a human might click.
  *  - Non-allowlist host → approve (human gate); loud when a secret or taint is
  *    also present (the trifecta case).
+ *  - Tainted input plus a live secret, even against an allowlisted and
+ *    correctly-bound host → approve. Host-binding only guards WHERE a secret
+ *    can go, not WHAT gets said with it — untrusted content could still direct
+ *    the agent to spend a legitimate secret on an attacker-chosen payload at a
+ *    legitimate destination (e.g. a poisoned notification tricking the agent
+ *    into posting attacker text to our own Slack webhook).
  *  - Allowlist host with no boundary signal → allow.
  */
 export function classifyEgress(opts: {
@@ -173,6 +180,21 @@ export function classifyEgress(opts: {
     return {
       decision: 'approve',
       reason: `host ${host} is not on the egress allowlist`,
+      signals,
+    };
+  }
+
+  // Trifecta case even on an allowlisted, correctly-bound host: untrusted input
+  // (taint) plus a live secret means the CONTENT of the request — not just its
+  // destination — may be attacker-directed (e.g. a poisoned notification
+  // tricking the agent into posting attacker-chosen text to a legitimate,
+  // allowlisted Slack webhook using our own valid key). The host-binding check
+  // above only guards where a secret can go, not what gets said with it.
+  if (tainted && authRef) {
+    signals.push('tainted-secret-spend');
+    return {
+      decision: 'approve',
+      reason: `tainted input plus a live secret ("${authRef}") to ${host} requires human approval`,
       signals,
     };
   }

--- a/lib/capability-envelope.ts
+++ b/lib/capability-envelope.ts
@@ -1,0 +1,277 @@
+/**
+ * lib/capability-envelope.ts — CAP-001 / SECRET-001 / HTTP-001 pure core.
+ *
+ * Phase 0 「床/substrate」of the L1/L2 Capability Catalog
+ * (docs/superpowers/specs/2026-07-01-l1-l2-capability-catalog.md §3/§4). This is
+ * the OFFLINE-TESTABLE brain of the capability broker; the runtime broker
+ * (scripts/shelly-capability-broker.js) mirrors the constants below (the
+ * `capability-broker-parity.test.ts` keeps them in lock-step, matching the
+ * existing shelly-agent-driver asset-parity pattern).
+ *
+ * Strangler migration (§1/§8.2): the live `.sh` egress path stays green. The
+ * broker is opt-in behind SHELLY_CAP_BROKER=1 and is inserted at the single
+ * choke point every backend already funnels through (http_post_json /
+ * http_get_text in agent-executor.ts). Nothing here changes behaviour unless the
+ * flag is set.
+ *
+ * Three primitives, one seam:
+ *  - HTTP-001: egress allowlist — no skill gets `*`; non-allowlist hosts gate.
+ *  - SECRET-001: secret-by-reference — a skill passes an opaque `auth_ref`, never
+ *    a value, and a ref is BOUND to exactly one host (a Perplexity ref can only
+ *    authenticate api.perplexity.ai, so a mis-routed URL cannot exfiltrate it).
+ *  - CAP-001: budget / loop-limit / redacted audit / taint-aware structural rule.
+ */
+import { redactSecrets } from '@/lib/redact-secrets';
+
+/**
+ * SECRET-001. An opaque handle a skill/backend passes to the broker. The broker
+ * resolves `envVar` from ~/.shelly/agents/.env INSIDE itself and injects `header`
+ * — the raw value never returns to the calling shell (the /proc same-uid leak the
+ * spec §4.4 closes). A ref is bound to a single `host`: the broker refuses to
+ * spend it against any other host, so a tainted/mis-built URL cannot redirect the
+ * secret to an attacker.
+ */
+export interface AuthRefSpec {
+  /** the opaque handle the skill passes (e.g. "perplexity") */
+  ref: string;
+  /** the .env variable the broker reads inside itself; never surfaced */
+  envVar: string;
+  /** header name the broker injects (e.g. "Authorization") */
+  header: string;
+  /** value prefix (e.g. "Bearer "); "" for bare-value headers like x-goog-api-key */
+  scheme: string;
+  /** the ONLY host this ref may authenticate to */
+  host: string;
+}
+
+/**
+ * The known secret references. Mirrors the concrete backends in
+ * agent-executor.ts (perplexity / gemini-api / cerebras / groq). Each is bound to
+ * its single upstream host. Keep in sync with the broker's AUTH_REFS.
+ */
+export const AUTH_REFS: Readonly<Record<string, AuthRefSpec>> = Object.freeze({
+  perplexity: { ref: 'perplexity', envVar: 'PERPLEXITY_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.perplexity.ai' },
+  gemini: { ref: 'gemini', envVar: 'GEMINI_API_KEY', header: 'x-goog-api-key', scheme: '', host: 'generativelanguage.googleapis.com' },
+  cerebras: { ref: 'cerebras', envVar: 'CEREBRAS_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.cerebras.ai' },
+  groq: { ref: 'groq', envVar: 'GROQ_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.groq.com' },
+});
+
+/**
+ * HTTP-001. Hosts an autonomous run may reach WITHOUT a human approval gate: the
+ * curated model/search backends, loopback (local llama-server), and the
+ * llama.cpp release infrastructure the on-device installer pulls from. Everything
+ * else (user webhooks, arbitrary URLs a skill constructs) is non-allowlist and
+ * must pass the approval gate — matching today's webhook behaviour, generalised.
+ */
+export const EGRESS_ALLOWLIST: readonly string[] = Object.freeze([
+  'api.perplexity.ai',
+  'generativelanguage.googleapis.com',
+  'api.cerebras.ai',
+  'api.groq.com',
+  'api.github.com', // llama.cpp latest-release lookup
+  'objects.githubusercontent.com', // GitHub release asset CDN
+  'github.com', // GitHub release download redirects
+  '127.0.0.1', // loopback local LLM
+  'localhost',
+]);
+
+/** Loopback hosts are the only ones allowed over plain http. */
+export const LOOPBACK_HOSTS: readonly string[] = Object.freeze(['127.0.0.1', 'localhost']);
+
+/** Extract a lowercased hostname from a URL, or null if unparseable. */
+export function hostFromUrl(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function isLoopbackHost(host: string): boolean {
+  return LOOPBACK_HOSTS.includes(host);
+}
+
+export function isAllowlistedHost(host: string): boolean {
+  return EGRESS_ALLOWLIST.includes(host);
+}
+
+export type EgressDecision =
+  | 'allow' // allowlisted host (and, if a secret is spent, host matches its ref binding)
+  | 'approve' // non-allowlist host: human approval required, never auto
+  | 'deny'; // structurally forbidden (bad URL / secret bound to a different host)
+
+export type EgressSignal =
+  | 'non-allowlist-host' // destination is not on the egress allowlist
+  | 'secret-spend' // an auth_ref (secret) is being used on this request
+  | 'tainted' // this run consumed untrusted input (§4 taint tracking)
+  | 'ref-host-mismatch' // an auth_ref was spent against a host it is not bound to
+  | 'insecure-scheme'; // non-loopback plaintext / unparseable URL
+
+export interface EgressVerdict {
+  decision: EgressDecision;
+  reason: string;
+  signals: EgressSignal[];
+}
+
+/**
+ * CAP-001 §4.3 — the single structural rule that cuts the exfil trifecta:
+ *   a tainted run may not "spend a secret" or "send to a non-allowlist host"
+ *   without a human approval.
+ * We implement it as a classifier the broker consults before every egress:
+ *  - Unparseable URL, or non-loopback plaintext → deny.
+ *  - A secret (auth_ref) may only be spent against its bound host → else deny.
+ *    This is a HARD deny (not approve): a Perplexity key must never leave for any
+ *    host but api.perplexity.ai, regardless of what a human might click.
+ *  - Non-allowlist host → approve (human gate); loud when a secret or taint is
+ *    also present (the trifecta case).
+ *  - Allowlist host with no boundary signal → allow.
+ */
+export function classifyEgress(opts: {
+  url: string;
+  authRef?: string | null;
+  tainted?: boolean;
+}): EgressVerdict {
+  const signals: EgressSignal[] = [];
+  const host = hostFromUrl(opts.url);
+  const authRef = opts.authRef || null;
+  const tainted = opts.tainted === true;
+
+  let scheme: string | null = null;
+  try {
+    scheme = new URL(opts.url).protocol;
+  } catch {
+    scheme = null;
+  }
+
+  if (!host || scheme === null) {
+    return { decision: 'deny', reason: 'unparseable URL', signals: ['insecure-scheme'] };
+  }
+  // Only loopback may use plaintext http; every remote host must be https.
+  if (scheme !== 'https:' && !(scheme === 'http:' && isLoopbackHost(host))) {
+    return { decision: 'deny', reason: `insecure scheme ${scheme} for host ${host}`, signals: ['insecure-scheme'] };
+  }
+
+  if (authRef) {
+    signals.push('secret-spend');
+    const spec = AUTH_REFS[authRef];
+    if (!spec) {
+      return { decision: 'deny', reason: `unknown auth_ref "${authRef}"`, signals };
+    }
+    if (host !== spec.host) {
+      signals.push('ref-host-mismatch');
+      return {
+        decision: 'deny',
+        reason: `auth_ref "${authRef}" is bound to ${spec.host}, not ${host}`,
+        signals,
+      };
+    }
+  }
+  if (tainted) signals.push('tainted');
+
+  if (!isAllowlistedHost(host)) {
+    signals.push('non-allowlist-host');
+    return {
+      decision: 'approve',
+      reason: `host ${host} is not on the egress allowlist`,
+      signals,
+    };
+  }
+
+  return {
+    decision: 'allow',
+    reason: `host ${host} is allowlisted`,
+    signals,
+  };
+}
+
+/** CAP-001 budget — a run's egress is capped in both call count and wall time. */
+export interface EnvelopeBudget {
+  maxCalls: number;
+  maxWallMs: number;
+}
+
+export const DEFAULT_BUDGET: EnvelopeBudget = Object.freeze({
+  maxCalls: 40,
+  maxWallMs: 10 * 60 * 1000,
+});
+
+export interface BudgetState {
+  /** egress calls already made in this run (before the current one) */
+  calls: number;
+  /** epoch ms the run's envelope was opened */
+  startedAtMs: number;
+}
+
+export interface BudgetVerdict {
+  ok: boolean;
+  reason?: string;
+}
+
+/** Fail-closed budget check: the NEXT call is only allowed if it stays in-budget. */
+export function checkBudget(state: BudgetState, budget: EnvelopeBudget, nowMs: number): BudgetVerdict {
+  if (state.calls >= budget.maxCalls) {
+    return { ok: false, reason: `call budget exhausted (${state.calls}/${budget.maxCalls})` };
+  }
+  const elapsed = nowMs - state.startedAtMs;
+  if (elapsed >= budget.maxWallMs) {
+    return { ok: false, reason: `wall-time budget exhausted (${elapsed}ms/${budget.maxWallMs}ms)` };
+  }
+  return { ok: true };
+}
+
+/**
+ * CAP-001 redacted audit. One line per egress attempt. Never carries a secret
+ * value: only the auth_ref NAME, the host/path, and the verdict. `redactSecrets`
+ * is applied to free-text fields (reason, error) as defence-in-depth in case an
+ * upstream error body echoes a token.
+ */
+export interface EgressAuditEntry {
+  ts: string;
+  kind: 'http.request';
+  method: string;
+  host: string;
+  path: string;
+  authRef: string | null;
+  tainted: boolean;
+  decision: EgressDecision;
+  signals: EgressSignal[];
+  status?: number;
+  ok?: boolean;
+  reason?: string;
+}
+
+export function buildEgressAudit(opts: {
+  ts: string;
+  method: string;
+  url: string;
+  authRef?: string | null;
+  tainted?: boolean;
+  verdict: EgressVerdict;
+  status?: number;
+  ok?: boolean;
+}): EgressAuditEntry {
+  let host = '';
+  let path = '';
+  try {
+    const u = new URL(opts.url);
+    host = u.hostname.toLowerCase();
+    path = u.pathname; // query dropped on purpose (may carry a key, e.g. ?key=…)
+  } catch {
+    host = '<unparseable>';
+    path = '';
+  }
+  return {
+    ts: opts.ts,
+    kind: 'http.request',
+    method: (opts.method || 'GET').toUpperCase(),
+    host,
+    path,
+    authRef: opts.authRef || null,
+    tainted: opts.tainted === true,
+    decision: opts.verdict.decision,
+    signals: opts.verdict.signals,
+    status: opts.status,
+    ok: opts.ok,
+    reason: String(redactSecrets(opts.verdict.reason)),
+  };
+}

--- a/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+/*
+ * shelly-capability-broker.js — CAP-001 / SECRET-001 / HTTP-001 runtime broker.
+ *
+ * Phase 0 「床」of the L1/L2 Capability Catalog
+ * (docs/superpowers/specs/2026-07-01-l1-l2-capability-catalog.md). The generated
+ * agent .sh funnels every secret-bearing remote request through http_post_json;
+ * when SHELLY_CAP_BROKER=1 that function delegates the actual send to this broker
+ * instead of building `Authorization: Bearer $KEY` inline. The broker:
+ *   - HTTP-001: enforces the egress allowlist; a non-allowlist host is fail-closed
+ *     (blocked) unless --approved 1 was passed by an already-approved call site.
+ *   - SECRET-001: resolves an opaque --auth-ref to a real header by reading the
+ *     .env file ITSELF; the raw value never returns to the shell or rides in argv.
+ *     A ref is bound to one host, so a mis-routed URL cannot exfiltrate the key.
+ *   - CAP-001: enforces a per-run call/wall-time budget, and appends a REDACTED
+ *     audit line per attempt (host/path/ref-name/verdict/status — never the value).
+ *
+ * The classification constants below MIRROR lib/capability-envelope.ts; the
+ * capability-broker-parity test keeps them in lock-step (same pattern as the
+ * shelly-agent-driver asset parity guard).
+ *
+ * Exit codes (distinct from the http_post_json 0/22/23 contract this preserves):
+ *   0   success (HTTP <400)
+ *   22  permanent HTTP failure (4xx other than 429)
+ *   23  transient HTTP failure (429 / 5xx / network / timeout)
+ *   40  denied by policy (bad URL / secret bound to another host)
+ *   41  non-allowlist host requires approval (fail-closed; not pre-approved)
+ *   42  budget exhausted
+ *   43  auth_ref could not be resolved (missing/empty secret)
+ *   44  usage error
+ *   127 internal error
+ */
+
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+
+// ---------------------------------------------------------------------------
+// Mirror of lib/capability-envelope.ts — keep in sync (parity-tested).
+// ---------------------------------------------------------------------------
+
+const AUTH_REFS = {
+  perplexity: { envVar: 'PERPLEXITY_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.perplexity.ai' },
+  gemini: { envVar: 'GEMINI_API_KEY', header: 'x-goog-api-key', scheme: '', host: 'generativelanguage.googleapis.com' },
+  cerebras: { envVar: 'CEREBRAS_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.cerebras.ai' },
+  groq: { envVar: 'GROQ_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.groq.com' },
+};
+
+const EGRESS_ALLOWLIST = [
+  'api.perplexity.ai',
+  'generativelanguage.googleapis.com',
+  'api.cerebras.ai',
+  'api.groq.com',
+  'api.github.com',
+  'objects.githubusercontent.com',
+  'github.com',
+  '127.0.0.1',
+  'localhost',
+];
+
+const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost'];
+
+const DEFAULT_BUDGET = { maxCalls: 40, maxWallMs: 10 * 60 * 1000 };
+
+const EXIT = {
+  OK: 0,
+  HTTP_PERMANENT: 22,
+  HTTP_TRANSIENT: 23,
+  DENY: 40,
+  APPROVAL_REQUIRED: 41,
+  BUDGET: 42,
+  NO_SECRET: 43,
+  USAGE: 44,
+  INTERNAL: 127,
+};
+
+// Redaction for the free-text `reason`/error fields (defence-in-depth in case an
+// upstream error body echoes a token). Mirrors lib/redact-secrets.ts's shape.
+const REDACT_PATTERNS = [
+  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-proj-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bAIza[0-9A-Za-z_-]{25,}\b/g,
+  /\bgsk_[A-Za-z0-9_-]{20,}\b/g,
+  /\bcsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi,
+];
+
+function redact(text) {
+  let out = String(text == null ? '' : text);
+  for (const p of REDACT_PATTERNS) out = out.replace(p, '<redacted>');
+  return out;
+}
+
+function hostFromUrl(url) {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch (_) {
+    return null;
+  }
+}
+
+function isLoopbackHost(host) {
+  return LOOPBACK_HOSTS.indexOf(host) !== -1;
+}
+
+function isAllowlistedHost(host) {
+  return EGRESS_ALLOWLIST.indexOf(host) !== -1;
+}
+
+/**
+ * The CAP-001 §4.3 structural rule. Returns { decision, reason, signals }.
+ *   decision: 'allow' | 'approve' | 'deny'
+ */
+function classifyEgress(url, authRef, tainted) {
+  const signals = [];
+  const host = hostFromUrl(url);
+  let scheme = null;
+  try {
+    scheme = new URL(url).protocol;
+  } catch (_) {
+    scheme = null;
+  }
+  if (!host || scheme === null) {
+    return { decision: 'deny', reason: 'unparseable URL', signals: ['insecure-scheme'] };
+  }
+  if (scheme !== 'https:' && !(scheme === 'http:' && isLoopbackHost(host))) {
+    return { decision: 'deny', reason: 'insecure scheme ' + scheme + ' for host ' + host, signals: ['insecure-scheme'] };
+  }
+  if (authRef) {
+    signals.push('secret-spend');
+    const spec = AUTH_REFS[authRef];
+    if (!spec) {
+      return { decision: 'deny', reason: 'unknown auth_ref "' + authRef + '"', signals: signals };
+    }
+    if (host !== spec.host) {
+      signals.push('ref-host-mismatch');
+      return { decision: 'deny', reason: 'auth_ref "' + authRef + '" is bound to ' + spec.host + ', not ' + host, signals: signals };
+    }
+  }
+  if (tainted) signals.push('tainted');
+  if (!isAllowlistedHost(host)) {
+    signals.push('non-allowlist-host');
+    return { decision: 'approve', reason: 'host ' + host + ' is not on the egress allowlist', signals: signals };
+  }
+  return { decision: 'allow', reason: 'host ' + host + ' is allowlisted', signals: signals };
+}
+
+// ---------------------------------------------------------------------------
+// .env parsing (secret-by-reference resolution — SECRET-001)
+// ---------------------------------------------------------------------------
+
+// The agent .env is written by settings-store as KEY='value' (bash single-quoted,
+// with ' escaped as '\''), one per line, NOT exported. So a child node process
+// does not inherit these — the broker must read the file itself. That is the
+// point: the raw secret never becomes an environment variable a sibling skill can
+// read via /proc, and never rides in this process's argv.
+function parseEnvFile(filePath) {
+  const out = {};
+  let text;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch (_) {
+    return out;
+  }
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line || line[0] === '#') continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    let key = line.slice(0, eq).trim();
+    key = key.replace(/^export\s+/, '');
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    let val = line.slice(eq + 1).trim();
+    if (val.length >= 2 && val[0] === "'" && val[val.length - 1] === "'") {
+      val = val.slice(1, -1).replace(/'\\''/g, "'");
+    } else if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
+      val = val.slice(1, -1).replace(/\\(["\\])/g, '$1');
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Budget accounting (CAP-001)
+// ---------------------------------------------------------------------------
+
+function loadBudgetState(budgetFile, nowMs) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(budgetFile, 'utf8'));
+    if (parsed && typeof parsed.calls === 'number' && typeof parsed.startedAtMs === 'number') {
+      return { calls: parsed.calls, startedAtMs: parsed.startedAtMs };
+    }
+  } catch (_) {
+    /* first call / unreadable → fresh envelope */
+  }
+  return { calls: 0, startedAtMs: nowMs };
+}
+
+function saveBudgetState(budgetFile, state) {
+  try {
+    fs.writeFileSync(budgetFile, JSON.stringify(state));
+  } catch (_) {
+    /* best-effort; a lost counter fails safe on the next read (fresh, still capped) */
+  }
+}
+
+function checkBudget(state, budget, nowMs) {
+  if (state.calls >= budget.maxCalls) {
+    return { ok: false, reason: 'call budget exhausted (' + state.calls + '/' + budget.maxCalls + ')' };
+  }
+  const elapsed = nowMs - state.startedAtMs;
+  if (elapsed >= budget.maxWallMs) {
+    return { ok: false, reason: 'wall-time budget exhausted (' + elapsed + 'ms/' + budget.maxWallMs + 'ms)' };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Audit (CAP-001 redacted)
+// ---------------------------------------------------------------------------
+
+function appendAudit(auditFile, entry) {
+  if (!auditFile) return;
+  try {
+    fs.appendFileSync(auditFile, JSON.stringify(entry) + '\n');
+  } catch (_) {
+    /* best-effort */
+  }
+}
+
+function buildAudit(nowIso, method, url, authRef, tainted, verdict, extra) {
+  let host = '<unparseable>';
+  let path = '';
+  try {
+    const u = new URL(url);
+    host = u.hostname.toLowerCase();
+    path = u.pathname; // query dropped on purpose (may carry ?key=…)
+  } catch (_) {
+    /* keep placeholders */
+  }
+  const entry = {
+    ts: nowIso,
+    kind: 'http.request',
+    method: (method || 'GET').toUpperCase(),
+    host: host,
+    path: path,
+    authRef: authRef || null,
+    tainted: tainted === true,
+    decision: verdict.decision,
+    signals: verdict.signals,
+    reason: redact(verdict.reason),
+  };
+  if (extra) {
+    if (typeof extra.status === 'number') entry.status = extra.status;
+    if (typeof extra.ok === 'boolean') entry.ok = extra.ok;
+    if (extra.reason) entry.reason = redact(extra.reason);
+  }
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP send (mirrors the http_post_json node contract in agent-executor.ts)
+// ---------------------------------------------------------------------------
+
+function sendRequest(opts, cb) {
+  // opts: { method, url, bodyBuf, headers, timeoutSeconds, outFd, errFd }
+  let url;
+  try {
+    url = new URL(opts.url);
+  } catch (e) {
+    fs.writeSync(opts.errFd, 'invalid URL\n');
+    return cb(EXIT.INTERNAL);
+  }
+  const isHttps = url.protocol === 'https:';
+  const client = isHttps ? https : http;
+  const headers = Object.assign({}, opts.headers);
+  if (opts.bodyBuf) {
+    if (!headers['Content-Type']) headers['Content-Type'] = 'application/json';
+    headers['Content-Length'] = String(opts.bodyBuf.length);
+  }
+  const req = client.request(
+    {
+      method: opts.method,
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      headers: headers,
+    },
+    (res) => {
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        try {
+          fs.writeSync(opts.outFd, chunk);
+        } catch (_) {}
+      });
+      res.on('end', () => {
+        const code = res.statusCode || 0;
+        let exit;
+        if (code < 400) exit = EXIT.OK;
+        else if (code === 429 || code >= 500) exit = EXIT.HTTP_TRANSIENT;
+        else exit = EXIT.HTTP_PERMANENT;
+        cb(exit, code);
+      });
+    },
+  );
+  req.on('error', (err) => {
+    try {
+      fs.writeSync(opts.errFd, redact(err && err.message ? err.message : String(err)) + '\n');
+    } catch (_) {}
+    cb(EXIT.HTTP_TRANSIENT, 0);
+  });
+  const timeoutSeconds = Number(opts.timeoutSeconds || 0);
+  if (Number.isFinite(timeoutSeconds) && timeoutSeconds > 0) {
+    req.setTimeout(timeoutSeconds * 1000, () => {
+      req.destroy(new Error('request timed out'));
+    });
+  }
+  if (opts.bodyBuf) req.write(opts.bodyBuf);
+  req.end();
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a.slice(0, 2) === '--') {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.slice(0, 2) === '--') {
+        args[key] = '1';
+      } else {
+        args[key] = next;
+        i += 1;
+      }
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const method = (args.method || 'POST').toUpperCase();
+  const url = args.url || '';
+  const authRef = args['auth-ref'] || '';
+  const tainted = args.tainted === '1';
+  const approved = args.approved === '1';
+  const envFile = args['secret-env-file'] || '';
+  const auditFile = args['audit-log'] || '';
+  const budgetFile = args['budget-file'] || '';
+  const outFile = args.out || '';
+  const errFile = args.err || '';
+  const bodyFile = args['body-file'] || '';
+  const timeoutSeconds = args['timeout-seconds'] || '30';
+
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  if (!url || !outFile || !errFile) {
+    process.stderr.write('usage: --url <u> --out <f> --err <f> [--method] [--body-file] [--auth-ref] [--tainted 0|1] [--approved 0|1] [--secret-env-file] [--audit-log] [--budget-file] [--timeout-seconds]\n');
+    process.exit(EXIT.USAGE);
+  }
+
+  let outFd;
+  let errFd;
+  try {
+    outFd = fs.openSync(outFile, 'w');
+    errFd = fs.openSync(errFile, 'w');
+  } catch (e) {
+    process.stderr.write('cannot open out/err files\n');
+    process.exit(EXIT.INTERNAL);
+  }
+
+  const finish = (code, verdict, extra) => {
+    appendAudit(auditFile, buildAudit(nowIso, method, url, authRef, tainted, verdict, extra));
+    try {
+      fs.closeSync(outFd);
+    } catch (_) {}
+    try {
+      fs.closeSync(errFd);
+    } catch (_) {}
+    process.exit(code);
+  };
+
+  // 1. Structural classification.
+  const verdict = classifyEgress(url, authRef, tainted);
+  if (verdict.decision === 'deny') {
+    fs.writeSync(errFd, 'capability broker: ' + redact(verdict.reason) + '\n');
+    return finish(EXIT.DENY, verdict);
+  }
+  if (verdict.decision === 'approve' && !approved) {
+    // Fail-closed: a non-allowlist host is blocked unless the call site already
+    // obtained a human approval (the webhook action path does, and passes
+    // --approved 1). Interactive mid-run egress approval is a Phase-0 follow-up.
+    fs.writeSync(errFd, 'capability broker: ' + redact(verdict.reason) + ' (egress blocked — not approved)\n');
+    return finish(EXIT.APPROVAL_REQUIRED, verdict);
+  }
+
+  // 2. Budget (fail-closed).
+  const budgetState = loadBudgetState(budgetFile, nowMs);
+  const budgetVerdict = checkBudget(budgetState, DEFAULT_BUDGET, nowMs);
+  if (!budgetVerdict.ok) {
+    fs.writeSync(errFd, 'capability broker: ' + budgetVerdict.reason + '\n');
+    return finish(EXIT.BUDGET, verdict, { reason: budgetVerdict.reason });
+  }
+
+  // 3. Secret-by-reference resolution (inside the broker only).
+  const headers = {};
+  if (authRef) {
+    const spec = AUTH_REFS[authRef]; // classifyEgress already validated existence + host binding
+    const env = envFile ? parseEnvFile(envFile) : {};
+    const value = env[spec.envVar];
+    if (!value) {
+      const reason = 'auth_ref "' + authRef + '" has no configured secret (' + spec.envVar + ')';
+      fs.writeSync(errFd, 'capability broker: ' + reason + '\n');
+      return finish(EXIT.NO_SECRET, verdict, { reason: reason });
+    }
+    headers[spec.header] = spec.scheme + value;
+  }
+
+  // 4. Body (POST) and send.
+  let bodyBuf = null;
+  if (method !== 'GET' && bodyFile) {
+    try {
+      bodyBuf = fs.readFileSync(bodyFile);
+    } catch (e) {
+      fs.writeSync(errFd, 'capability broker: cannot read body file\n');
+      return finish(EXIT.INTERNAL, verdict);
+    }
+  }
+
+  // Count the call against the budget BEFORE sending (fail-closed: a crash mid-send
+  // still consumed the slot). NOTE: http_post_json_retry re-invokes the broker once
+  // per transient retry, so each retry counts as a separate egress here — intended,
+  // since a retry IS a real outbound request; the budget caps actual egress, not
+  // logical calls.
+  budgetState.calls += 1;
+  saveBudgetState(budgetFile, budgetState);
+
+  sendRequest(
+    {
+      method: method,
+      url: url,
+      bodyBuf: bodyBuf,
+      headers: headers,
+      timeoutSeconds: timeoutSeconds,
+      outFd: outFd,
+      errFd: errFd,
+    },
+    (code, status) => {
+      finish(code, verdict, { status: status, ok: code === EXIT.OK });
+    },
+  );
+}
+
+main();

--- a/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
@@ -115,6 +115,13 @@ function isAllowlistedHost(host) {
 /**
  * The CAP-001 §4.3 structural rule. Returns { decision, reason, signals }.
  *   decision: 'allow' | 'approve' | 'deny'
+ *
+ * Tainted input plus a live secret, even against an allowlisted and
+ * correctly-bound host, also requires approval: host-binding only guards
+ * WHERE a secret can go, not WHAT gets said with it — untrusted content could
+ * still direct the agent to spend a legitimate secret on an attacker-chosen
+ * payload at a legitimate destination (e.g. a poisoned notification tricking
+ * the agent into posting attacker text to our own Slack webhook).
  */
 function classifyEgress(url, authRef, tainted) {
   const signals = [];
@@ -146,6 +153,10 @@ function classifyEgress(url, authRef, tainted) {
   if (!isAllowlistedHost(host)) {
     signals.push('non-allowlist-host');
     return { decision: 'approve', reason: 'host ' + host + ' is not on the egress allowlist', signals: signals };
+  }
+  if (tainted && authRef) {
+    signals.push('tainted-secret-spend');
+    return { decision: 'approve', reason: 'tainted input plus a live secret "' + authRef + '" to ' + host + ' requires human approval', signals: signals };
   }
   return { decision: 'allow', reason: 'host ' + host + ' is allowlisted', signals: signals };
 }

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -28,7 +28,7 @@ data class AgentRunResult(
 object AgentRuntime {
     private const val TAG = "AgentRuntime"
     private const val DEFAULT_TIMEOUT_MS = 30 * 60 * 1000
-    private const val CURRENT_SCRIPT_VERSION = 8
+    private const val CURRENT_SCRIPT_VERSION = 9
 
     fun runAgent(context: Context, agentId: String): AgentRunResult {
         val appContext = context.applicationContext

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
@@ -1202,6 +1202,18 @@ patchCodex(libDir);
         } catch (e: Exception) {
             android.util.Log.e("HomeInitializer", "shelly-agent-driver.js extract failed: ${e.message}")
         }
+        // Phase 0 床: CAP-001/SECRET-001/HTTP-001 capability broker. Invoked via
+        // node from the agent .sh when SHELLY_CAP_BROKER=1; only needs to be
+        // readable, matching the gate/driver helpers above.
+        val capabilityBrokerScript = File(home, ".shelly-capability-broker.js")
+        try {
+            context.assets.open("shelly-capability-broker.js").use { input ->
+                capabilityBrokerScript.outputStream().use { output -> input.copyTo(output) }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("HomeInitializer", "shelly-capability-broker.js extract failed: ${e.message}")
+        }
+
         val agentEscalationDir = File(home, ".shelly/agents/escalations")
         agentEscalationDir.mkdirs()
         val agentEscalationReplyDir = File(context.noBackupFilesDir, "shelly-agent-escalation-replies")

--- a/scripts/shelly-capability-broker.js
+++ b/scripts/shelly-capability-broker.js
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+/*
+ * shelly-capability-broker.js — CAP-001 / SECRET-001 / HTTP-001 runtime broker.
+ *
+ * Phase 0 「床」of the L1/L2 Capability Catalog
+ * (docs/superpowers/specs/2026-07-01-l1-l2-capability-catalog.md). The generated
+ * agent .sh funnels every secret-bearing remote request through http_post_json;
+ * when SHELLY_CAP_BROKER=1 that function delegates the actual send to this broker
+ * instead of building `Authorization: Bearer $KEY` inline. The broker:
+ *   - HTTP-001: enforces the egress allowlist; a non-allowlist host is fail-closed
+ *     (blocked) unless --approved 1 was passed by an already-approved call site.
+ *   - SECRET-001: resolves an opaque --auth-ref to a real header by reading the
+ *     .env file ITSELF; the raw value never returns to the shell or rides in argv.
+ *     A ref is bound to one host, so a mis-routed URL cannot exfiltrate the key.
+ *   - CAP-001: enforces a per-run call/wall-time budget, and appends a REDACTED
+ *     audit line per attempt (host/path/ref-name/verdict/status — never the value).
+ *
+ * The classification constants below MIRROR lib/capability-envelope.ts; the
+ * capability-broker-parity test keeps them in lock-step (same pattern as the
+ * shelly-agent-driver asset parity guard).
+ *
+ * Exit codes (distinct from the http_post_json 0/22/23 contract this preserves):
+ *   0   success (HTTP <400)
+ *   22  permanent HTTP failure (4xx other than 429)
+ *   23  transient HTTP failure (429 / 5xx / network / timeout)
+ *   40  denied by policy (bad URL / secret bound to another host)
+ *   41  non-allowlist host requires approval (fail-closed; not pre-approved)
+ *   42  budget exhausted
+ *   43  auth_ref could not be resolved (missing/empty secret)
+ *   44  usage error
+ *   127 internal error
+ */
+
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+
+// ---------------------------------------------------------------------------
+// Mirror of lib/capability-envelope.ts — keep in sync (parity-tested).
+// ---------------------------------------------------------------------------
+
+const AUTH_REFS = {
+  perplexity: { envVar: 'PERPLEXITY_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.perplexity.ai' },
+  gemini: { envVar: 'GEMINI_API_KEY', header: 'x-goog-api-key', scheme: '', host: 'generativelanguage.googleapis.com' },
+  cerebras: { envVar: 'CEREBRAS_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.cerebras.ai' },
+  groq: { envVar: 'GROQ_API_KEY', header: 'Authorization', scheme: 'Bearer ', host: 'api.groq.com' },
+};
+
+const EGRESS_ALLOWLIST = [
+  'api.perplexity.ai',
+  'generativelanguage.googleapis.com',
+  'api.cerebras.ai',
+  'api.groq.com',
+  'api.github.com',
+  'objects.githubusercontent.com',
+  'github.com',
+  '127.0.0.1',
+  'localhost',
+];
+
+const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost'];
+
+const DEFAULT_BUDGET = { maxCalls: 40, maxWallMs: 10 * 60 * 1000 };
+
+const EXIT = {
+  OK: 0,
+  HTTP_PERMANENT: 22,
+  HTTP_TRANSIENT: 23,
+  DENY: 40,
+  APPROVAL_REQUIRED: 41,
+  BUDGET: 42,
+  NO_SECRET: 43,
+  USAGE: 44,
+  INTERNAL: 127,
+};
+
+// Redaction for the free-text `reason`/error fields (defence-in-depth in case an
+// upstream error body echoes a token). Mirrors lib/redact-secrets.ts's shape.
+const REDACT_PATTERNS = [
+  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-proj-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bAIza[0-9A-Za-z_-]{25,}\b/g,
+  /\bgsk_[A-Za-z0-9_-]{20,}\b/g,
+  /\bcsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi,
+];
+
+function redact(text) {
+  let out = String(text == null ? '' : text);
+  for (const p of REDACT_PATTERNS) out = out.replace(p, '<redacted>');
+  return out;
+}
+
+function hostFromUrl(url) {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch (_) {
+    return null;
+  }
+}
+
+function isLoopbackHost(host) {
+  return LOOPBACK_HOSTS.indexOf(host) !== -1;
+}
+
+function isAllowlistedHost(host) {
+  return EGRESS_ALLOWLIST.indexOf(host) !== -1;
+}
+
+/**
+ * The CAP-001 §4.3 structural rule. Returns { decision, reason, signals }.
+ *   decision: 'allow' | 'approve' | 'deny'
+ */
+function classifyEgress(url, authRef, tainted) {
+  const signals = [];
+  const host = hostFromUrl(url);
+  let scheme = null;
+  try {
+    scheme = new URL(url).protocol;
+  } catch (_) {
+    scheme = null;
+  }
+  if (!host || scheme === null) {
+    return { decision: 'deny', reason: 'unparseable URL', signals: ['insecure-scheme'] };
+  }
+  if (scheme !== 'https:' && !(scheme === 'http:' && isLoopbackHost(host))) {
+    return { decision: 'deny', reason: 'insecure scheme ' + scheme + ' for host ' + host, signals: ['insecure-scheme'] };
+  }
+  if (authRef) {
+    signals.push('secret-spend');
+    const spec = AUTH_REFS[authRef];
+    if (!spec) {
+      return { decision: 'deny', reason: 'unknown auth_ref "' + authRef + '"', signals: signals };
+    }
+    if (host !== spec.host) {
+      signals.push('ref-host-mismatch');
+      return { decision: 'deny', reason: 'auth_ref "' + authRef + '" is bound to ' + spec.host + ', not ' + host, signals: signals };
+    }
+  }
+  if (tainted) signals.push('tainted');
+  if (!isAllowlistedHost(host)) {
+    signals.push('non-allowlist-host');
+    return { decision: 'approve', reason: 'host ' + host + ' is not on the egress allowlist', signals: signals };
+  }
+  return { decision: 'allow', reason: 'host ' + host + ' is allowlisted', signals: signals };
+}
+
+// ---------------------------------------------------------------------------
+// .env parsing (secret-by-reference resolution — SECRET-001)
+// ---------------------------------------------------------------------------
+
+// The agent .env is written by settings-store as KEY='value' (bash single-quoted,
+// with ' escaped as '\''), one per line, NOT exported. So a child node process
+// does not inherit these — the broker must read the file itself. That is the
+// point: the raw secret never becomes an environment variable a sibling skill can
+// read via /proc, and never rides in this process's argv.
+function parseEnvFile(filePath) {
+  const out = {};
+  let text;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch (_) {
+    return out;
+  }
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line || line[0] === '#') continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    let key = line.slice(0, eq).trim();
+    key = key.replace(/^export\s+/, '');
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    let val = line.slice(eq + 1).trim();
+    if (val.length >= 2 && val[0] === "'" && val[val.length - 1] === "'") {
+      val = val.slice(1, -1).replace(/'\\''/g, "'");
+    } else if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
+      val = val.slice(1, -1).replace(/\\(["\\])/g, '$1');
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Budget accounting (CAP-001)
+// ---------------------------------------------------------------------------
+
+function loadBudgetState(budgetFile, nowMs) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(budgetFile, 'utf8'));
+    if (parsed && typeof parsed.calls === 'number' && typeof parsed.startedAtMs === 'number') {
+      return { calls: parsed.calls, startedAtMs: parsed.startedAtMs };
+    }
+  } catch (_) {
+    /* first call / unreadable → fresh envelope */
+  }
+  return { calls: 0, startedAtMs: nowMs };
+}
+
+function saveBudgetState(budgetFile, state) {
+  try {
+    fs.writeFileSync(budgetFile, JSON.stringify(state));
+  } catch (_) {
+    /* best-effort; a lost counter fails safe on the next read (fresh, still capped) */
+  }
+}
+
+function checkBudget(state, budget, nowMs) {
+  if (state.calls >= budget.maxCalls) {
+    return { ok: false, reason: 'call budget exhausted (' + state.calls + '/' + budget.maxCalls + ')' };
+  }
+  const elapsed = nowMs - state.startedAtMs;
+  if (elapsed >= budget.maxWallMs) {
+    return { ok: false, reason: 'wall-time budget exhausted (' + elapsed + 'ms/' + budget.maxWallMs + 'ms)' };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Audit (CAP-001 redacted)
+// ---------------------------------------------------------------------------
+
+function appendAudit(auditFile, entry) {
+  if (!auditFile) return;
+  try {
+    fs.appendFileSync(auditFile, JSON.stringify(entry) + '\n');
+  } catch (_) {
+    /* best-effort */
+  }
+}
+
+function buildAudit(nowIso, method, url, authRef, tainted, verdict, extra) {
+  let host = '<unparseable>';
+  let path = '';
+  try {
+    const u = new URL(url);
+    host = u.hostname.toLowerCase();
+    path = u.pathname; // query dropped on purpose (may carry ?key=…)
+  } catch (_) {
+    /* keep placeholders */
+  }
+  const entry = {
+    ts: nowIso,
+    kind: 'http.request',
+    method: (method || 'GET').toUpperCase(),
+    host: host,
+    path: path,
+    authRef: authRef || null,
+    tainted: tainted === true,
+    decision: verdict.decision,
+    signals: verdict.signals,
+    reason: redact(verdict.reason),
+  };
+  if (extra) {
+    if (typeof extra.status === 'number') entry.status = extra.status;
+    if (typeof extra.ok === 'boolean') entry.ok = extra.ok;
+    if (extra.reason) entry.reason = redact(extra.reason);
+  }
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP send (mirrors the http_post_json node contract in agent-executor.ts)
+// ---------------------------------------------------------------------------
+
+function sendRequest(opts, cb) {
+  // opts: { method, url, bodyBuf, headers, timeoutSeconds, outFd, errFd }
+  let url;
+  try {
+    url = new URL(opts.url);
+  } catch (e) {
+    fs.writeSync(opts.errFd, 'invalid URL\n');
+    return cb(EXIT.INTERNAL);
+  }
+  const isHttps = url.protocol === 'https:';
+  const client = isHttps ? https : http;
+  const headers = Object.assign({}, opts.headers);
+  if (opts.bodyBuf) {
+    if (!headers['Content-Type']) headers['Content-Type'] = 'application/json';
+    headers['Content-Length'] = String(opts.bodyBuf.length);
+  }
+  const req = client.request(
+    {
+      method: opts.method,
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      headers: headers,
+    },
+    (res) => {
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        try {
+          fs.writeSync(opts.outFd, chunk);
+        } catch (_) {}
+      });
+      res.on('end', () => {
+        const code = res.statusCode || 0;
+        let exit;
+        if (code < 400) exit = EXIT.OK;
+        else if (code === 429 || code >= 500) exit = EXIT.HTTP_TRANSIENT;
+        else exit = EXIT.HTTP_PERMANENT;
+        cb(exit, code);
+      });
+    },
+  );
+  req.on('error', (err) => {
+    try {
+      fs.writeSync(opts.errFd, redact(err && err.message ? err.message : String(err)) + '\n');
+    } catch (_) {}
+    cb(EXIT.HTTP_TRANSIENT, 0);
+  });
+  const timeoutSeconds = Number(opts.timeoutSeconds || 0);
+  if (Number.isFinite(timeoutSeconds) && timeoutSeconds > 0) {
+    req.setTimeout(timeoutSeconds * 1000, () => {
+      req.destroy(new Error('request timed out'));
+    });
+  }
+  if (opts.bodyBuf) req.write(opts.bodyBuf);
+  req.end();
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a.slice(0, 2) === '--') {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.slice(0, 2) === '--') {
+        args[key] = '1';
+      } else {
+        args[key] = next;
+        i += 1;
+      }
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const method = (args.method || 'POST').toUpperCase();
+  const url = args.url || '';
+  const authRef = args['auth-ref'] || '';
+  const tainted = args.tainted === '1';
+  const approved = args.approved === '1';
+  const envFile = args['secret-env-file'] || '';
+  const auditFile = args['audit-log'] || '';
+  const budgetFile = args['budget-file'] || '';
+  const outFile = args.out || '';
+  const errFile = args.err || '';
+  const bodyFile = args['body-file'] || '';
+  const timeoutSeconds = args['timeout-seconds'] || '30';
+
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  if (!url || !outFile || !errFile) {
+    process.stderr.write('usage: --url <u> --out <f> --err <f> [--method] [--body-file] [--auth-ref] [--tainted 0|1] [--approved 0|1] [--secret-env-file] [--audit-log] [--budget-file] [--timeout-seconds]\n');
+    process.exit(EXIT.USAGE);
+  }
+
+  let outFd;
+  let errFd;
+  try {
+    outFd = fs.openSync(outFile, 'w');
+    errFd = fs.openSync(errFile, 'w');
+  } catch (e) {
+    process.stderr.write('cannot open out/err files\n');
+    process.exit(EXIT.INTERNAL);
+  }
+
+  const finish = (code, verdict, extra) => {
+    appendAudit(auditFile, buildAudit(nowIso, method, url, authRef, tainted, verdict, extra));
+    try {
+      fs.closeSync(outFd);
+    } catch (_) {}
+    try {
+      fs.closeSync(errFd);
+    } catch (_) {}
+    process.exit(code);
+  };
+
+  // 1. Structural classification.
+  const verdict = classifyEgress(url, authRef, tainted);
+  if (verdict.decision === 'deny') {
+    fs.writeSync(errFd, 'capability broker: ' + redact(verdict.reason) + '\n');
+    return finish(EXIT.DENY, verdict);
+  }
+  if (verdict.decision === 'approve' && !approved) {
+    // Fail-closed: a non-allowlist host is blocked unless the call site already
+    // obtained a human approval (the webhook action path does, and passes
+    // --approved 1). Interactive mid-run egress approval is a Phase-0 follow-up.
+    fs.writeSync(errFd, 'capability broker: ' + redact(verdict.reason) + ' (egress blocked — not approved)\n');
+    return finish(EXIT.APPROVAL_REQUIRED, verdict);
+  }
+
+  // 2. Budget (fail-closed).
+  const budgetState = loadBudgetState(budgetFile, nowMs);
+  const budgetVerdict = checkBudget(budgetState, DEFAULT_BUDGET, nowMs);
+  if (!budgetVerdict.ok) {
+    fs.writeSync(errFd, 'capability broker: ' + budgetVerdict.reason + '\n');
+    return finish(EXIT.BUDGET, verdict, { reason: budgetVerdict.reason });
+  }
+
+  // 3. Secret-by-reference resolution (inside the broker only).
+  const headers = {};
+  if (authRef) {
+    const spec = AUTH_REFS[authRef]; // classifyEgress already validated existence + host binding
+    const env = envFile ? parseEnvFile(envFile) : {};
+    const value = env[spec.envVar];
+    if (!value) {
+      const reason = 'auth_ref "' + authRef + '" has no configured secret (' + spec.envVar + ')';
+      fs.writeSync(errFd, 'capability broker: ' + reason + '\n');
+      return finish(EXIT.NO_SECRET, verdict, { reason: reason });
+    }
+    headers[spec.header] = spec.scheme + value;
+  }
+
+  // 4. Body (POST) and send.
+  let bodyBuf = null;
+  if (method !== 'GET' && bodyFile) {
+    try {
+      bodyBuf = fs.readFileSync(bodyFile);
+    } catch (e) {
+      fs.writeSync(errFd, 'capability broker: cannot read body file\n');
+      return finish(EXIT.INTERNAL, verdict);
+    }
+  }
+
+  // Count the call against the budget BEFORE sending (fail-closed: a crash mid-send
+  // still consumed the slot). NOTE: http_post_json_retry re-invokes the broker once
+  // per transient retry, so each retry counts as a separate egress here — intended,
+  // since a retry IS a real outbound request; the budget caps actual egress, not
+  // logical calls.
+  budgetState.calls += 1;
+  saveBudgetState(budgetFile, budgetState);
+
+  sendRequest(
+    {
+      method: method,
+      url: url,
+      bodyBuf: bodyBuf,
+      headers: headers,
+      timeoutSeconds: timeoutSeconds,
+      outFd: outFd,
+      errFd: errFd,
+    },
+    (code, status) => {
+      finish(code, verdict, { status: status, ok: code === EXIT.OK });
+    },
+  );
+}
+
+main();

--- a/scripts/shelly-capability-broker.js
+++ b/scripts/shelly-capability-broker.js
@@ -115,6 +115,13 @@ function isAllowlistedHost(host) {
 /**
  * The CAP-001 §4.3 structural rule. Returns { decision, reason, signals }.
  *   decision: 'allow' | 'approve' | 'deny'
+ *
+ * Tainted input plus a live secret, even against an allowlisted and
+ * correctly-bound host, also requires approval: host-binding only guards
+ * WHERE a secret can go, not WHAT gets said with it — untrusted content could
+ * still direct the agent to spend a legitimate secret on an attacker-chosen
+ * payload at a legitimate destination (e.g. a poisoned notification tricking
+ * the agent into posting attacker text to our own Slack webhook).
  */
 function classifyEgress(url, authRef, tainted) {
   const signals = [];
@@ -146,6 +153,10 @@ function classifyEgress(url, authRef, tainted) {
   if (!isAllowlistedHost(host)) {
     signals.push('non-allowlist-host');
     return { decision: 'approve', reason: 'host ' + host + ' is not on the egress allowlist', signals: signals };
+  }
+  if (tainted && authRef) {
+    signals.push('tainted-secret-spend');
+    return { decision: 'approve', reason: 'tainted input plus a live secret "' + authRef + '" to ' + host + ' requires human approval', signals: signals };
   }
   return { decision: 'allow', reason: 'host ' + host + ' is allowlisted', signals: signals };
 }


### PR DESCRIPTION
## Summary

Ports the dormant Phase 0 capability-broker foundation from `claude/work-handoff-2qb1xd` onto `main`:

- CAP-001 capability envelope: egress classification, host-bound auth refs, budgets/loop limits, taint signals, and redacted audit records
- SECRET-001 partial secret-by-reference path: the broker resolves built-in API credentials from `.env`, keeping raw credentials out of request argv and child environment
- HTTP-001 strangler seam: `http_post_json` routes through the broker only when `SHELLY_CAP_BROKER=1`
- fail-closed behavior when broker mode is requested but unavailable
- the follow-up security fix requiring approval for tainted + secret-bearing requests even to correctly bound allowlisted hosts

The feature remains **OFF by default**. With no `SHELLY_CAP_BROKER=1`, the existing production request path is preserved.

## Scoping decision

This PR deliberately ports `996f2d73` and the mandatory security correction `2ef428ad`, but not `690b7303`.

The first two commits are a self-contained foundation: new envelope/broker files, focused tests, one egress choke-point hookup, asset extraction, and a generated-script version gate. `690b7303` is an independent custom-secret product extension adding SecureStore APIs, settings-store mutations, types, i18n, and a settings UI. It is not required by any built-in broker route and touches shared files that have diverged through SKILL-001 and several unrelated UI/settings changes. Keeping it for a separate reviewed batch makes this PR materially easier to audit and avoids mixing the security substrate with a new registration UI.

## Conflict resolution

- Rebasing dev's generated script version `10 -> 11` onto main's current version changed main `8 -> 9`; TypeScript, native gate, and tests remain in lockstep.
- Kept main's existing `DEFERRED.md` history instead of importing the dev branch's larger capability-catalog context; added only the broker-specific state and follow-ups relevant to this port.
- Preserved main's unrelated executor behavior while applying only the CAP/SECRET/HTTP seam hunks.
- Added a small follow-up test commit to align the cherry-picked wiring assertion with main's version `9`.

## Verification

- `corepack pnpm run check` — PASS
- `pnpm run lint` (via a temporary Corepack shim because standalone `pnpm` is not on PATH) — PASS, 0 errors; 2 pre-existing warnings in `ScouterDetailModal.tsx`
- Broker-focused Jest suites — PASS: 4 suites, 38 tests
  - `capability-envelope.test.ts`
  - `capability-broker.test.ts`
  - `capability-broker-parity.test.ts`
  - `agent-executor-cap-broker.test.ts`
- `node --check` for both broker script copies — PASS
- script/Android asset SHA parity — PASS
- `git diff --check` — PASS

The broader `agent-executor-autonomous.test.ts` run reached 94 passing assertions but has 4 known Windows-only `spawnSync bash ENAMETOOLONG` failures from passing the generated shell through `bash -n -c`; these are environment command-line length failures, not broker assertion failures.

## Deferred follow-up

- Port user-registered custom secrets (`690b7303`) as its own settings/UI-focused batch.
- Complete `.env` de-source, nonce/host-bound interactive approval, policy-deny diagnostics, and opt-in device E2E verification as tracked in `DEFERRED.md`.

Do not merge until independent CC review is complete.