### PR TITLE
feat(event-queue): port EVENT-001 durable queue core

### DIFF
--- a/__tests__/event-queue/at-least-once.test.ts
+++ b/__tests__/event-queue/at-least-once.test.ts
@@ -1,0 +1,59 @@
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { InMemoryQueueStorage } from '@/lib/event-queue/storage-memory';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+
+describe('EventQueue at-least-once', () => {
+  it('redelivers after lease expiry and ignores the stale ack', async () => {
+    const clock = new FakeClock(1000);
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock,
+      idGen: new SeqIdGen(),
+      defaults: { leaseMs: 5000 },
+    });
+    await q.load();
+    await q.enqueue({ topic: 't', source: 'manual', payload: { v: 42 } });
+
+    const first = await q.lease();
+    expect(first).toHaveLength(1);
+    const firstLease = first[0].leaseId!;
+    expect(first[0].attempts).toBe(1);
+
+    // Worker stalls past the lease; sweep on the next lease reclaims it.
+    clock.advance(5001);
+    const second = await q.lease();
+    expect(second).toHaveLength(1);
+    expect(second[0].payload).toEqual({ v: 42 });
+    expect(second[0].attempts).toBe(2);
+    expect(second[0].leaseId).not.toBe(firstLease);
+
+    // The stale worker finally acks with the OLD leaseId — must be a no-op.
+    await q.ack(second[0].id, firstLease);
+    expect(q.peek({ state: 'leased' })).toHaveLength(1);
+
+    // The live worker acks correctly.
+    await q.ack(second[0].id, second[0].leaseId!);
+    expect(q.peek()).toHaveLength(0);
+  });
+
+  it('dead-letters a record whose lease keeps expiring past maxAttempts', async () => {
+    const clock = new FakeClock(1000);
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock,
+      idGen: new SeqIdGen(),
+      defaults: { leaseMs: 1000, maxAttempts: 2 },
+    });
+    await q.load();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+
+    await q.lease(); // attempts=1
+    clock.advance(1001);
+    await q.lease(); // attempts=2
+    clock.advance(1001);
+    // sweep sees attempts>=maxAttempts → dead, not redelivered.
+    const again = await q.lease();
+    expect(again).toHaveLength(0);
+    expect(q.stats().dead).toBe(1);
+  });
+});

--- a/__tests__/event-queue/backoff.test.ts
+++ b/__tests__/event-queue/backoff.test.ts
@@ -1,0 +1,43 @@
+import { computeBackoffMs, nextVisibleAt } from '@/lib/event-queue/backoff';
+import { RetryPolicy } from '@/lib/event-queue/types';
+
+const policy: RetryPolicy = { baseMs: 1000, factor: 2, maxMs: 10000, jitter: false };
+
+describe('computeBackoffMs', () => {
+  it('is exponential from the first retry and caps at maxMs', () => {
+    expect(computeBackoffMs(1, policy)).toBe(1000);
+    expect(computeBackoffMs(2, policy)).toBe(2000);
+    expect(computeBackoffMs(3, policy)).toBe(4000);
+    expect(computeBackoffMs(4, policy)).toBe(8000);
+    expect(computeBackoffMs(5, policy)).toBe(10000); // capped
+    expect(computeBackoffMs(50, policy)).toBe(10000);
+  });
+
+  it('treats attempts<=1 as the base delay', () => {
+    expect(computeBackoffMs(0, policy)).toBe(1000);
+    expect(computeBackoffMs(1, policy)).toBe(1000);
+  });
+
+  it('applies deterministic jitter only when enabled and rng provided', () => {
+    const jittered: RetryPolicy = { ...policy, jitter: true };
+    // rng=1 → +50% of the raw delay (here raw==base, below the cap)
+    expect(computeBackoffMs(1, jittered, () => 1)).toBe(1500);
+    // no rng → no jitter even if the policy asks for it
+    expect(computeBackoffMs(1, jittered)).toBe(1000);
+    // jitter never applied when policy.jitter is false
+    expect(computeBackoffMs(1, policy, () => 1)).toBe(1000);
+  });
+
+  it('keeps maxMs a hard ceiling even with jitter (cap applied after jitter)', () => {
+    const jittered: RetryPolicy = { ...policy, jitter: true };
+    // attempts=5 → raw 16000, jittered ×1.5 = 24000, but must clamp to maxMs.
+    expect(computeBackoffMs(5, jittered, () => 1)).toBe(policy.maxMs);
+    expect(computeBackoffMs(50, jittered, () => 1)).toBe(policy.maxMs);
+  });
+});
+
+describe('nextVisibleAt', () => {
+  it('adds the backoff to now', () => {
+    expect(nextVisibleAt(5000, 2, policy)).toBe(5000 + 2000);
+  });
+});

--- a/__tests__/event-queue/crash-recovery.test.ts
+++ b/__tests__/event-queue/crash-recovery.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { JsonFileQueueStorage } from '@/lib/event-queue/storage-json';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+import { makeNodeFsPort, makeTmpDir } from '../support/node-fs-port';
+
+describe('EventQueue crash recovery (JSON durable backend)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = path.join(makeTmpDir(), 'event-queue');
+  });
+  afterEach(() => {
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  });
+
+  it('redelivers a leased record from disk after a simulated crash', async () => {
+    const clock = new FakeClock(1000);
+    const fsPort = makeNodeFsPort();
+
+    // Instance A: enqueue + lease, then "crash" (discard A without ack).
+    const a = new EventQueue({
+      adapter: new JsonFileQueueStorage(fsPort, dir),
+      clock,
+      idGen: new SeqIdGen('a'),
+      defaults: { leaseMs: 5000 },
+    });
+    await a.load();
+    await a.enqueue({ topic: 't', source: 'schedule', payload: { v: 7 } });
+    const leased = await a.lease();
+    expect(leased).toHaveLength(1);
+
+    // Instance B over the SAME directory, after the lease would have expired.
+    clock.advance(5001);
+    const b = new EventQueue({
+      adapter: new JsonFileQueueStorage(fsPort, dir),
+      clock,
+      idGen: new SeqIdGen('b'),
+      defaults: { leaseMs: 5000 },
+    });
+    await b.load(); // sweeps the expired lease back to ready
+    const redelivered = await b.lease();
+    expect(redelivered).toHaveLength(1);
+    expect(redelivered[0].payload).toEqual({ v: 7 });
+    expect(redelivered[0].attempts).toBe(2);
+
+    await b.ack(redelivered[0].id, redelivered[0].leaseId!);
+    expect(b.peek()).toHaveLength(0);
+    // Disk is drained too.
+    const remaining = new EventQueue({
+      adapter: new JsonFileQueueStorage(fsPort, dir),
+      clock,
+      idGen: new SeqIdGen('c'),
+    });
+    await remaining.load();
+    expect(remaining.peek()).toHaveLength(0);
+  });
+});

