### PR TITLE
fix(security): redact synchronous broker request failures

### DIFF
--- a/__tests__/capability-broker.test.ts
+++ b/__tests__/capability-broker.test.ts
@@ -9,6 +9,7 @@ interface RunResult {
   code: number;
   out: string;
   err: string;
+  processErr: string;
   audit: any[];
 }
 
@@ -32,6 +33,7 @@ function runBroker(
     approved?: boolean;
     env?: Record<string, string>;
     budget?: { calls: number; startedAtMs: number };
+    nodeOptions?: string;
   },
 ): Promise<RunResult> {
   const outFile = path.join(dir, 'out.txt');
@@ -78,13 +80,18 @@ function runBroker(
   }
 
   return new Promise((resolve) => {
-    execFile('node', argv, { encoding: 'utf8' }, (err: any) => {
-      const code = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      const read = (f: string) => (fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : '');
-      const auditText = read(auditFile).trim();
-      const audit = auditText ? auditText.split('\n').map((l) => JSON.parse(l)) : [];
-      resolve({ code, out: read(outFile), err: read(errFile), audit });
-    });
+    execFile(
+      'node',
+      argv,
+      { encoding: 'utf8', env: { ...process.env, NODE_OPTIONS: opts.nodeOptions || '' } },
+      (err: any, _stdout, stderr) => {
+        const code = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
+        const read = (f: string) => (fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : '');
+        const auditText = read(auditFile).trim();
+        const audit = auditText ? auditText.split('\n').map((l) => JSON.parse(l)) : [];
+        resolve({ code, out: read(outFile), err: read(errFile), processErr: stderr, audit });
+      },
+    );
   });
 }
 
@@ -197,5 +204,28 @@ describe('shelly-capability-broker: secret injection + send (loopback server)', 
     expect(budget.calls).toBe(1);
     // no auth header was sent for an un-authed call
     expect(lastAuthHeader).toBeUndefined();
+  });
+
+  it('redacts a synchronous request error and audits the failed attempt', async () => {
+    const secret = 'gsk_SECRETSECRETSECRETSECRET';
+    const preload = path.join(dir, 'throw-request.js');
+    fs.writeFileSync(
+      preload,
+      `require('http').request = () => { throw new Error('request failed with ${secret}'); };\n`,
+    );
+
+    const r = await runBroker(dir, {
+      url: `http://127.0.0.1:${port}/v1/chat/completions`,
+      body: '{}',
+      nodeOptions: `--require=${preload}`,
+    });
+
+    expect(r.code).toBe(23);
+    expect(r.err).toContain('request failed with <redacted>');
+    expect(r.processErr).toBe('');
+    expect(r.err + r.processErr + JSON.stringify(r.audit)).not.toContain(secret);
+    expect(r.audit).toHaveLength(1);
+    expect(r.audit[0]).toMatchObject({ decision: 'allow', status: 0, ok: false });
+    expect(r.audit[0].reason).toBe('request failed with <redacted>');
   });
 });

--- a/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
@@ -458,20 +458,28 @@ function main() {
   budgetState.calls += 1;
   saveBudgetState(budgetFile, budgetState);
 
-  sendRequest(
-    {
-      method: method,
-      url: url,
-      bodyBuf: bodyBuf,
-      headers: headers,
-      timeoutSeconds: timeoutSeconds,
-      outFd: outFd,
-      errFd: errFd,
-    },
-    (code, status) => {
-      finish(code, verdict, { status: status, ok: code === EXIT.OK });
-    },
-  );
+  try {
+    sendRequest(
+      {
+        method: method,
+        url: url,
+        bodyBuf: bodyBuf,
+        headers: headers,
+        timeoutSeconds: timeoutSeconds,
+        outFd: outFd,
+        errFd: errFd,
+      },
+      (code, status) => {
+        finish(code, verdict, { status: status, ok: code === EXIT.OK });
+      },
+    );
+  } catch (e) {
+    const reason = e && e.message ? e.message : String(e);
+    try {
+      fs.writeSync(errFd, 'capability broker: ' + redact(reason) + '\n');
+    } catch (_) {}
+    return finish(EXIT.HTTP_TRANSIENT, verdict, { status: 0, ok: false, reason: reason });
+  }
 }
 
 main();

--- a/scripts/shelly-capability-broker.js
+++ b/scripts/shelly-capability-broker.js
@@ -458,20 +458,28 @@ function main() {
   budgetState.calls += 1;
   saveBudgetState(budgetFile, budgetState);
 
-  sendRequest(
-    {
-      method: method,
-      url: url,
-      bodyBuf: bodyBuf,
-      headers: headers,
-      timeoutSeconds: timeoutSeconds,
-      outFd: outFd,
-      errFd: errFd,
-    },
-    (code, status) => {
-      finish(code, verdict, { status: status, ok: code === EXIT.OK });
-    },
-  );
+  try {
+    sendRequest(
+      {
+        method: method,
+        url: url,
+        bodyBuf: bodyBuf,
+        headers: headers,
+        timeoutSeconds: timeoutSeconds,
+        outFd: outFd,
+        errFd: errFd,
+      },
+      (code, status) => {
+        finish(code, verdict, { status: status, ok: code === EXIT.OK });
+      },
+    );
+  } catch (e) {
+    const reason = e && e.message ? e.message : String(e);
+    try {
+      fs.writeSync(errFd, 'capability broker: ' + redact(reason) + '\n');
+    } catch (_) {}
+    return finish(EXIT.HTTP_TRANSIENT, verdict, { status: 0, ok: false, reason: reason });
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary
- catch synchronous request setup failures before Node can emit an unredacted stack trace
- redact the broker error and record the failed attempt in the existing audit JSONL format
- keep the host script and Android asset byte-identical
- add regression coverage for stderr redaction and audit logging

## Verification
- corepack pnpm run check
- pnpm run lint (0 errors; 2 pre-existing ScouterDetailModal warnings)
- corepack pnpm test -- --runInBand __tests__/capability-broker.test.ts __tests__/capability-broker-parity.test.ts
- git diff --check
- SHA-256 parity: A9275DB18A4C108C692D6768AF48A404EAC4A4D3C41BBC85C135E564CE1FD140