### PR TITLE
fix(agent): guard malformed names during lookup

### DIFF
--- a/__tests__/agent-store-name-guard.test.ts
+++ b/__tests__/agent-store-name-guard.test.ts
@@ -1,0 +1,17 @@
+import { useAgentStore } from '@/store/agent-store';
+import type { Agent } from '@/store/types';
+
+describe('agent store name lookup', () => {
+  afterEach(() => {
+    useAgentStore.getState().setAgents([]);
+  });
+
+  it('skips malformed agents with a missing name', () => {
+    const malformedAgent = { id: 'malformed' } as Agent;
+    const validAgent = { id: 'valid', name: 'Researcher' } as Agent;
+
+    useAgentStore.getState().setAgents([malformedAgent, validAgent]);
+
+    expect(useAgentStore.getState().getAgentByName('researcher')).toBe(validAgent);
+  });
+});

--- a/store/agent-store.ts
+++ b/store/agent-store.ts
@@ -70,7 +70,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   getAgentByName: (name) =>
     get().agents.find(
-      (a) => a.name.toLowerCase() === name.toLowerCase()
+      (a) => (a.name || '').toLowerCase() === name.toLowerCase()
     ),
 
   setPendingEnvSync: (cmd) => set({ pendingEnvSync: cmd }),


### PR DESCRIPTION
## Summary
- guard agent name normalization against malformed on-disk records
- add regression coverage ensuring a missing-name record is skipped during lookup

## Verification
- \corepack pnpm test -- --runInBand __tests__/agent-store-name-guard.test.ts\ ✅
- \corepack pnpm run check\ ✅
- \git diff --check\ ✅
- lint: changed files are clean; full repository ESLint currently reports 24 pre-existing errors in unrelated native assets/modules (the \pnpm\ shim is unavailable on this Windows PATH, so lint was run as \corepack pnpm exec eslint .\)