--- a/__tests__/event-queue/dedup.test.ts
+++ b/__tests__/event-queue/dedup.test.ts
@@ -1,0 +1,44 @@
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { InMemoryQueueStorage } from '@/lib/event-queue/storage-memory';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+
+async function makeQueue() {
+  const q = new EventQueue({
+    adapter: new InMemoryQueueStorage(),
+    clock: new FakeClock(1000),
+    idGen: new SeqIdGen(),
+  });
+  await q.load();
+  return q;
+}
+
+describe('EventQueue dedup', () => {
+  it('drops a duplicate dedupKey while the record is pending', async () => {
+    const q = await makeQueue();
+    const a = await q.enqueue({ topic: 't', source: 'schedule', payload: 1, dedupKey: 'k' });
+    const b = await q.enqueue({ topic: 't', source: 'schedule', payload: 2, dedupKey: 'k' });
+    expect(a).toEqual({ id: 'id-1', deduped: false });
+    expect(b).toEqual({ id: 'id-1', deduped: true });
+    expect(q.peek()).toHaveLength(1);
+  });
+
+  it('dedups against a leased (in-flight) record too', async () => {
+    const q = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'schedule', payload: 1, dedupKey: 'k' });
+    const leased = await q.lease();
+    expect(leased).toHaveLength(1);
+    const b = await q.enqueue({ topic: 't', source: 'schedule', payload: 2, dedupKey: 'k' });
+    expect(b.deduped).toBe(true);
+    expect(q.peek()).toHaveLength(1);
+  });
+
+  it('frees the key once the record is ack’d', async () => {
+    const q = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'schedule', payload: 1, dedupKey: 'k' });
+    const [rec] = await q.lease();
+    await q.ack(rec.id, rec.leaseId!);
+    const b = await q.enqueue({ topic: 't', source: 'schedule', payload: 2, dedupKey: 'k' });
+    expect(b.deduped).toBe(false);
+    expect(b.id).not.toBe(rec.id);
+  });
+});

--- a/__tests__/event-queue/enqueue.test.ts
+++ b/__tests__/event-queue/enqueue.test.ts
@@ -1,0 +1,50 @@
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { InMemoryQueueStorage } from '@/lib/event-queue/storage-memory';
+import { EVENT_QUEUE_SCHEMA_VERSION } from '@/lib/event-queue/types';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+
+async function makeQueue() {
+  const clock = new FakeClock(1000);
+  const q = new EventQueue({
+    adapter: new InMemoryQueueStorage(),
+    clock,
+    idGen: new SeqIdGen(),
+  });
+  await q.load();
+  return { q, clock };
+}
+
+describe('EventQueue.enqueue', () => {
+  it('creates a ready record with generated id and opaque payload', async () => {
+    const { q } = await makeQueue();
+    const res = await q.enqueue({ topic: 'agent.run', source: 'schedule', payload: { a: 1 } });
+    expect(res).toEqual({ id: 'id-1', deduped: false });
+
+    const [rec] = q.peek();
+    expect(rec.id).toBe('id-1');
+    expect(rec.state).toBe('ready');
+    expect(rec.attempts).toBe(0);
+    expect(rec.schemaVersion).toBe(EVENT_QUEUE_SCHEMA_VERSION);
+    expect(rec.payload).toEqual({ a: 1 });
+    expect(rec.visibleAt).toBe(1000);
+    expect(rec.enqueuedAt).toBe(1000);
+  });
+
+  it('honors delayMs by pushing visibleAt forward', async () => {
+    const { q } = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'manual', payload: {}, delayMs: 5000 });
+    const [rec] = q.peek();
+    expect(rec.visibleAt).toBe(6000);
+  });
+
+  it('requires load() before use', async () => {
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock: new FakeClock(),
+      idGen: new SeqIdGen(),
+    });
+    await expect(q.enqueue({ topic: 't', source: 'manual', payload: {} })).rejects.toThrow(
+      /load\(\) must be awaited/,
+    );
+  });
+});

--- a/__tests__/event-queue/lease-ack.test.ts
+++ b/__tests__/event-queue/lease-ack.test.ts
@@ -1,0 +1,58 @@
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { InMemoryQueueStorage } from '@/lib/event-queue/storage-memory';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+
+async function makeQueue() {
+  const clock = new FakeClock(1000);
+  const q = new EventQueue({
+    adapter: new InMemoryQueueStorage(),
+    clock,
+    idGen: new SeqIdGen(),
+    defaults: { leaseMs: 30000 },
+  });
+  await q.load();
+  return { q, clock };
+}
+
+describe('EventQueue lease/ack', () => {
+  it('leases the visible record, marks it leased, and ack removes it', async () => {
+    const { q, clock } = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+
+    const leased = await q.lease();
+    expect(leased).toHaveLength(1);
+    const rec = leased[0];
+    expect(rec.state).toBe('leased');
+    expect(rec.leaseId).toBeTruthy();
+    expect(rec.leaseExpiresAt).toBe(clock.now() + 30000);
+    expect(rec.attempts).toBe(1);
+
+    // A second lease before ack returns nothing (already leased).
+    expect(await q.lease()).toHaveLength(0);
+
+    await q.ack(rec.id, rec.leaseId!);
+    expect(q.peek()).toHaveLength(0);
+    expect(await q.lease()).toHaveLength(0);
+  });
+
+  it('respects max and topic filter and FIFO order', async () => {
+    const { q } = await makeQueue();
+    await q.enqueue({ topic: 'a', source: 'manual', payload: 1 });
+    await q.enqueue({ topic: 'b', source: 'manual', payload: 2 });
+    await q.enqueue({ topic: 'a', source: 'manual', payload: 3 });
+
+    const onlyA = await q.lease({ topic: 'a', max: 5 });
+    expect(onlyA.map((r) => r.payload)).toEqual([1, 3]);
+  });
+
+  it('ignores ack with a non-matching leaseId', async () => {
+    const { q } = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+    const [rec] = await q.lease();
+    await q.ack(rec.id, 'wrong-lease');
+    expect(q.peek()).toHaveLength(1);
+    // Correct leaseId still works.
+    await q.ack(rec.id, rec.leaseId!);
+    expect(q.peek()).toHaveLength(0);
+  });
+});

--- a/__tests__/event-queue/nack-backoff.test.ts
+++ b/__tests__/event-queue/nack-backoff.test.ts
@@ -1,0 +1,104 @@
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { InMemoryQueueStorage } from '@/lib/event-queue/storage-memory';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+
+describe('EventQueue nack + backoff', () => {
+  it('requeues with exponential backoff and is not leasable until visible', async () => {
+    const clock = new FakeClock(1000);
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock,
+      idGen: new SeqIdGen(),
+      retry: { baseMs: 1000, factor: 2, maxMs: 300000, jitter: false },
+      defaults: { maxAttempts: 10 },
+    });
+    await q.load();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+
+    // attempt 1 fails → backoff base 1000
+    let [rec] = await q.lease();
+    await q.nack(rec.id, rec.leaseId!, { error: 'boom' });
+    let [pending] = q.peek({ state: 'ready' });
+    expect(pending.visibleAt).toBe(1000 + 1000);
+    expect(pending.source).toBe('retry');
+    expect(pending.lastError).toBe('boom');
+    expect(await q.lease()).toHaveLength(0); // not yet visible
+
+    // advance to visible, attempt 2 fails → backoff 2000
+    clock.set(2000);
+    [rec] = await q.lease();
+    expect(rec.attempts).toBe(2);
+    await q.nack(rec.id, rec.leaseId!);
+    [pending] = q.peek({ state: 'ready' });
+    expect(pending.visibleAt).toBe(2000 + 2000);
+
+    // attempt 3 fails → backoff 4000
+    clock.set(4000);
+    [rec] = await q.lease();
+    await q.nack(rec.id, rec.leaseId!);
+    [pending] = q.peek({ state: 'ready' });
+    expect(pending.visibleAt).toBe(4000 + 4000);
+  });
+
+  it('dead-letters after maxAttempts and never redelivers', async () => {
+    const clock = new FakeClock(0);
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock,
+      idGen: new SeqIdGen(),
+      retry: { baseMs: 1, factor: 1, maxMs: 10, jitter: false },
+      defaults: { maxAttempts: 3 },
+    });
+    await q.load();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+
+    for (let i = 0; i < 3; i += 1) {
+      clock.advance(100);
+      const [rec] = await q.lease();
+      expect(rec).toBeDefined();
+      await q.nack(rec.id, rec.leaseId!);
+    }
+    expect(q.stats().dead).toBe(1);
+    clock.advance(100);
+    expect(await q.lease()).toHaveLength(0);
+  });
+
+  it('ignores nack with a stale leaseId', async () => {
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock: new FakeClock(1000),
+      idGen: new SeqIdGen(),
+    });
+    await q.load();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+    const [rec] = await q.lease();
+    await q.nack(rec.id, 'wrong');
+    expect(q.peek({ state: 'leased' })).toHaveLength(1);
+  });
+
+  it('ignores a stale nack that arrives after the record was swept and re-leased', async () => {
+    const clock = new FakeClock(1000);
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock,
+      idGen: new SeqIdGen(),
+      defaults: { leaseMs: 5000 },
+    });
+    await q.load();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+
+    const [first] = await q.lease();
+    const staleLease = first.leaseId!;
+    clock.advance(5001); // first lease expires
+    const [second] = await q.lease(); // swept back to ready, then re-leased
+    expect(second.leaseId).not.toBe(staleLease);
+
+    // The stalled first worker nacks with its OLD leaseId — must NOT touch the
+    // live second lease (no requeue, no dead-letter, no lastError overwrite).
+    await q.nack(second.id, staleLease, { error: 'from-stale-worker' });
+    const [live] = q.peek({ state: 'leased' });
+    expect(live).toBeDefined();
+    expect(live.leaseId).toBe(second.leaseId);
+    expect(live.lastError).toBeUndefined();
+  });
+});

--- a/__tests__/event-queue/purge-dead.test.ts
+++ b/__tests__/event-queue/purge-dead.test.ts
@@ -1,0 +1,47 @@
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { InMemoryQueueStorage } from '@/lib/event-queue/storage-memory';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+
+describe('EventQueue.purgeDead', () => {
+  it('drains dead-lettered records from memory and storage, leaving live ones', async () => {
+    const clock = new FakeClock(0);
+    const adapter = new InMemoryQueueStorage();
+    const q = new EventQueue({
+      adapter,
+      clock,
+      idGen: new SeqIdGen(),
+      retry: { baseMs: 1, factor: 1, maxMs: 1, jitter: false },
+      defaults: { maxAttempts: 1 },
+    });
+    await q.load();
+
+    // One record we drive to dead, one that stays ready.
+    await q.enqueue({ topic: 't', source: 'manual', payload: 'doomed' });
+    const [doomed] = await q.lease(); // attempts=1
+    await q.nack(doomed.id, doomed.leaseId!); // attempts>=maxAttempts → dead
+    await q.enqueue({ topic: 't', source: 'manual', payload: 'alive' });
+
+    expect(q.stats().dead).toBe(1);
+    const purged = await q.purgeDead();
+    expect(purged).toBe(1);
+    expect(q.stats().dead).toBe(0);
+    expect(q.peek().map((r) => r.payload)).toEqual(['alive']);
+
+    // Storage was drained too — a fresh queue over the same adapter sees no dead.
+    const fresh = new EventQueue({ adapter, clock, idGen: new SeqIdGen('f') });
+    await fresh.load();
+    expect(fresh.stats().dead).toBe(0);
+  });
+
+  it('is a no-op when there are no dead records', async () => {
+    const q = new EventQueue({
+      adapter: new InMemoryQueueStorage(),
+      clock: new FakeClock(),
+      idGen: new SeqIdGen(),
+    });
+    await q.load();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+    expect(await q.purgeDead()).toBe(0);
+    expect(q.peek()).toHaveLength(1);
+  });
+});

--- a/__tests__/event-queue/storage-json.test.ts
+++ b/__tests__/event-queue/storage-json.test.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { JsonFileQueueStorage } from '@/lib/event-queue/storage-json';
+import {
+  EVENT_QUEUE_SCHEMA_VERSION,
+  QueueRecord,
+} from '@/lib/event-queue/types';
+import { makeNodeFsPort, makeTmpDir } from '../support/node-fs-port';
+
+function record(id: string): QueueRecord {
+  return {
+    id,
+    schemaVersion: EVENT_QUEUE_SCHEMA_VERSION,
+    topic: 't',
+    source: 'manual',
+    payload: { id },
+    state: 'ready',
+    visibleAt: 0,
+    enqueuedAt: 0,
+    attempts: 0,
+    maxAttempts: 5,
+  };
+}
+
+describe('JsonFileQueueStorage', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = path.join(makeTmpDir(), 'event-queue');
+  });
+  afterEach(() => {
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  });
+
+  it('round-trips put/loadAll/delete over the node FsPort', async () => {
+    const store = new JsonFileQueueStorage(makeNodeFsPort(), dir);
+    await store.put(record('a'));
+    await store.put(record('b'));
+    expect((await store.loadAll()).map((r) => r.id).sort()).toEqual(['a', 'b']);
+    await store.delete('a');
+    expect((await store.loadAll()).map((r) => r.id)).toEqual(['b']);
+  });
+
+  it('returns [] for a missing directory rather than throwing', async () => {
+    const store = new JsonFileQueueStorage(makeNodeFsPort(), path.join(dir, 'nope'));
+    expect(await store.loadAll()).toEqual([]);
+  });
+
+  it('skips a single corrupt file instead of failing the whole load', async () => {
+    const store = new JsonFileQueueStorage(makeNodeFsPort(), dir);
+    await store.put(record('good'));
+    fs.writeFileSync(path.join(dir, 'garbage.json'), '{ not json');
+    const loaded = await store.loadAll();
+    expect(loaded.map((r) => r.id)).toEqual(['good']);
+  });
+
+  it('writes atomically (no leftover tmp files after put)', async () => {
+    const store = new JsonFileQueueStorage(makeNodeFsPort(), dir);
+    await store.put(record('a'));
+    const names = fs.readdirSync(dir);
+    expect(names).toEqual(['a.json']);
+  });
+
+  it('maps distinct ids with special chars to distinct files (no collision)', async () => {
+    const store = new JsonFileQueueStorage(makeNodeFsPort(), dir);
+    // Under a non-injective sanitizer these three would all clobber "a_b.json".
+    const ids = ['a/b', 'a b', 'a+b', 'a%b'];
+    for (const id of ids) await store.put(record(id));
+    const loaded = await store.loadAll();
+    expect(loaded.map((r) => r.id).sort()).toEqual([...ids].sort());
+    // deleting one leaves the others intact
+    await store.delete('a/b');
+    expect((await store.loadAll()).map((r) => r.id).sort()).toEqual(
+      ['a b', 'a+b', 'a%b'].sort(),
+    );
+  });
+
+  it('drops a parseable but malformed record (bad state) instead of admitting it', async () => {
+    const store = new JsonFileQueueStorage(makeNodeFsPort(), dir);
+    await store.put(record('good'));
+    // valid JSON, valid id, but no/garbage state — would stall + NaN-poison stats.
+    fs.writeFileSync(
+      path.join(dir, 'bad.json'),
+      JSON.stringify({ id: 'bad', topic: 't', attempts: 0 }),
+    );
+    const loaded = await store.loadAll();
+    expect(loaded.map((r) => r.id)).toEqual(['good']);
+  });
+});

--- a/__tests__/event-queue/visibility.test.ts
+++ b/__tests__/event-queue/visibility.test.ts
@@ -1,0 +1,46 @@
+import { EventQueue } from '@/lib/event-queue/event-queue';
+import { InMemoryQueueStorage } from '@/lib/event-queue/storage-memory';
+import { FakeClock, SeqIdGen } from '../support/event-queue-harness';
+
+async function makeQueue(start = 1000) {
+  const clock = new FakeClock(start);
+  const q = new EventQueue({
+    adapter: new InMemoryQueueStorage(),
+    clock,
+    idGen: new SeqIdGen(),
+  });
+  await q.load();
+  return { q, clock };
+}
+
+describe('EventQueue visibility', () => {
+  it('does not lease a delayed record before visibleAt', async () => {
+    const { q, clock } = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1, delayMs: 5000 });
+    expect(await q.lease()).toHaveLength(0);
+    clock.advance(4999);
+    expect(await q.lease()).toHaveLength(0);
+    clock.advance(1);
+    expect(await q.lease()).toHaveLength(1);
+  });
+
+  it('orders eligible records FIFO by (visibleAt, enqueuedAt)', async () => {
+    const { q, clock } = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 'a', delayMs: 3000 });
+    await q.enqueue({ topic: 't', source: 'manual', payload: 'b' });
+    await q.enqueue({ topic: 't', source: 'manual', payload: 'c', delayMs: 1000 });
+    clock.advance(5000);
+    const leased = await q.lease({ max: 10 });
+    // b (visible@1000) < c (2000) < a (4000)
+    expect(leased.map((r) => r.payload)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('caps the batch at max', async () => {
+    const { q } = await makeQueue();
+    await q.enqueue({ topic: 't', source: 'manual', payload: 1 });
+    await q.enqueue({ topic: 't', source: 'manual', payload: 2 });
+    await q.enqueue({ topic: 't', source: 'manual', payload: 3 });
+    expect(await q.lease({ max: 2 })).toHaveLength(2);
+    expect(q.stats().ready).toBe(1);
+  });
+});

--- a/__tests__/event-queue/wiring-flag.test.ts
+++ b/__tests__/event-queue/wiring-flag.test.ts
@@ -1,0 +1,29 @@
+import {
+  AGENT_RUN_TOPIC,
+  buildScheduledFireEnqueue,
+  EVENT_QUEUE_ENABLED,
+} from '@/lib/event-queue/wiring';
+
+describe('EVENT-001 dormancy + wiring seam', () => {
+  it('ships disabled — the queue is implemented but not enabled', () => {
+    expect(EVENT_QUEUE_ENABLED).toBe(false);
+  });
+
+  it('buildScheduledFireEnqueue produces a well-formed schedule input without touching production', () => {
+    const input = buildScheduledFireEnqueue('agent-42', 3600000, '0 * * * *');
+    expect(input.topic).toBe(AGENT_RUN_TOPIC);
+    expect(input.source).toBe('schedule');
+    expect(input.payload).toEqual({
+      agentId: 'agent-42',
+      intervalMs: 3600000,
+      cron: '0 * * * *',
+    });
+    // One pending scheduled fire per agent — re-arm collapses onto the same key.
+    expect(input.dedupKey).toBe('agent.run:agent-42');
+  });
+
+  it('accepts a null cron (interval-only schedule)', () => {
+    const input = buildScheduledFireEnqueue('agent-1', 60000, null);
+    expect(input.payload.cron).toBeNull();
+  });
+});

--- a/__tests__/support/event-queue-harness.ts
+++ b/__tests__/support/event-queue-harness.ts
@@ -1,0 +1,30 @@
+// Deterministic ports for EVENT-001 host tests: an injectable clock and a
+// sequential id generator, so every test is reproducible without Date.now or
+// Math.random.
+
+import { Clock, IdGen } from '@/lib/event-queue/types';
+
+export class FakeClock implements Clock {
+  private t: number;
+  constructor(start = 1_000) {
+    this.t = start;
+  }
+  now(): number {
+    return this.t;
+  }
+  advance(ms: number): void {
+    this.t += ms;
+  }
+  set(ms: number): void {
+    this.t = ms;
+  }
+}
+
+export class SeqIdGen implements IdGen {
+  private n = 0;
+  constructor(private readonly prefix = 'id') {}
+  next(): string {
+    this.n += 1;
+    return `${this.prefix}-${this.n}`;
+  }
+}

--- a/__tests__/support/node-fs-port.ts
+++ b/__tests__/support/node-fs-port.ts
@@ -1,0 +1,51 @@
+// Host-only FsPort backed by node fs, for exercising the JSON storage adapter
+// and crash-recovery tests. Lives under __tests__/support (not a *.test.ts) so
+// jest never runs it as a suite and Metro never bundles it into the app, while
+// tsc still type-checks it. Never imported by production code.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { FsPort } from '@/lib/event-queue/types';
+
+export function makeNodeFsPort(): FsPort {
+  return {
+    async readFile(p: string): Promise<string | null> {
+      try {
+        return await fs.promises.readFile(p, 'utf8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        throw err;
+      }
+    },
+    async writeFileAtomic(p: string, data: string): Promise<void> {
+      const tmp = `${p}.tmp-${process.pid}`;
+      await fs.promises.writeFile(tmp, data, 'utf8');
+      await fs.promises.rename(tmp, p);
+    },
+    async deleteFile(p: string): Promise<void> {
+      try {
+        await fs.promises.unlink(p);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+        throw err;
+      }
+    },
+    async listFiles(dir: string): Promise<string[]> {
+      try {
+        return await fs.promises.readdir(dir);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw err;
+      }
+    },
+    async ensureDir(dir: string): Promise<void> {
+      await fs.promises.mkdir(dir, { recursive: true });
+    },
+  };
+}
+
+export function makeTmpDir(prefix = 'shelly-event-queue-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}

--- a/lib/event-queue/backoff.ts
+++ b/lib/event-queue/backoff.ts
@@ -1,0 +1,37 @@
+// EVENT-001 event.queue — deterministic retry backoff.
+//
+// Pure: no clock, no randomness unless an rng is explicitly injected (and only
+// consulted when the policy enables jitter). Exponential with a hard cap.
+
+import { RetryPolicy } from './types';
+
+// Fraction of the base delay that jitter may add (0..jitterFraction).
+const JITTER_FRACTION = 0.5;
+
+// attempts is the number of deliveries so far (>=1 when a record is being
+// requeued after its first failed attempt). The first retry uses baseMs.
+export function computeBackoffMs(
+  attempts: number,
+  policy: RetryPolicy,
+  rng?: () => number,
+): number {
+  const exponent = Math.max(0, attempts - 1);
+  const raw = policy.baseMs * Math.pow(policy.factor, exponent);
+  let delay = raw;
+  if (policy.jitter && rng) {
+    delay = delay * (1 + rng() * JITTER_FRACTION);
+  }
+  // Cap AFTER jitter so maxMs is a true hard ceiling — jitter must not push the
+  // delay past the stated bound.
+  return Math.round(Math.min(policy.maxMs, delay));
+}
+
+// Convenience: the absolute epoch-ms visibility time for the next retry.
+export function nextVisibleAt(
+  now: number,
+  attempts: number,
+  policy: RetryPolicy,
+  rng?: () => number,
+): number {
+  return now + computeBackoffMs(attempts, policy, rng);
+}

--- a/lib/event-queue/event-queue.ts
+++ b/lib/event-queue/event-queue.ts
@@ -1,0 +1,260 @@
+// EVENT-001 event.queue — the durable at-least-once state machine.
+//
+// Pure core: depends only on ./types, ./backoff, and injected ports
+// (adapter/clock/idGen/rng). No FS, no Date.now, no Math.random, no expo.
+// The queue holds authoritative state in memory and persists every mutation
+// through the storage adapter, so a fresh instance over the same adapter
+// recovers by calling load().
+
+import { computeBackoffMs } from './backoff';
+import {
+  Clock,
+  DEFAULT_LEASE_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_POLICY,
+  EnqueueInput,
+  EnqueueResult,
+  EVENT_QUEUE_SCHEMA_VERSION,
+  IdGen,
+  LeaseOptions,
+  QueueRecord,
+  QueueRecordState,
+  QueueStorageAdapter,
+  RetryPolicy,
+} from './types';
+
+export interface EventQueueOptions {
+  adapter: QueueStorageAdapter;
+  clock: Clock;
+  idGen: IdGen;
+  retry?: Partial<RetryPolicy>;
+  defaults?: { leaseMs?: number; maxAttempts?: number };
+  rng?: () => number;
+}
+
+function clone<P>(record: QueueRecord<P>): QueueRecord<P> {
+  // Structured-ish copy so callers cannot mutate internal state. Payloads are
+  // JSON-serialisable by convention (they round-trip through storage).
+  return JSON.parse(JSON.stringify(record)) as QueueRecord<P>;
+}
+
+export class EventQueue {
+  private readonly adapter: QueueStorageAdapter;
+  private readonly clock: Clock;
+  private readonly idGen: IdGen;
+  private readonly retry: RetryPolicy;
+  private readonly leaseMs: number;
+  private readonly maxAttempts: number;
+  private readonly rng?: () => number;
+
+  // Authoritative in-memory state, keyed by record id.
+  private records = new Map<string, QueueRecord>();
+  private loaded = false;
+
+  constructor(opts: EventQueueOptions) {
+    this.adapter = opts.adapter;
+    this.clock = opts.clock;
+    this.idGen = opts.idGen;
+    this.retry = { ...DEFAULT_RETRY_POLICY, ...opts.retry };
+    this.leaseMs = opts.defaults?.leaseMs ?? DEFAULT_LEASE_MS;
+    this.maxAttempts = opts.defaults?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.rng = opts.rng;
+  }
+
+  // Rehydrate from storage and return expired leases to ready. Idempotent.
+  async load(): Promise<void> {
+    const all = await this.adapter.loadAll();
+    this.records = new Map(all.map((r) => [r.id, r]));
+    this.loaded = true;
+    await this.sweep();
+  }
+
+  private ensureLoaded(): void {
+    if (!this.loaded) {
+      // A queue must be load()ed before use so crash-recovery is deterministic.
+      throw new Error('EventQueue.load() must be awaited before use');
+    }
+  }
+
+  async enqueue<P>(input: EnqueueInput<P>): Promise<EnqueueResult> {
+    this.ensureLoaded();
+    const now = this.clock.now();
+
+    if (input.dedupKey) {
+      const existing = this.findPendingByDedupKey(input.dedupKey);
+      if (existing) {
+        return { id: existing.id, deduped: true };
+      }
+    }
+
+    const record: QueueRecord<P> = {
+      id: this.idGen.next(),
+      schemaVersion: EVENT_QUEUE_SCHEMA_VERSION,
+      topic: input.topic,
+      source: input.source,
+      payload: input.payload,
+      dedupKey: input.dedupKey,
+      state: 'ready',
+      visibleAt: now + Math.max(0, input.delayMs ?? 0),
+      enqueuedAt: now,
+      attempts: 0,
+      maxAttempts: input.maxAttempts ?? this.maxAttempts,
+    };
+    this.records.set(record.id, record as QueueRecord);
+    await this.adapter.put(record as QueueRecord);
+    return { id: record.id, deduped: false };
+  }
+
+  // Dedup window = while a record with the key is still pending (ready|leased).
+  // Once ack'd (removed) or dead, the key is free again.
+  private findPendingByDedupKey(dedupKey: string): QueueRecord | undefined {
+    for (const r of this.records.values()) {
+      if (r.dedupKey === dedupKey && (r.state === 'ready' || r.state === 'leased')) {
+        return r;
+      }
+    }
+    return undefined;
+  }
+
+  async lease(opts: LeaseOptions = {}): Promise<QueueRecord[]> {
+    this.ensureLoaded();
+    // Reclaim expired leases before selecting, so a crashed worker's record is
+    // eligible again.
+    await this.sweep();
+
+    const now = this.clock.now();
+    const leaseMs = opts.leaseMs ?? this.leaseMs;
+    const max = Math.max(1, opts.max ?? 1);
+
+    const eligible = [...this.records.values()]
+      .filter(
+        (r) =>
+          r.state === 'ready' &&
+          r.visibleAt <= now &&
+          (opts.topic === undefined || r.topic === opts.topic),
+      )
+      // FIFO by (visibleAt, enqueuedAt).
+      .sort((a, b) => a.visibleAt - b.visibleAt || a.enqueuedAt - b.enqueuedAt)
+      .slice(0, max);
+
+    const leased: QueueRecord[] = [];
+    for (const r of eligible) {
+      r.state = 'leased';
+      r.leaseId = this.idGen.next();
+      r.leaseExpiresAt = now + leaseMs;
+      // Count the attempt at delivery: a worker that crashes mid-process still
+      // consumes an attempt, bounding poison messages.
+      r.attempts += 1;
+      await this.adapter.put(r);
+      leased.push(clone(r));
+    }
+    return leased;
+  }
+
+  // Remove a record on successful processing. Idempotent; a stale leaseId (from
+  // an expired-then-re-leased record) is ignored so it cannot delete a live lease.
+  async ack(id: string, leaseId: string): Promise<void> {
+    this.ensureLoaded();
+    const r = this.records.get(id);
+    if (!r) return;
+    if (r.state !== 'leased' || r.leaseId !== leaseId) return;
+    this.records.delete(id);
+    await this.adapter.delete(id);
+  }
+
+  // Consumer-facing synonym for ack.
+  async complete(id: string, leaseId: string): Promise<void> {
+    return this.ack(id, leaseId);
+  }
+
+  // Application-level failure: requeue with backoff, or dead-letter once the
+  // attempt budget is spent. A stale leaseId is a no-op.
+  async nack(
+    id: string,
+    leaseId: string,
+    opts: { error?: string; requeueDelayMs?: number } = {},
+  ): Promise<void> {
+    this.ensureLoaded();
+    const r = this.records.get(id);
+    if (!r) return;
+    if (r.state !== 'leased' || r.leaseId !== leaseId) return;
+
+    r.lastError = opts.error;
+    delete r.leaseId;
+    delete r.leaseExpiresAt;
+
+    if (r.attempts >= r.maxAttempts) {
+      r.state = 'dead';
+      await this.adapter.put(r);
+      return;
+    }
+
+    const now = this.clock.now();
+    const delay =
+      opts.requeueDelayMs ?? computeBackoffMs(r.attempts, this.retry, this.rng);
+    r.state = 'ready';
+    r.source = 'retry';
+    r.visibleAt = now + Math.max(0, delay);
+    await this.adapter.put(r);
+  }
+
+  // Return expired leases to ready (crash recovery), dead-lettering those that
+  // have exhausted their attempts. Idempotent; returns the number moved.
+  async sweep(): Promise<number> {
+    const now = this.clock.now();
+    let moved = 0;
+    for (const r of this.records.values()) {
+      if (r.state !== 'leased') continue;
+      if (r.leaseExpiresAt === undefined || r.leaseExpiresAt > now) continue;
+
+      delete r.leaseId;
+      delete r.leaseExpiresAt;
+      if (r.attempts >= r.maxAttempts) {
+        r.state = 'dead';
+      } else {
+        // A lease timeout is a crash, not an app-level failure: redeliver
+        // immediately. attempts was already counted at lease, so it stays bounded.
+        r.state = 'ready';
+        r.visibleAt = now;
+      }
+      await this.adapter.put(r);
+      moved += 1;
+    }
+    return moved;
+  }
+
+  // Dead-lettered records are retained for inspection but grow unbounded over a
+  // long-lived install. Callers drain them explicitly (e.g. after exporting for
+  // diagnostics). Returns the number purged from memory and storage.
+  async purgeDead(): Promise<number> {
+    this.ensureLoaded();
+    let purged = 0;
+    for (const r of [...this.records.values()]) {
+      if (r.state !== 'dead') continue;
+      this.records.delete(r.id);
+      await this.adapter.delete(r.id);
+      purged += 1;
+    }
+    return purged;
+  }
+
+  peek(filter: { state?: QueueRecordState; topic?: string } = {}): QueueRecord[] {
+    this.ensureLoaded();
+    return [...this.records.values()]
+      .filter(
+        (r) =>
+          (filter.state === undefined || r.state === filter.state) &&
+          (filter.topic === undefined || r.topic === filter.topic),
+      )
+      .map((r) => clone(r));
+  }
+
+  stats(): { ready: number; leased: number; dead: number } {
+    this.ensureLoaded();
+    const out = { ready: 0, leased: 0, dead: 0 };
+    for (const r of this.records.values()) {
+      out[r.state] += 1;
+    }
+    return out;
+  }
+}

--- a/lib/event-queue/index.ts
+++ b/lib/event-queue/index.ts
@@ -1,0 +1,18 @@
+// EVENT-001 event.queue — public surface.
+//
+// Dormant Phase 1 primitive: a durable at-least-once queue that unifies
+// schedule/inbound/poller/retry/lease origins. Flag-OFF (see wiring.ts); no
+// production dispatch path imports it yet.
+
+export * from './types';
+export { computeBackoffMs, nextVisibleAt } from './backoff';
+export { EventQueue } from './event-queue';
+export type { EventQueueOptions } from './event-queue';
+export { InMemoryQueueStorage } from './storage-memory';
+export { JsonFileQueueStorage } from './storage-json';
+export {
+  EVENT_QUEUE_ENABLED,
+  AGENT_RUN_TOPIC,
+  buildScheduledFireEnqueue,
+} from './wiring';
+export type { ScheduledFirePayload } from './wiring';

--- a/lib/event-queue/storage-json.ts
+++ b/lib/event-queue/storage-json.ts
@@ -1,0 +1,96 @@
+// EVENT-001 event.queue — JSON file storage adapter.
+//
+// Durable backend: one JSON file per record under a base directory, written
+// atomically. RN/host safe because it imports no `fs`/expo directly — all I/O
+// goes through an injected FsPort (node-fs in host tests, expo-file-system on
+// device via the deferred fs-expo.ts). One bad/corrupt file is skipped on load
+// rather than failing the whole queue.
+
+import { FsPort, QueueRecord, QueueStorageAdapter } from './types';
+
+const FILE_SUFFIX = '.json';
+
+const VALID_STATES = new Set(['ready', 'leased', 'dead']);
+
+// A record that parses as JSON but has a missing/garbage shape (truncated then
+// hand-repaired, schema drift) must not enter the queue: an invalid `state`
+// would be un-leasable (silent stall) and would poison stats(). Admit only
+// well-formed records; drop the rest like a corrupt file.
+function isWellFormed(value: unknown): value is QueueRecord {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.id === 'string' &&
+    typeof r.topic === 'string' &&
+    typeof r.state === 'string' &&
+    VALID_STATES.has(r.state) &&
+    typeof r.attempts === 'number' &&
+    typeof r.maxAttempts === 'number' &&
+    typeof r.visibleAt === 'number' &&
+    typeof r.enqueuedAt === 'number'
+  );
+}
+
+function joinPath(dir: string, name: string): string {
+  return dir.endsWith('/') ? `${dir}${name}` : `${dir}/${name}`;
+}
+
+// Record ids are queue-generated (not user input), but encode the filename
+// anyway so a future id scheme can neither escape the base dir nor collide.
+// encodeURIComponent is injective and reversible and emits no path separator,
+// so distinct ids always map to distinct files (no silent clobber/mis-delete).
+function fileNameFor(id: string): string {
+  return `${encodeURIComponent(id)}${FILE_SUFFIX}`;
+}
+
+export class JsonFileQueueStorage implements QueueStorageAdapter {
+  private readonly fs: FsPort;
+  private readonly dir: string;
+  private ensured = false;
+
+  constructor(fs: FsPort, dir: string) {
+    this.fs = fs;
+    this.dir = dir;
+  }
+
+  private async ensureDir(): Promise<void> {
+    if (this.ensured) return;
+    await this.fs.ensureDir(this.dir);
+    this.ensured = true;
+  }
+
+  async loadAll(): Promise<QueueRecord[]> {
+    await this.ensureDir();
+    const names = await this.fs.listFiles(this.dir);
+    const out: QueueRecord[] = [];
+    for (const name of names) {
+      if (!name.endsWith(FILE_SUFFIX)) continue;
+      const raw = await this.fs.readFile(joinPath(this.dir, name));
+      if (raw === null) continue;
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        if (isWellFormed(parsed)) {
+          out.push(parsed);
+        }
+      } catch {
+        // Tolerate a single corrupt file (partial write, manual edit) rather
+        // than bricking the whole queue.
+        continue;
+      }
+    }
+    return out;
+  }
+
+  async put(record: QueueRecord): Promise<void> {
+    await this.ensureDir();
+    await this.fs.writeFileAtomic(
+      joinPath(this.dir, fileNameFor(record.id)),
+      JSON.stringify(record),
+    );
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.ensureDir();
+    await this.fs.deleteFile(joinPath(this.dir, fileNameFor(id)));
+  }
+}

--- a/lib/event-queue/storage-memory.ts
+++ b/lib/event-queue/storage-memory.ts
@@ -1,0 +1,26 @@
+// EVENT-001 event.queue — in-memory storage adapter.
+//
+// The default backend for host tests and any ephemeral use. Pure: a Map with a
+// defensive copy on every boundary so callers cannot alias internal state.
+
+import { QueueRecord, QueueStorageAdapter } from './types';
+
+function clone(record: QueueRecord): QueueRecord {
+  return JSON.parse(JSON.stringify(record)) as QueueRecord;
+}
+
+export class InMemoryQueueStorage implements QueueStorageAdapter {
+  private store = new Map<string, QueueRecord>();
+
+  async loadAll(): Promise<QueueRecord[]> {
+    return [...this.store.values()].map(clone);
+  }
+
+  async put(record: QueueRecord): Promise<void> {
+    this.store.set(record.id, clone(record));
+  }
+
+  async delete(id: string): Promise<void> {
+    this.store.delete(id);
+  }
+}

--- a/lib/event-queue/types.ts
+++ b/lib/event-queue/types.ts
@@ -1,0 +1,122 @@
+// EVENT-001 event.queue — shared types and ports.
+//
+// This module is the pure, dependency-free contract for the durable event
+// queue that Phase 1 unifies schedule/inbound/poller/retry/lease origins onto.
+// It imports nothing at runtime: the core state machine (event-queue.ts) and
+// every storage adapter depend only on these types plus injected ports, so the
+// whole primitive is host-testable and free of `Date.now`/`Math.random`/expo.
+//
+// Dormancy: nothing here is wired into a production dispatch path yet
+// (see wiring.ts, EVENT_QUEUE_ENABLED). "実装されるが有効化はされない."
+
+// Bump only alongside a persisted-record shape change. FUTURE LOCKSTEP POINT:
+// once a native/script consumer or the bundled-sqlite adapter reads persisted
+// records, mirror this exactly like PLAN_SPEC_SCHEMA_VERSION — TS constant +
+// script asset + AgentRuntime.CURRENT_* + a parity test. No mirror is required
+// while the queue is a dormant TS-only library. See wiring.ts §migration.
+export const EVENT_QUEUE_SCHEMA_VERSION = 1;
+
+export type QueueRecordState = 'ready' | 'leased' | 'dead';
+
+// The unified origin of a record. schedule/inbound/poller/retry/lease all land
+// on the same queue, differing only by (topic, source).
+export type QueueSource = 'schedule' | 'inbound' | 'poller' | 'retry' | 'manual';
+
+export interface QueueRecord<P = unknown> {
+  id: string;
+  schemaVersion: typeof EVENT_QUEUE_SCHEMA_VERSION;
+  topic: string;
+  source: QueueSource;
+  // Opaque to the queue — never interpreted here. By convention payloads carry
+  // no secret values (secret-by-reference lives in the capability layer).
+  payload: P;
+  dedupKey?: string;
+  state: QueueRecordState;
+  // Epoch ms. A record is leasable only when state==='ready' && visibleAt<=now.
+  // Delay and retry backoff both move this forward.
+  visibleAt: number;
+  enqueuedAt: number;
+  // Incremented at lease (delivery), so a worker that crashes mid-process still
+  // consumes an attempt — poison messages are bounded by maxAttempts.
+  attempts: number;
+  maxAttempts: number;
+  leaseId?: string;
+  leaseExpiresAt?: number;
+  // Set by nack. Callers redact before storing.
+  lastError?: string;
+}
+
+// Injected clock — Date.now is unavailable in some native contexts, so the core
+// never reads wall-clock time directly.
+export interface Clock {
+  now(): number;
+}
+
+// Injected id source — the core never calls Math.random directly.
+export interface IdGen {
+  next(): string;
+}
+
+// Adapter boundary port for file-backed storage. A host adapter injects a
+// node-fs implementation; the device adapter injects an expo-file-system one.
+export interface FsPort {
+  // Resolves to null when the file is absent (not an error).
+  readFile(path: string): Promise<string | null>;
+  writeFileAtomic(path: string, data: string): Promise<void>;
+  deleteFile(path: string): Promise<void>;
+  listFiles(dir: string): Promise<string[]>;
+  ensureDir(dir: string): Promise<void>;
+}
+
+export interface RetryPolicy {
+  baseMs: number;
+  factor: number;
+  maxMs: number;
+  jitter: boolean;
+}
+
+export interface EnqueueInput<P = unknown> {
+  topic: string;
+  source: QueueSource;
+  payload: P;
+  // Optional idempotency key. While a record with this key is still pending
+  // (ready OR leased/in-flight), a further enqueue with the same key is dropped
+  // as a duplicate. CONTRACT: the queue's at-least-once guarantee is per
+  // dedupKey — callers must treat a shared dedupKey as "the same logical
+  // event." Do NOT reuse a key for a distinct event you need delivered while an
+  // earlier one is in flight (it would be swallowed). Leave undefined for
+  // at-least-once delivery of every enqueue.
+  dedupKey?: string;
+  delayMs?: number;
+  maxAttempts?: number;
+}
+
+export interface EnqueueResult {
+  id: string;
+  deduped: boolean;
+}
+
+export interface LeaseOptions {
+  leaseMs?: number;
+  max?: number;
+  topic?: string;
+}
+
+// The single storage boundary. The core holds authoritative state in memory and
+// persists every mutation through this interface, which maps cleanly onto one
+// JSON file per record (host/device) or a sqlite row (deferred, flag-gated).
+export interface QueueStorageAdapter {
+  loadAll(): Promise<QueueRecord[]>;
+  put(record: QueueRecord): Promise<void>; // upsert by id
+  delete(id: string): Promise<void>;
+}
+
+export const DEFAULT_RETRY_POLICY: RetryPolicy = {
+  baseMs: 1000,
+  factor: 2,
+  maxMs: 300000,
+  jitter: false,
+};
+
+export const DEFAULT_LEASE_MS = 30000;
+export const DEFAULT_MAX_ATTEMPTS = 5;

--- a/lib/event-queue/wiring.ts
+++ b/lib/event-queue/wiring.ts
@@ -1,0 +1,51 @@
+// EVENT-001 event.queue — dormant wiring seam.
+//
+// This file documents the future migration WITHOUT enabling it. The queue is
+// implemented (pure core + adapters + tests) but not wired into any production
+// dispatch path: EVENT_QUEUE_ENABLED stays false, and no native/scheduler code
+// imports this. "実装されるが有効化はされない."
+//
+// MIGRATION (deferred, flag-ON step, out of scope until the floor is verified):
+//   1. Native alarm → trigger. TerminalSessionService.ACTION_RUN_AGENT and
+//      AgentAlarmScheduler.scheduleNext stop calling runAgentInBackground
+//      directly and instead enqueue the shape produced by
+//      buildScheduledFireEnqueue below; a single consumer lease()s → dispatches.
+//      Until that step the alarm path is byte-preserved.
+//   2. G4 router / G5 inbound / pollers become producers (enqueue) + consumers
+//      (lease→dispatch→ack/nack).
+//   3. Consumer loop owner (TS foreground vs native FGS) — a design fork to
+//      decide before flag-ON; it also determines whether
+//      EVENT_QUEUE_SCHEMA_VERSION needs a native/script mirror (see types.ts).
+
+import { EnqueueInput, QueueSource } from './types';
+
+// Master dormancy switch. Never flipped by this /goal — flipping it is the
+// separate "enable" decision, gated on a device-verified floor.
+export const EVENT_QUEUE_ENABLED = false;
+
+export interface ScheduledFirePayload {
+  agentId: string;
+  intervalMs: number;
+  cron: string | null;
+}
+
+export const AGENT_RUN_TOPIC = 'agent.run';
+
+// Documents the native-alarm → enqueue mapping without invoking any production
+// path. When the alarm path is migrated (step 1 above), the fire produces
+// exactly this input.
+export function buildScheduledFireEnqueue(
+  agentId: string,
+  intervalMs: number,
+  cron: string | null,
+): EnqueueInput<ScheduledFirePayload> {
+  const source: QueueSource = 'schedule';
+  return {
+    topic: AGENT_RUN_TOPIC,
+    source,
+    payload: { agentId, intervalMs, cron },
+    // One pending scheduled fire per agent at a time — a re-arm that lands
+    // before the prior fire is consumed collapses onto the same record.
+    dedupKey: `${AGENT_RUN_TOPIC}:${agentId}`,
+  };
+}


### PR DESCRIPTION
## Summary

- Port EVENT-001's durable, at-least-once event queue core from `eec65284`.
- Add pure queue state-machine behavior for enqueue/dedup, leases, ack/nack, exponential backoff, crash recovery, visibility, dead-record purging, and JSON/in-memory storage adapters.
- Add host-only EVENT-001 tests with injected storage, clock, and ID ports.

## Flag-off / reachability verification

- The master switch defaults to the literal `false` at `lib/event-queue/wiring.ts:24` (`export const EVENT_QUEUE_ENABLED = false`).
- A repository-wide production-source trace found no event-queue references outside the new `lib/event-queue/` directory; no scheduler, native dispatch, agent manager, or other existing production path imports it. Therefore disabled/default builds have no reachable production execution path into EVENT-001.

## Shadow producer decision

The optional shadow producer commit `4e581ee3` was deliberately excluded. It did not port cleanly: its `lib/agent-manager.ts` context depends on unrelated, currently unported PlanSpec and MEMORY-001 substrate imports. Resolving that conflict here would couple this isolated queue-core PR to unexpected substrate drift, contrary to the requirement that the shadow increment stay cleanly separable and genuinely inert.

## Verification

- `pnpm run check` — PASS
- `pnpm run lint` — PASS (0 errors; 2 pre-existing warnings in `components/scouter/ScouterDetailModal.tsx`)
- `pnpm test -- --runInBand __tests__/event-queue` — PASS (11 suites, 35 tests)
- `git diff --check origin/main...HEAD` — PASS

## Deliberate exclusions

- Boot autostart was not ported because it changes the APK's always-on manifest/boot receiver surface and requires physical-device reboot/Doze verification.
- STOP-ALL (`d503e47a`) was not ported because it depends on the unported PlanSpec executor substrate and must travel with that future batch.

These exclusions follow the prior batch-4b scoping decision supplied with this task. This PR must not be merged until Claude Code completes its independent review.