### PR TITLE
feat(agent): port PlanSpec executor core and hardening (batch 8)

### DIFF
--- a/__tests__/agent-executor-autonomous.test.ts
+++ b/__tests__/agent-executor-autonomous.test.ts
@@ -251,12 +251,12 @@ describe('dated-folder output template (N4)', () => {
     expect(sanitizeOutputTemplate('../../etc/{slug}')).toBe('etc/{slug}');
   });
 
-  it('the generated save uses the template (placeholder substitution + dir create)', () => {
+  it('the generated save uses the template (placeholder substitution + scoped write)', () => {
     const s = generateRunScript(agent({ type: 'local' }));
     expect(s).toContain('OUTPUT_NAME_TEMPLATE=');
     expect(s).toContain('s|{date}|$DATE|g');
     expect(s).toContain('s|{slug}|$SLUG|g');
-    expect(s).toContain('mkdir -p "$(dirname "$SAVED_FILE")"');
+    expect(s).toContain('cap_fs_write_file "$SAVED_FILE" "$result_file"');
     // The old hardcoded flat name is gone.
     expect(s).not.toContain('SAVED_FILE="$OUTPUT_DIR/$DATE-$SLUG.md"');
   });
@@ -443,7 +443,7 @@ describe('generateRunScript — orchestration suppressAction (Phase 4)', () => {
 describe('generateRunScript — autonomous tool resolution (Spec A §4/§5)', () => {
   it('resolves autonomous auto → codex (OAuth), key-free env', () => {
     const s = generateRunScript(agent({ type: 'auto' }, true));
-    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=9');
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=10');
     expect(s).toContain('.shelly-agent-driver.js'); // resolved to cli/codex via the approval driver
     expect(s).toContain('--prompt-file "$PROMPT_FILE"');
     expect(s).toContain('if node_usable && [ -f "$HOME/.shelly-agent-driver.js" ]; then');
@@ -629,7 +629,8 @@ describe('generateRunScript — autonomous tool resolution (Spec A §4/§5)', ()
     expect(cli).toContain("ACTION_COMMAND_SAFETY_LEVEL='HIGH'");
     expect(cli).toContain('write_action_approval_request "cli" "$preview" "$result_file"');
     expect(cli).toContain('wait_action_approval "cli" || return 1');
-    expect(cli).toContain('bash -lc "$ACTION_COMMAND" > "$cli_output" 2>&1');
+    expect(cli).toContain('cap_workspace_exec "$ACTION_COMMAND" "$CLI_EXEC_CWD" "$cli_output" "$cli_error"');
+    expect(cli).toContain('bash -lc "$command_text" > "$out_file" 2>&1');
     expect(cli).not.toContain('eval "$ACTION_COMMAND"');
   });
 });

--- a/__tests__/agent-executor-cap-broker.test.ts
+++ b/__tests__/agent-executor-cap-broker.test.ts
@@ -63,7 +63,31 @@ describe('capability broker wiring — http_post_json seam (CAP/HTTP/SECRET-001)
   });
 
   it('bumps the script version in lockstep with the native gate', () => {
-    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=9');
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=10');
+  });
+});
+
+describe('capability broker wiring — scoped.fs and workspace.exec seams (FS/EXEC-001)', () => {
+  it('draft saving routes through scoped.fs when SHELLY_CAP_FS=1 and fails closed if unavailable', () => {
+    const s = generateRunScript(agent({ type: 'local' }, false));
+    expect(s).toContain('cap_fs_write_file "$SAVED_FILE" "$result_file"');
+    expect(s).toContain('cap_fs_write_file "$OBSIDIAN_DEST" "$SAVED_FILE"');
+    expect(s).toContain('if [ "${SHELLY_CAP_FS:-0}" = "1" ] && node_usable && [ -f "$HOME/.shelly-capability-broker.js" ]; then');
+    expect(s).toContain('--op fs.write --path "$dest" --input-file "$src"');
+    expect(s).toContain('Scoped filesystem broker requested but unavailable; refusing unbrokered write.');
+  });
+
+  it('cli actions keep in-app approval but execute through workspace.exec when SHELLY_CAP_EXEC=1', () => {
+    const s = generateRunScript({
+      ...agent({ type: 'local' }, false),
+      action: { type: 'cli', command: 'printf ok' },
+    } as Agent);
+    expect(s).toContain('write_action_approval_request "cli" "$preview" "$result_file"');
+    expect(s).toContain('wait_action_approval "cli" || return 1');
+    expect(s).toContain('if [ "${SHELLY_CAP_EXEC:-0}" = "1" ] && [ "$ACTION_COMMAND_SAFETY_LEVEL" = "CRITICAL" ]; then');
+    expect(s).toContain('cap_workspace_exec "$ACTION_COMMAND" "$CLI_EXEC_CWD" "$cli_output" "$cli_error"');
+    expect(s).toContain('--op workspace.exec --command-file "$command_file" --cwd "$cwd"');
+    expect(s).toContain('workspace.exec broker requested but unavailable; refusing unbrokered exec.');
   });
 });
 

--- a/__tests__/agent-plan-spec.test.ts
+++ b/__tests__/agent-plan-spec.test.ts
@@ -1,0 +1,65 @@
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+import { buildAgentPlanSpec, PLAN_SPEC_KIND, PLAN_SPEC_SCHEMA_VERSION, validateAgentPlanSpec } from '@/lib/agent-plan-spec';
+import type { Agent } from '@/store/types';
+
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-plan-test',
+    name: 'Plan Test',
+    description: 'plan',
+    prompt: 'say hello',
+    schedule: null,
+    tool: { type: 'local' },
+    autonomous: true,
+    autonomyLevel: 'L1',
+    workspaceRoot: '/tmp/work',
+    outputPath: '~/agent-output',
+    outputTemplate: null,
+    action: { type: 'draft' },
+    enabled: true,
+    lastRun: null,
+    lastResult: null,
+    createdAt: 1,
+    version: 1,
+    ...overrides,
+  };
+}
+
+describe('Agent PlanSpec v1', () => {
+  it('builds a versioned sidecar without raw API secret fields', () => {
+    const spec = buildAgentPlanSpec(agent({ autonomous: false, tool: { type: 'perplexity', model: 'sonar' } }));
+
+    expect(spec.kind).toBe(PLAN_SPEC_KIND);
+    expect(spec.schemaVersion).toBe(PLAN_SPEC_SCHEMA_VERSION);
+    expect(spec.tool).toMatchObject({ type: 'perplexity', authRef: 'perplexity' });
+    expect(spec.policy.level).toBe('L1');
+    expect(spec.output.suggestedRoots).toEqual(expect.arrayContaining([expect.stringContaining('/agent-output')]));
+
+    const serialized = JSON.stringify(spec);
+    expect(serialized).not.toContain('PERPLEXITY_API_KEY');
+    expect(serialized).not.toContain('Authorization');
+    expect(serialized).not.toContain('Bearer ');
+  });
+
+  it('marks unsupported tools and actions fail-closed in the plan', () => {
+    const spec = buildAgentPlanSpec(agent({
+      tool: { type: 'cli', cli: 'codex' },
+      action: { type: 'cli', command: 'rm -rf /' },
+    }));
+
+    expect(spec.tool.type).toBe('unsupported');
+    expect(spec.tool.unsupportedReason).toContain('does not support cli tools yet');
+    expect(spec.action.type).toBe('unsupported');
+    expect(spec.action.unsupportedReason).toContain('does not support cli actions yet');
+  });
+
+  it('validates schema version and agent id', () => {
+    const spec = buildAgentPlanSpec(agent());
+    expect(validateAgentPlanSpec(spec).ok).toBe(true);
+    expect(validateAgentPlanSpec({ ...spec, schemaVersion: 99 }).ok).toBe(false);
+    expect(validateAgentPlanSpec({ ...spec, agent: { ...spec.agent, id: '../../bad' } }).ok).toBe(false);
+  });
+});

--- a/__tests__/agent-plan-spec.test.ts
+++ b/__tests__/agent-plan-spec.test.ts
@@ -44,7 +44,7 @@ describe('Agent PlanSpec v1', () => {
     expect(serialized).not.toContain('Bearer ');
   });
 
-  it('marks unsupported tools and actions fail-closed in the plan', () => {
+  it('marks unsupported tools fail-closed while preserving broker-supported actions', () => {
     const spec = buildAgentPlanSpec(agent({
       tool: { type: 'cli', cli: 'codex' },
       action: { type: 'cli', command: 'rm -rf /' },
@@ -52,8 +52,32 @@ describe('Agent PlanSpec v1', () => {
 
     expect(spec.tool.type).toBe('unsupported');
     expect(spec.tool.unsupportedReason).toContain('does not support cli tools yet');
-    expect(spec.action.type).toBe('unsupported');
-    expect(spec.action.unsupportedReason).toContain('does not support cli actions yet');
+    expect(spec.action.type).toBe('cli');
+    expect(spec.action.command).toBe('rm -rf /');
+    expect(spec.action.safety?.level).toBe('CRITICAL');
+  });
+
+  it('serializes webhook and cli actions without raw authorization material', () => {
+    const webhook = buildAgentPlanSpec(agent({
+      action: { type: 'webhook', webhookUrl: 'https://hooks.example.test/incoming' },
+    }));
+    expect(webhook.action).toMatchObject({
+      type: 'webhook',
+      webhookUrl: 'https://hooks.example.test/incoming',
+    });
+
+    const cli = buildAgentPlanSpec(agent({
+      action: { type: 'cli', command: 'printf ok' },
+    }));
+    expect(cli.action).toMatchObject({
+      type: 'cli',
+      command: 'printf ok',
+    });
+    expect(cli.action.safety?.level).toBe('SAFE');
+
+    const serialized = JSON.stringify({ webhook, cli });
+    expect(serialized).not.toContain('Authorization');
+    expect(serialized).not.toContain('Bearer ');
   });
 
   it('validates schema version and agent id', () => {

--- a/__tests__/capability-broker-parity.test.ts
+++ b/__tests__/capability-broker-parity.test.ts
@@ -33,4 +33,12 @@ describe('shelly-capability-broker.js parity', () => {
       expect(brokerSrc).toMatch(re);
     }
   });
+
+  it('ships the FS-001 and EXEC-001 broker ops in the asset copy', () => {
+    expect(brokerSrc).toContain("op === 'fs.read'");
+    expect(brokerSrc).toContain("op === 'fs.write'");
+    expect(brokerSrc).toContain("op === 'fs.list'");
+    expect(brokerSrc).toContain("op === 'fs.search'");
+    expect(brokerSrc).toContain("op === 'workspace.exec'");
+  });
 });

--- a/__tests__/capability-broker.test.ts
+++ b/__tests__/capability-broker.test.ts
@@ -95,6 +95,31 @@ function runBroker(
   });
 }
 
+function runBrokerArgs(dir: string, argv: string[], env?: Record<string, string>): Promise<RunResult> {
+  const outFile = path.join(dir, 'out.txt');
+  const errFile = path.join(dir, 'err.txt');
+  const auditFile = path.join(dir, 'audit.jsonl');
+  const fullArgv = [
+    BROKER,
+    ...argv,
+    '--audit-log',
+    auditFile,
+    '--out',
+    outFile,
+    '--err',
+    errFile,
+  ];
+  return new Promise((resolve) => {
+    execFile('node', fullArgv, { encoding: 'utf8', env: { ...process.env, ...(env || {}) } }, (err: any, _stdout, stderr) => {
+      const code = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
+      const read = (f: string) => (fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : '');
+      const auditText = read(auditFile).trim();
+      const audit = auditText ? auditText.split('\n').map((l) => JSON.parse(l)) : [];
+      resolve({ code, out: read(outFile), err: read(errFile), processErr: stderr, audit });
+    });
+  });
+}
+
 describe('shelly-capability-broker: policy gates (no network)', () => {
   let dir: string;
   beforeEach(() => {
@@ -227,5 +252,241 @@ describe('shelly-capability-broker: secret injection + send (loopback server)', 
     expect(r.audit).toHaveLength(1);
     expect(r.audit[0]).toMatchObject({ decision: 'allow', status: 0, ok: false });
     expect(r.audit[0].reason).toBe('request failed with <redacted>');
+  });
+});
+
+describe('shelly-capability-broker: FS-001 scoped.fs', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeDir();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes inside a declared root and records a scoped.fs audit', async () => {
+    const root = path.join(dir, 'root');
+    const input = path.join(root, 'input.txt');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.writeFileSync(input, 'ok');
+    fs.writeFileSync(roots, root + '\n');
+    const dest = path.join(root, 'nested', 'result.md');
+
+    const r = await runBrokerArgs(dir, ['--op', 'fs.write', '--path', dest, '--input-file', input, '--roots-file', roots]);
+    expect(r.code).toBe(0);
+    expect(fs.readFileSync(dest, 'utf8')).toBe('ok');
+    expect(r.audit[0].kind).toBe('scoped.fs');
+    expect(r.audit[0].decision).toBe('allow');
+  });
+
+  it('denies writes outside declared roots', async () => {
+    const root = path.join(dir, 'root');
+    const outside = path.join(dir, 'outside');
+    const input = path.join(root, 'input.txt');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    fs.writeFileSync(input, 'nope');
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'fs.write', '--path', path.join(outside, 'x.md'), '--input-file', input, '--roots-file', roots]);
+    expect(r.code).toBe(45);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('outside-root');
+    expect(fs.existsSync(path.join(outside, 'x.md'))).toBe(false);
+  });
+
+  it('denies writes through an in-root symlink that points outside', async () => {
+    const root = path.join(dir, 'root');
+    const outside = path.join(dir, 'outside');
+    const input = path.join(root, 'input.txt');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    fs.symlinkSync(outside, path.join(root, 'link-out'), 'dir');
+    fs.writeFileSync(input, 'nope');
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'fs.write', '--path', path.join(root, 'link-out', 'x.md'), '--input-file', input, '--roots-file', roots]);
+    expect(r.code).toBe(45);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('outside-root');
+    expect(fs.existsSync(path.join(outside, 'x.md'))).toBe(false);
+  });
+
+  it('denies writes to an in-root dangling symlink whose target is outside', async () => {
+    const root = path.join(dir, 'root');
+    const outside = path.join(dir, 'outside');
+    const input = path.join(root, 'input.txt');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    fs.symlinkSync(path.join(outside, 'evil.txt'), path.join(root, 'link.md'), 'file');
+    fs.writeFileSync(input, 'payload');
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'fs.write', '--path', path.join(root, 'link.md'), '--input-file', input, '--roots-file', roots]);
+    expect(r.code).toBe(45);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('outside-root');
+    expect(fs.existsSync(path.join(outside, 'evil.txt'))).toBe(false);
+  });
+
+  it('denies writes below an in-root dangling symlink directory whose target is outside', async () => {
+    const root = path.join(dir, 'root');
+    const outside = path.join(dir, 'outside');
+    const input = path.join(root, 'input.txt');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    fs.symlinkSync(path.join(outside, 'missing-dir'), path.join(root, 'link-dir'), 'dir');
+    fs.writeFileSync(input, 'payload');
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'fs.write', '--path', path.join(root, 'link-dir', 'evil.txt'), '--input-file', input, '--roots-file', roots]);
+    expect(r.code).toBe(45);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('outside-root');
+    expect(fs.existsSync(path.join(outside, 'missing-dir', 'evil.txt'))).toBe(false);
+  });
+
+  it('denies fs.write input files outside declared roots', async () => {
+    const root = path.join(dir, 'root');
+    const input = path.join(dir, 'input.txt');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.writeFileSync(input, 'secret-ish');
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'fs.write', '--path', path.join(root, 'x.md'), '--input-file', input, '--roots-file', roots]);
+    expect(r.code).toBe(45);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].reason).toContain('input file is outside');
+    expect(r.audit[0].path).toBe(path.join(root, 'x.md'));
+    expect(fs.existsSync(path.join(root, 'x.md'))).toBe(false);
+  });
+});
+
+describe('shelly-capability-broker: EXEC-001 workspace.exec', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeDir();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('executes inside a root with API-key-like env stripped', async () => {
+    const root = path.join(dir, 'workspace');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    const command = path.join(root, 'cmd.sh');
+    fs.writeFileSync(roots, root + '\n');
+    fs.writeFileSync(command, 'env');
+
+    const r = await runBrokerArgs(
+      dir,
+      ['--op', 'workspace.exec', '--command-file', command, '--cwd', root, '--roots-file', roots, '--timeout-seconds', '5'],
+      { GEMINI_API_KEY: 'AIzaSECRETSECRETSECRETSECRETSECRETSECRET' },
+    );
+    expect(r.code).toBe(0);
+    expect(r.out).not.toContain('GEMINI_API_KEY');
+    expect(r.out + r.err + JSON.stringify(r.audit)).not.toContain('AIzaSECRET');
+    expect(r.audit[0].kind).toBe('workspace.exec');
+    expect(r.audit[0].decision).toBe('allow');
+  });
+
+  it('allows curated cat only for files inside declared roots', async () => {
+    const root = path.join(dir, 'workspace');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    const inside = path.join(root, 'note.txt');
+    const command = path.join(root, 'cmd.sh');
+    fs.writeFileSync(inside, 'VISIBLE');
+    fs.writeFileSync(command, 'cat note.txt');
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'workspace.exec', '--command-file', command, '--cwd', root, '--roots-file', roots]);
+    expect(r.code).toBe(0);
+    expect(r.out).toBe('VISIBLE');
+    expect(r.audit[0].decision).toBe('allow');
+  });
+
+  it('denies curated path arguments outside declared roots', async () => {
+    const root = path.join(dir, 'workspace');
+    const outside = path.join(dir, 'outside');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    const secret = path.join(outside, 'secret.txt');
+    const command = path.join(root, 'cmd.sh');
+    fs.writeFileSync(secret, 'TOPSECRET');
+    fs.writeFileSync(command, `cat ${secret}`);
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'workspace.exec', '--command-file', command, '--cwd', root, '--roots-file', roots]);
+    expect(r.code).toBe(46);
+    expect(r.out + r.err + JSON.stringify(r.audit)).not.toContain('TOPSECRET');
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('outside-root');
+  });
+
+  it('denies unsupported raw shell commands', async () => {
+    const root = path.join(dir, 'workspace');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    const command = path.join(root, 'cmd.sh');
+    fs.writeFileSync(command, 'bash -lc cat /tmp/secret.txt');
+    fs.writeFileSync(roots, root + '\n');
+
+    const r = await runBrokerArgs(dir, ['--op', 'workspace.exec', '--command-file', command, '--cwd', root, '--roots-file', roots]);
+    expect(r.code).toBe(46);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('unsupported-command');
+  });
+
+  it('denies cwd outside roots', async () => {
+    const root = path.join(dir, 'workspace');
+    const outside = path.join(dir, 'outside');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    const command = path.join(root, 'cmd.sh');
+    fs.writeFileSync(roots, root + '\n');
+    fs.writeFileSync(command, 'printf ok');
+
+    const r = await runBrokerArgs(dir, ['--op', 'workspace.exec', '--command-file', command, '--cwd', outside, '--roots-file', roots]);
+    expect(r.code).toBe(46);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('outside-root');
+  });
+
+  it('hard-denies CRITICAL commands', async () => {
+    const root = path.join(dir, 'workspace');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    const command = path.join(root, 'cmd.sh');
+    fs.writeFileSync(roots, root + '\n');
+    fs.writeFileSync(command, 'rm -rf /');
+
+    const r = await runBrokerArgs(dir, ['--op', 'workspace.exec', '--command-file', command, '--cwd', root, '--roots-file', roots]);
+    expect(r.code).toBe(46);
+    expect(r.audit[0].decision).toBe('deny');
+    expect(r.audit[0].signals).toContain('critical-command');
+  });
+
+  it('enforces timeout', async () => {
+    const root = path.join(dir, 'workspace');
+    const roots = path.join(dir, 'roots.txt');
+    fs.mkdirSync(root);
+    const command = path.join(root, 'cmd.sh');
+    fs.writeFileSync(roots, root + '\n');
+    fs.writeFileSync(command, 'sleep 2');
+
+    const r = await runBrokerArgs(dir, ['--op', 'workspace.exec', '--command-file', command, '--cwd', root, '--roots-file', roots, '--timeout-seconds', '1']);
+    expect(r.code).toBe(124);
+    expect(r.err).toContain('timed out');
+    expect(r.audit[0].exitCode).toBe(124);
   });
 });

--- a/__tests__/capability-exec.test.ts
+++ b/__tests__/capability-exec.test.ts
@@ -1,0 +1,75 @@
+import { buildExecAudit, classifyWorkspaceExec } from '@/lib/capability-exec';
+
+describe('capability-exec pure core', () => {
+  it('allows a curated command inside a workspace root', () => {
+    const verdict = classifyWorkspaceExec({
+      command: 'pwd',
+      cwd: '/home/shelly/projects/shelly-content-studio',
+      roots: ['/home/shelly/projects/shelly-content-studio'],
+    });
+    expect(verdict.decision).toBe('allow');
+    expect(verdict.signals).toContain('inside-root');
+    expect(verdict.command?.template).toBe('pwd');
+  });
+
+  it('denies cwd traversal outside roots', () => {
+    const verdict = classifyWorkspaceExec({
+      command: 'printf ok',
+      cwd: '/home/shelly/projects/shelly-content-studio/../../outside',
+      roots: ['/home/shelly/projects/shelly-content-studio'],
+    });
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.signals).toContain('outside-root');
+  });
+
+  it('hard-denies CRITICAL commands even inside a root', () => {
+    const verdict = classifyWorkspaceExec({
+      command: 'rm -rf /',
+      cwd: '/home/shelly/projects/shelly-content-studio',
+      roots: ['/home/shelly/projects/shelly-content-studio'],
+    });
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.signals).toContain('critical-command');
+    expect(verdict.dangerLevel).toBe('CRITICAL');
+  });
+
+  it('denies commands outside the curated template allowlist', () => {
+    const verdict = classifyWorkspaceExec({
+      command: 'bash -lc cat /tmp/secret.txt',
+      cwd: '/home/shelly/projects/shelly-content-studio',
+      roots: ['/home/shelly/projects/shelly-content-studio'],
+    });
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.signals).toContain('unsupported-command');
+  });
+
+  it('denies curated path arguments outside roots', () => {
+    const verdict = classifyWorkspaceExec({
+      command: 'cat /tmp/secret.txt',
+      cwd: '/home/shelly/projects/shelly-content-studio',
+      roots: ['/home/shelly/projects/shelly-content-studio'],
+    });
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.signals).toContain('outside-root');
+  });
+
+  it('denies shell expansion syntax', () => {
+    const verdict = classifyWorkspaceExec({
+      command: 'printf ${GEMINI_API_KEY}',
+      cwd: '/home/shelly/projects/shelly-content-studio',
+      roots: ['/home/shelly/projects/shelly-content-studio'],
+    });
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.signals).toContain('unsafe-shell-syntax');
+  });
+
+  it('does not include command text in exec audit entries', () => {
+    const verdict = classifyWorkspaceExec({
+      command: 'printf "$GEMINI_API_KEY"',
+      cwd: '/home/shelly/projects/shelly-content-studio',
+      roots: ['/home/shelly/projects/shelly-content-studio'],
+    });
+    const audit = buildExecAudit({ ts: '2026-07-01T00:00:00.000Z', verdict, timeoutSeconds: 1 });
+    expect(JSON.stringify(audit)).not.toContain('GEMINI_API_KEY');
+  });
+});

--- a/__tests__/capability-fs.test.ts
+++ b/__tests__/capability-fs.test.ts
@@ -1,0 +1,32 @@
+import { buildFsAudit, classifyFsAccess } from '@/lib/capability-fs';
+
+describe('capability-fs pure core', () => {
+  it('allows paths inside a declared root after lexical normalization', () => {
+    const verdict = classifyFsAccess({
+      op: 'write',
+      path: '/home/shelly/agent-output/day/../day/result.md',
+      roots: ['/home/shelly/agent-output'],
+    });
+    expect(verdict.decision).toBe('allow');
+    expect(verdict.canonicalPath).toBe('/home/shelly/agent-output/day/result.md');
+    expect(verdict.matchedRoot).toBe('/home/shelly/agent-output');
+  });
+
+  it('denies traversal outside every declared root', () => {
+    const verdict = classifyFsAccess({
+      op: 'write',
+      path: '../../.shelly/agents/.env',
+      cwd: '/home/shelly/agent-output/day',
+      roots: ['/home/shelly/agent-output'],
+    });
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.signals).toContain('outside-root');
+  });
+
+  it('redacts free-text audit reasons', () => {
+    const verdict = classifyFsAccess({ op: 'read', path: 'x', roots: [] });
+    verdict.reason = 'failed with GEMINI_API_KEY=AIzaSECRETSECRETSECRETSECRETSECRETSECRET';
+    const audit = buildFsAudit({ ts: '2026-07-01T00:00:00.000Z', op: 'read', path: 'x', verdict });
+    expect(audit.reason).toContain('<redacted');
+  });
+});

--- a/__tests__/notify-listener/parity.test.ts
+++ b/__tests__/notify-listener/parity.test.ts
@@ -57,7 +57,10 @@ describe('NOTIFY-001 Increment 0 Manifest + native parity (dormant, flag-OFF)', 
   it('threads notification taint into the legacy generated-agent broker path', () => {
     expect(listener).toContain('putExtra(TerminalSessionService.EXTRA_TAINTED, true)');
     expect(service).toContain('getBooleanExtra(EXTRA_TAINTED, false)');
-    expect(service).toContain('AgentRuntime.runAgent(applicationContext, agentId, tainted)');
+    expect(service).toContain('AgentRuntime.runAgent(');
+    expect(service).toContain('applicationContext,');
+    expect(service).toContain('agentId,');
+    expect(service).toContain('tainted = tainted');
     expect(runtime).toContain('export SHELLY_CAP_TAINTED=1');
   });
 

--- a/__tests__/plan-executor-orchestration.test.ts
+++ b/__tests__/plan-executor-orchestration.test.ts
@@ -1,0 +1,174 @@
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { spawn } from 'child_process';
+import { PLAN_SPEC_KIND, PLAN_SPEC_SCHEMA_VERSION } from '@/lib/agent-plan-spec';
+import { buildStepPrompt } from '@/lib/agent-orchestration';
+
+// Option B multi-step orchestration is already wired app-side: agent-manager
+// materializes a per-step PlanSpec and re-dispatches through the native gate into
+// the single-plan executor, threading prior results as prompt text via
+// buildStepPrompt and suppressing the action on non-final steps. This test locks
+// that contract end-to-end against the REAL executor + broker, offline: a
+// __suppressed__ step saves its draft without notifying, and the next step's
+// buildStepPrompt-carried prompt actually reaches the broker's outbound request.
+
+const root = path.resolve(__dirname, '..');
+const executor = path.join(root, 'scripts', 'shelly-plan-executor.js');
+const broker = path.join(root, 'scripts', 'shelly-capability-broker.js');
+
+function makeHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'shelly-plan-orch-'));
+  fs.mkdirSync(path.join(home, '.shelly/agents/plans'), { recursive: true });
+  fs.mkdirSync(path.join(home, '.shelly/tmp'), { recursive: true });
+  return home;
+}
+
+const AGENT_ID = 'agent-orch-smoke';
+
+function writePlan(home: string, port: number, prompt: string, actionType: 'draft' | '__suppressed__') {
+  const plan = {
+    kind: PLAN_SPEC_KIND,
+    schemaVersion: PLAN_SPEC_SCHEMA_VERSION,
+    generatedAt: 1,
+    agent: { id: AGENT_ID, name: 'Orch Smoke', autonomous: false, autonomyLevel: 'L2' },
+    prompt,
+    tool: { type: 'local', label: 'Local LLM', model: 'fixture' },
+    action: { type: actionType },
+    paths: { home },
+    output: {
+      outputDir: path.join(home, 'agent-output'),
+      outputNameTemplate: '{date}-{slug}',
+      slug: 'orch-smoke',
+      useGlobalOutput: true,
+      suggestedRoots: [],
+    },
+    limits: { timeoutSeconds: 30, maxConcurrent: 2 },
+    policy: { level: 'L2', workspaceRoot: home, secretPaths: [], policyPath: '.shelly/agents/policy.json', denyPatterns: [], allowPatterns: [] },
+    routeDecision: { route: 'on-device', toolType: 'local', toolLabel: 'Local LLM', guard: 'configured-tool', why: 'test' },
+  };
+  const planFile = path.join(home, `.shelly/agents/plans/plan-agent-${AGENT_ID}.json`);
+  fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+  fs.writeFileSync(path.join(home, '.shelly/agents/.env'), `LOCAL_LLM_URL='http://127.0.0.1:${port}'\n`);
+  return planFile;
+}
+
+function runExecutor(planFile: string, home: string): Promise<number | null> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [executor, '--plan-file', planFile, '--home', home, '--agent-id', AGENT_ID, '--broker', broker], {
+      env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.on('close', (status) => resolve(status));
+  });
+}
+
+// A __suppressed__ step never requests approval; a terminal draft does. Auto-accept
+// any approval request that appears so the terminal step can complete.
+function autoApprove(home: string): void {
+  const requestDir = path.join(home, '.shelly/agents/action-approvals');
+  const replyDir = path.join(home, '.shelly/agents/action-approval-replies');
+  const timer = setInterval(() => {
+    if (!fs.existsSync(requestDir)) return;
+    for (const name of fs.readdirSync(requestDir)) {
+      if (!name.startsWith('action-') || !name.endsWith('.json')) continue;
+      const bytes = fs.readFileSync(path.join(requestDir, name));
+      const request = JSON.parse(bytes.toString('utf8'));
+      const requestSha256 = crypto.createHash('sha256').update(bytes).digest('hex');
+      fs.mkdirSync(replyDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(replyDir, `action-${request.runId}.reply.json`),
+        JSON.stringify({ runId: request.runId, decision: 'accept', by: 'test', requestSha256, ts: new Date().toISOString() }) + '\n',
+      );
+    }
+  }, 40);
+  (autoApprove as any)._timer = timer;
+}
+function stopAutoApprove(): void {
+  if ((autoApprove as any)._timer) clearInterval((autoApprove as any)._timer);
+}
+
+describe('shelly-plan-executor orchestration (Option B per-step contract)', () => {
+  let server: http.Server;
+  let port = 0;
+  let requestPrompts: string[];
+
+  beforeEach((done) => {
+    requestPrompts = [];
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        const parsed = JSON.parse(body);
+        const userContent = parsed.messages[0].content;
+        requestPrompts.push(userContent);
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ choices: [{ message: { content: `RESULT#${requestPrompts.length}` } }] }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      port = (server.address() as any).port;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    stopAutoApprove();
+    server.close(done);
+  });
+
+  it('carries prior-step results into the next step and only the final step notifies', async () => {
+    const home = makeHome();
+    autoApprove(home);
+    const notifyFile = path.join(home, `.shelly/agents/logs/${AGENT_ID}/native-result-notification.json`);
+
+    // Step 1 — non-final, suppressed. Saves a draft for the next step, no notification.
+    const step1Prompt = buildStepPrompt('Base task', 'gather the sources', []);
+    const rc1 = await runExecutor(writePlan(home, port, step1Prompt, '__suppressed__'), home);
+    expect(rc1).toBe(0);
+    const step1Result = fs.readFileSync(path.join(home, '.shelly/tmp', `agent-result-${AGENT_ID}.md`), 'utf8').trim();
+    expect(step1Result).toBe('RESULT#1');
+    // Suppressed step wrote a draft but did NOT fire a completion notification.
+    expect(listMd(path.join(home, 'agent-output')).length).toBeGreaterThanOrEqual(1);
+    expect(fs.existsSync(notifyFile)).toBe(false);
+
+    // Step 2 — final, draft. Prompt is built (as agent-manager does) from the base
+    // prompt + step 1's carried result.
+    const step2Prompt = buildStepPrompt('Base task', 'write the article from the sources', [step1Result]);
+    const rc2 = await runExecutor(writePlan(home, port, step2Prompt, 'draft'), home);
+    expect(rc2).toBe(0);
+
+    // The carried prior result actually reached the broker's outbound request for step 2.
+    expect(requestPrompts).toHaveLength(2);
+    expect(requestPrompts[1]).toContain('RESULT#1');
+    expect(requestPrompts[1]).toContain('# Results from previous steps');
+    expect(requestPrompts[1]).toContain('write the article from the sources');
+
+    // Final step notified exactly once, with a shape-compatible run log.
+    expect(fs.existsSync(notifyFile)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(notifyFile, 'utf8')).status).toBe('success');
+    const logDir = path.join(home, `.shelly/agents/logs/${AGENT_ID}`);
+    const runLogs = fs.readdirSync(logDir).filter((n) => /^\d+\.json$/.test(n));
+    expect(runLogs.length).toBeGreaterThanOrEqual(1);
+    const lastLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs.sort()[runLogs.length - 1]), 'utf8'));
+    expect(lastLog).toMatchObject({ status: 'success', executor: 'planspec', toolUsed: 'Local LLM' });
+  });
+});
+
+function listMd(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listMd(full));
+    else if (entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -91,6 +91,15 @@ describe('shelly-plan-executor.js parity', () => {
     expect(executorSrc).toContain('delete env.LD_PRELOAD');
   });
 
+  it('resets the per-run CAP budget envelope at run start (wall-time-budget guard)', () => {
+    const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
+    // The broker budget file is keyed per-agent and persists; without a per-run
+    // reset the wall-time budget runs from the first-ever run and every later run
+    // fails rc=42 "wall-time budget exhausted" (found in device-verify). Match the
+    // .sh path which rm's it at run start.
+    expect(executorSrc).toMatch(/fs\.rmSync\(path\.join\(paths\.tmpDir, `cap-budget-\$\{plan\.agent\.id\}\.json`\)/);
+  });
+
   it('honors the STOP-ALL kill-switch in both the native gate and the executor', () => {
     const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
     expect(agentRuntime).toContain('.shelly/agents/.halted');

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -1,0 +1,42 @@
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { PLAN_SPEC_SCHEMA_VERSION } from '@/lib/agent-plan-spec';
+
+describe('shelly-plan-executor.js parity', () => {
+  const root = path.resolve(__dirname, '..');
+  const scriptCopy = path.join(root, 'scripts', 'shelly-plan-executor.js');
+  const assetCopy = path.join(root, 'modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js');
+  const homeInitializer = fs.readFileSync(
+    path.join(root, 'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt'),
+    'utf8',
+  );
+  const agentRuntime = fs.readFileSync(
+    path.join(root, 'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt'),
+    'utf8',
+  );
+
+  it('scripts/ copy and the APK asset are byte-identical', () => {
+    expect(fs.readFileSync(assetCopy, 'utf8')).toBe(fs.readFileSync(scriptCopy, 'utf8'));
+  });
+
+  it('extracts the plan executor asset into Shelly HOME', () => {
+    expect(homeInitializer).toContain('shelly-plan-executor.js');
+    expect(homeInitializer).toContain('.shelly-plan-executor.js');
+  });
+
+  it('keeps schema version lockstep across TS, JS, and native gate', () => {
+    const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
+    expect(executorSrc).toContain(`const PLAN_SPEC_SCHEMA_VERSION = ${PLAN_SPEC_SCHEMA_VERSION}`);
+    expect(agentRuntime).toContain(`private const val CURRENT_PLAN_SPEC_VERSION = ${PLAN_SPEC_SCHEMA_VERSION}`);
+  });
+
+  it('gates the canary by both flag and target agent id', () => {
+    expect(agentRuntime).toContain('SHELLY_PLAN_EXECUTOR');
+    expect(agentRuntime).toContain('SHELLY_PLAN_EXECUTOR_AGENT_ID');
+    expect(agentRuntime).toContain('return flags["SHELLY_PLAN_EXECUTOR_AGENT_ID"] == agentId');
+  });
+});

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -85,8 +85,9 @@ describe('shelly-plan-executor.js parity', () => {
   it('does not pass LD_PRELOAD to the leaf node (bionic OpenSSL crash guard)', () => {
     const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
     // The exec wrapper preload is only for shell/codex exec, not the pure-node
-    // broker/executor: it corrupts node's OpenSSL config read on device.
-    expect(agentRuntime).not.toContain('LD_PRELOAD');
+    // broker/executor: explicitly clear it before launching bionic node.
+    expect(agentRuntime).toContain('unset LD_PRELOAD && /system/bin/linker64');
+    expect(agentRuntime).not.toContain('export LD_PRELOAD');
     expect(executorSrc).toContain('delete env.LD_PRELOAD');
   });
 

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -66,4 +66,34 @@ describe('shelly-plan-executor.js parity', () => {
     expect(terminalSessionService).toContain('tainted = tainted');
     expect(terminalSessionService).toContain('unattended = unattended');
   });
+
+  it('launches the executor via linker64 node with SHELLY_LIB_DIR and the plan version gate', () => {
+    // Startup contract: bionic node under the dynamic linker, lib dir exported,
+    // and the schema-version gate that refuses a stale on-disk PlanSpec.
+    expect(agentRuntime).toContain('/system/bin/linker64');
+    expect(agentRuntime).toContain('"$libPath/node"');
+    expect(agentRuntime).toContain('export SHELLY_LIB_DIR=');
+    expect(agentRuntime).toContain('planVersion != CURRENT_PLAN_SPEC_VERSION');
+  });
+
+  it('never falls back to the .sh runner once the PlanSpec path is chosen', () => {
+    // shouldRunPlanExecutor => `return runPlanAgent(...)`, so the flag-gated canary
+    // returns its own result and can never source run-agent-<id>.sh on failure.
+    expect(agentRuntime).toContain('return runPlanAgent(');
+  });
+
+  it('does not pass LD_PRELOAD to the leaf node (bionic OpenSSL crash guard)', () => {
+    const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
+    // The exec wrapper preload is only for shell/codex exec, not the pure-node
+    // broker/executor: it corrupts node's OpenSSL config read on device.
+    expect(agentRuntime).not.toContain('LD_PRELOAD');
+    expect(executorSrc).toContain('delete env.LD_PRELOAD');
+  });
+
+  it('honors the STOP-ALL kill-switch in both the native gate and the executor', () => {
+    const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
+    expect(agentRuntime).toContain('.shelly/agents/.halted');
+    expect(executorSrc).toContain('paths.haltSentinel');
+    expect(executorSrc).toContain("haltSentinel: path.join(agentsDir, '.halted')");
+  });
 });

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -18,6 +18,10 @@ describe('shelly-plan-executor.js parity', () => {
     path.join(root, 'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt'),
     'utf8',
   );
+  const terminalSessionService = fs.readFileSync(
+    path.join(root, 'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalSessionService.kt'),
+    'utf8',
+  );
 
   it('scripts/ copy and the APK asset are byte-identical', () => {
     expect(fs.readFileSync(assetCopy, 'utf8')).toBe(fs.readFileSync(scriptCopy, 'utf8'));
@@ -40,9 +44,26 @@ describe('shelly-plan-executor.js parity', () => {
     expect(agentRuntime).toContain('return flags["SHELLY_PLAN_EXECUTOR_AGENT_ID"] == agentId');
   });
 
-  it('does not trust plan.agent.autonomous to skip action approval', () => {
+  it('passes native trust state separately from the untrusted plan file', () => {
     const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
-    expect(executorSrc).toContain('requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config)');
+    expect(agentRuntime).toContain('readPlanSpecAgentId(plan)');
+    expect(agentRuntime).toContain('PlanSpec agent id mismatch');
+    expect(agentRuntime).toContain('--agent-id');
+    expect(agentRuntime).toContain('--unattended 1');
+    expect(agentRuntime).toContain('--trusted-autonomous-agent-id');
+    expect(agentRuntime).toContain('--trusted-autonomous-action');
+    expect(agentRuntime).toContain('--trusted-tool-type');
+    expect(executorSrc).toContain('trustedNativeLowRiskAction(args, plan, actionType)');
+    expect(executorSrc).toContain("trustedTool === 'local' && plan.tool.type === 'local'");
     expect(executorSrc).not.toContain('if (!plan.agent.autonomous) requestActionApproval');
+    expect(executorSrc).not.toContain('plan.paths && plan.paths.home');
+  });
+
+  it('derives unattended mode from scheduled service extras before launching the agent', () => {
+    expect(terminalSessionService).toContain('val intervalMs = intent.getLongExtra(EXTRA_INTERVAL_MS, 0L)');
+    expect(terminalSessionService).toContain('val unattended = intervalMs > 0 || !cron.isNullOrBlank()');
+    expect(terminalSessionService).toContain('runAgentInBackground(agentId, tainted, unattended)');
+    expect(terminalSessionService).toContain('tainted = tainted');
+    expect(terminalSessionService).toContain('unattended = unattended');
   });
 });

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -39,4 +39,10 @@ describe('shelly-plan-executor.js parity', () => {
     expect(agentRuntime).toContain('SHELLY_PLAN_EXECUTOR_AGENT_ID');
     expect(agentRuntime).toContain('return flags["SHELLY_PLAN_EXECUTOR_AGENT_ID"] == agentId');
   });
+
+  it('does not trust plan.agent.autonomous to skip action approval', () => {
+    const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
+    expect(executorSrc).toContain('requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config)');
+    expect(executorSrc).not.toContain('if (!plan.agent.autonomous) requestActionApproval');
+  });
 });

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -227,6 +227,44 @@ describe('shelly-plan-executor host smoke', () => {
     expect(planAudit).toContain('"event":"plan_finish"');
   });
 
+  it('refuses to run when the global kill-switch (.halted) sentinel is present', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    fs.writeFileSync(path.join(home, '.shelly/agents/.halted'), 'halted\n');
+
+    const result = await runExecutor([executor, '--plan-file', planFile, '--home', home, '--broker', broker], home);
+
+    expect(result.status).toBe(0);
+    // Fail-closed before any model IO: the loopback fixture is never hit.
+    expect(requestCount).toBe(0);
+    expect(listMarkdownFiles(path.join(home, 'agent-output'))).toHaveLength(0);
+
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog.status).toBe('skipped');
+    expect(runLog.errorMessage).toContain('global kill-switch');
+
+    const planAudit = fs.readFileSync(path.join(logDir, 'plan-executor-audit.jsonl'), 'utf8');
+    expect(planAudit).toContain('"status":"skipped"');
+    // Broker was never invoked, so no broker audit file was produced.
+    expect(fs.existsSync(path.join(logDir, 'agent-driver-audit.jsonl'))).toBe(false);
+  });
+
+  it('writes the native-result-notification.json completion request on a successful draft', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+
+    const result = await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--broker', broker], home);
+    expect(result.status).toBe(0);
+
+    const notifyFile = path.join(home, `.shelly/agents/logs/${plan.agent.id}/native-result-notification.json`);
+    expect(fs.existsSync(notifyFile)).toBe(true);
+    const notify = JSON.parse(fs.readFileSync(notifyFile, 'utf8'));
+    expect(notify).toMatchObject({ agentId: plan.agent.id, status: 'success' });
+    expect(notify.preview).toContain('fixture result: say hello');
+  });
+
   it('denies a symlink outputDir instead of adding it as a scoped root', async () => {
     const home = makeHome();
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'shelly-plan-outside-'));

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -144,6 +144,20 @@ async function readNextActionRequest(home: string): Promise<{ file: string; requ
   throw new Error('timed out waiting for action approval request');
 }
 
+function writeActionReply(home: string, pending: { request: any; sha: string }, decision = 'accept'): void {
+  fs.mkdirSync(path.join(home, '.shelly/agents/action-approval-replies'), { recursive: true });
+  fs.writeFileSync(
+    path.join(home, '.shelly/agents/action-approval-replies', `action-${pending.request.runId}.reply.json`),
+    JSON.stringify({
+      runId: pending.request.runId,
+      decision,
+      by: 'test',
+      requestSha256: pending.sha,
+      ts: new Date().toISOString(),
+    }) + '\n',
+  );
+}
+
 describe('shelly-plan-executor host smoke', () => {
   let server: http.Server;
   let port = 0;
@@ -380,19 +394,104 @@ describe('shelly-plan-executor host smoke', () => {
     expect(pending.request.preview).toContain('<redacted>');
     expect(pending.request.preview).not.toContain('gsk_abcdefghijklmnopqrstuvwxyz1234567890');
 
-    fs.mkdirSync(path.join(home, '.shelly/agents/action-approval-replies'), { recursive: true });
-    fs.writeFileSync(
-      path.join(home, '.shelly/agents/action-approval-replies', `action-${pending.request.runId}.reply.json`),
-      JSON.stringify({
-        runId: pending.request.runId,
-        decision: 'accept',
-        by: 'test',
-        requestSha256: pending.sha,
-        ts: new Date().toISOString(),
-      }) + '\n',
-    );
+    writeActionReply(home, pending);
     const result = await run;
     expect(result.status).toBe(0);
+  });
+
+  it('requests webhook approval with destination host and payload path, then skips on decline without sending', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    (plan as any).action = { type: 'webhook', webhookUrl: 'https://hooks.example.test/incoming' };
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const run = runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--broker', broker,
+    ], home);
+    const pending = await readNextActionRequest(home);
+    expect(pending.request.actionType).toBe('webhook');
+    expect(pending.request.destinationHost).toBe('hooks.example.test');
+    expect(pending.request.payloadPath).toContain('webhook-payload-');
+    expect(fs.readFileSync(pending.request.payloadPath, 'utf8')).toContain('"result":"fixture result: say hello"');
+
+    writeActionReply(home, pending, 'decline');
+    const result = await run;
+    expect(result.status).toBe(0);
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog.status).toBe('skipped');
+    expect(runLog.errorMessage).toContain('webhook action declined');
+    const brokerAudit = fs.readFileSync(path.join(logDir, 'agent-driver-audit.jsonl'), 'utf8');
+    expect(brokerAudit).toContain('"kind":"http.request"');
+    expect(brokerAudit).not.toContain('hooks.example.test');
+  });
+
+  it('runs approved cli actions through workspace.exec and appends the action report', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    (plan as any).action = {
+      type: 'cli',
+      command: 'printf ok',
+      safety: { level: 'SAFE', reason: 'No risky command pattern matched.', message: '', autoApprovable: true },
+    };
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const result = await runExecutorWithApproval([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(0);
+    const resultFile = path.join(home, `.shelly/tmp/agent-result-${plan.agent.id}.md`);
+    const resultText = fs.readFileSync(resultFile, 'utf8');
+    expect(resultText).toContain('## CLI action');
+    expect(resultText).toContain('Command:');
+    expect(resultText).toContain('printf ok');
+    expect(resultText).toContain('Exit code: 0');
+    expect(resultText).toContain('ok');
+
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const brokerAudit = fs.readFileSync(path.join(logDir, 'agent-driver-audit.jsonl'), 'utf8');
+    expect(brokerAudit).toContain('"kind":"workspace.exec"');
+    expect(brokerAudit).toContain('"decision":"allow"');
+  });
+
+  it('keeps webhook and cli actions fail-closed in unattended mode', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    (plan as any).action = { type: 'cli', command: 'printf ok' };
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--unattended', '1',
+      '--trusted-autonomous-agent-id', plan.agent.id,
+      '--trusted-autonomous-action', 'cli',
+      '--trusted-tool-type', 'local',
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(0);
+    expect(requestCount).toBe(0);
+    const requestDir = path.join(home, '.shelly/agents/action-approvals');
+    const approvalRequests = fs.existsSync(requestDir) ? fs.readdirSync(requestDir) : [];
+    expect(approvalRequests).toHaveLength(0);
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog.status).toBe('skipped');
+    expect(runLog.errorMessage).toContain('unsupported unattended PlanSpec action: cli');
   });
 
   it('redacts secret-like model text from previews and native notifications', async () => {

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -1,0 +1,158 @@
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { PLAN_SPEC_KIND, PLAN_SPEC_SCHEMA_VERSION } from '@/lib/agent-plan-spec';
+
+const root = path.resolve(__dirname, '..');
+const executor = path.join(root, 'scripts', 'shelly-plan-executor.js');
+const broker = path.join(root, 'scripts', 'shelly-capability-broker.js');
+
+function makeHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'shelly-plan-executor-'));
+  fs.mkdirSync(path.join(home, '.shelly/agents/plans'), { recursive: true });
+  fs.mkdirSync(path.join(home, '.shelly/tmp'), { recursive: true });
+  return home;
+}
+
+function makePlan(home: string, port: number) {
+  const agentId = 'agent-plan-smoke';
+  const plan = {
+    kind: PLAN_SPEC_KIND,
+    schemaVersion: PLAN_SPEC_SCHEMA_VERSION,
+    generatedAt: 1,
+    agent: { id: agentId, name: 'Plan Smoke', autonomous: true, autonomyLevel: 'L2' },
+    prompt: 'say hello',
+    tool: { type: 'local', label: 'Local LLM', model: 'fixture' },
+    action: { type: 'draft' },
+    paths: { home },
+    output: {
+      outputDir: path.join(home, 'agent-output'),
+      outputNameTemplate: '{date}-{slug}',
+      slug: 'plan-smoke',
+      useGlobalOutput: true,
+      suggestedRoots: [],
+    },
+    limits: { timeoutSeconds: 30, maxConcurrent: 2 },
+    policy: { level: 'L2', workspaceRoot: home, secretPaths: [], policyPath: '.shelly/agents/policy.json', denyPatterns: [], allowPatterns: [] },
+    routeDecision: { route: 'on-device', toolType: 'local', toolLabel: 'Local LLM', guard: 'configured-tool', why: 'test' },
+  };
+  const planFile = path.join(home, `.shelly/agents/plans/plan-agent-${agentId}.json`);
+  fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+  fs.writeFileSync(path.join(home, '.shelly/agents/.env'), `LOCAL_LLM_URL='http://127.0.0.1:${port}'\n`);
+  return { plan, planFile };
+}
+
+function listMarkdownFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listMarkdownFiles(full));
+    else if (entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+function runExecutor(args: string[], home: string): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('shelly-plan-executor host smoke', () => {
+  let server: http.Server;
+  let port = 0;
+
+  beforeEach((done) => {
+    server = http.createServer((req, res) => {
+      if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
+        res.statusCode = 404;
+        res.end('not found');
+        return;
+      }
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        const parsed = JSON.parse(body);
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({
+          choices: [{ message: { content: `fixture result: ${parsed.messages[0].content}` } }],
+        }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      port = typeof address === 'object' && address ? address.port : 0;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    server.close(done);
+  });
+
+  it('runs local loopback through the broker, writes draft output, log, and audits', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+
+    const result = await runExecutor([executor, '--plan-file', planFile, '--home', home, '--broker', broker], home);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+
+    const outputFiles = listMarkdownFiles(path.join(home, 'agent-output'));
+    expect(outputFiles).toHaveLength(1);
+    expect(fs.readFileSync(outputFiles[0], 'utf8')).toContain('fixture result: say hello');
+
+    const logs = listMarkdownFiles(path.join(home, '.shelly/agents/logs'));
+    expect(logs).toHaveLength(0);
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    expect(runLogs).toHaveLength(1);
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog).toMatchObject({ status: 'success', executor: 'planspec', toolUsed: 'Local LLM' });
+
+    const brokerAudit = fs.readFileSync(path.join(logDir, 'agent-driver-audit.jsonl'), 'utf8');
+    expect(brokerAudit).toContain('"kind":"http.request"');
+    expect(brokerAudit).toContain('"kind":"scoped.fs"');
+    expect(brokerAudit).not.toContain('Bearer ');
+
+    const planAudit = fs.readFileSync(path.join(logDir, 'plan-executor-audit.jsonl'), 'utf8');
+    expect(planAudit).toContain('"event":"plan_start"');
+    expect(planAudit).toContain('"event":"plan_finish"');
+  });
+
+  it('fails closed when the broker asset is missing', async () => {
+    const home = makeHome();
+    const { planFile } = makePlan(home, port);
+    const missingBroker = path.join(home, 'missing-broker.js');
+
+    const result = await runExecutor([executor, '--plan-file', planFile, '--home', home, '--broker', missingBroker], home);
+
+    expect(result.status).toBe(48);
+    expect(listMarkdownFiles(path.join(home, 'agent-output'))).toHaveLength(0);
+  });
+});

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -399,7 +399,7 @@ describe('shelly-plan-executor host smoke', () => {
     expect(result.status).toBe(0);
   });
 
-  it('requests webhook approval with destination host and payload path, then skips on decline without sending', async () => {
+  it('requests webhook approval with destination host and redacted payload path, then skips on decline without sending', async () => {
     const home = makeHome();
     const { plan, planFile } = makePlan(home, port);
     (plan as any).action = { type: 'webhook', webhookUrl: 'https://hooks.example.test/incoming' };
@@ -415,8 +415,10 @@ describe('shelly-plan-executor host smoke', () => {
     const pending = await readNextActionRequest(home);
     expect(pending.request.actionType).toBe('webhook');
     expect(pending.request.destinationHost).toBe('hooks.example.test');
-    expect(pending.request.payloadPath).toContain('webhook-payload-');
-    expect(fs.readFileSync(pending.request.payloadPath, 'utf8')).toContain('"result":"fixture result: say hello"');
+    expect(pending.request.payloadPath).toMatch(/^webhook-payload-\d+\.json$/);
+    expect(pending.request.payloadPath).not.toContain(home);
+    const actualPayloadPath = path.join(home, `.shelly/agents/logs/${plan.agent.id}`, pending.request.payloadPath);
+    expect(fs.readFileSync(actualPayloadPath, 'utf8')).toContain('"result":"fixture result: say hello"');
 
     writeActionReply(home, pending, 'decline');
     const result = await run;
@@ -462,6 +464,38 @@ describe('shelly-plan-executor host smoke', () => {
     const brokerAudit = fs.readFileSync(path.join(logDir, 'agent-driver-audit.jsonl'), 'utf8');
     expect(brokerAudit).toContain('"kind":"workspace.exec"');
     expect(brokerAudit).toContain('"decision":"allow"');
+  });
+
+  it('recomputes cli safety in the executor and blocks critical command tampering', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    (plan as any).action = {
+      type: 'cli',
+      command: 'rm -rf /',
+      safety: { level: 'SAFE', reason: 'tampered safe classification', message: '', autoApprovable: true },
+    };
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(0);
+    const requestDir = path.join(home, '.shelly/agents/action-approvals');
+    const approvalRequests = fs.existsSync(requestDir) ? fs.readdirSync(requestDir) : [];
+    expect(approvalRequests).toHaveLength(0);
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog.status).toBe('error');
+    expect(runLog.errorMessage).toContain('blocked by command safety');
+    const brokerAudit = fs.readFileSync(path.join(logDir, 'agent-driver-audit.jsonl'), 'utf8');
+    expect(brokerAudit).toContain('"kind":"http.request"');
+    expect(brokerAudit).not.toContain('"kind":"workspace.exec"');
   });
 
   it('keeps webhook and cli actions fail-closed in unattended mode', async () => {

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { spawn } from 'child_process';
 import { PLAN_SPEC_KIND, PLAN_SPEC_SCHEMA_VERSION } from '@/lib/agent-plan-spec';
 
@@ -79,6 +80,46 @@ function runExecutor(args: string[], home: string): Promise<{ status: number | n
   });
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function approveNextAction(home: string): Promise<void> {
+  const requestDir = path.join(home, '.shelly/agents/action-approvals');
+  const replyDir = path.join(home, '.shelly/agents/action-approval-replies');
+  for (let i = 0; i < 100; i += 1) {
+    const requests = fs.existsSync(requestDir)
+      ? fs.readdirSync(requestDir).filter((name) => name.startsWith('action-') && name.endsWith('.json'))
+      : [];
+    if (requests.length > 0) {
+      const requestFile = path.join(requestDir, requests[0]);
+      const bytes = fs.readFileSync(requestFile);
+      const request = JSON.parse(bytes.toString('utf8'));
+      const requestSha256 = crypto.createHash('sha256').update(bytes).digest('hex');
+      fs.mkdirSync(replyDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(replyDir, `action-${request.runId}.reply.json`),
+        JSON.stringify({
+          runId: request.runId,
+          decision: 'accept',
+          by: 'test',
+          requestSha256,
+          ts: new Date().toISOString(),
+        }) + '\n',
+      );
+      return;
+    }
+    await delay(50);
+  }
+  throw new Error('timed out waiting for action approval request');
+}
+
+function runExecutorWithApproval(args: string[], home: string): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  const run = runExecutor(args, home);
+  void approveNextAction(home).catch(() => undefined);
+  return run;
+}
+
 describe('shelly-plan-executor host smoke', () => {
   let server: http.Server;
   let port = 0;
@@ -118,7 +159,7 @@ describe('shelly-plan-executor host smoke', () => {
     const home = makeHome();
     const { plan, planFile } = makePlan(home, port);
 
-    const result = await runExecutor([executor, '--plan-file', planFile, '--home', home, '--broker', broker], home);
+    const result = await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--broker', broker], home);
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');
@@ -143,6 +184,38 @@ describe('shelly-plan-executor host smoke', () => {
     const planAudit = fs.readFileSync(path.join(logDir, 'plan-executor-audit.jsonl'), 'utf8');
     expect(planAudit).toContain('"event":"plan_start"');
     expect(planAudit).toContain('"event":"plan_finish"');
+  });
+
+  it('denies a symlink outputDir instead of adding it as a scoped root', async () => {
+    const home = makeHome();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'shelly-plan-outside-'));
+    const outsideReal = path.join(outside, 'real');
+    fs.mkdirSync(outsideReal, { recursive: true });
+    const linkDir = path.join(home, 'agent-output/linkdir');
+    fs.mkdirSync(path.dirname(linkDir), { recursive: true });
+    fs.symlinkSync(outsideReal, linkDir, 'dir');
+
+    const { plan, planFile } = makePlan(home, port);
+    plan.output.useGlobalOutput = false;
+    plan.output.outputDir = linkDir;
+    plan.output.outputNameTemplate = 'escaped';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const result = await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--broker', broker], home);
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(outsideReal, 'escaped.md'))).toBe(false);
+
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog.status).toBe('error');
+    expect(runLog.errorMessage).toContain('scoped filesystem write denied');
+
+    const brokerAudit = fs.readFileSync(path.join(logDir, 'agent-driver-audit.jsonl'), 'utf8');
+    expect(brokerAudit).toContain('"kind":"scoped.fs"');
+    expect(brokerAudit).toContain('"decision":"deny"');
+    expect(brokerAudit).toContain('outside-root');
   });
 
   it('fails closed when the broker asset is missing', async () => {

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -532,6 +532,49 @@ describe('shelly-plan-executor host smoke', () => {
     expect(JSON.parse(fs.readFileSync(path.join(runLogDir, runLogs[0]), 'utf8')).status).toBe('success');
   });
 
+  it('appends newline-separated draft source URLs to the shared registry, deduped (.sh parity)', async () => {
+    const home = makeHome();
+    const contentProject = path.join(home, 'content');
+    fs.mkdirSync(path.join(contentProject, 'sources'), { recursive: true });
+    const { plan, planFile } = makePlan(home, port);
+    plan.output.useGlobalOutput = false;
+    plan.output.outputDir = path.join(contentProject, 'drafts/x');
+    plan.output.outputNameTemplate = '{date}-{slug}';
+    // URLs on separate lines: the line-oriented .sh grep must not merge them.
+    plan.prompt = 'refs:\nhttps://a.example/x\nhttps://b.example/y';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+    fs.writeFileSync(path.join(home, '.shelly/agents/.env'), `LOCAL_LLM_URL='http://127.0.0.1:${port}'\nSHELLY_CONTENT_PROJECT='${contentProject}'\n`);
+
+    const registry = path.join(contentProject, 'sources', 'source-registry.tsv');
+    await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--agent-id', plan.agent.id, '--broker', broker], home);
+    const rows1 = fs.readFileSync(registry, 'utf8').trim().split('\n');
+    expect(rows1).toHaveLength(2);
+    // Column 4 (tab-separated) is the URL; adjacent-line URLs stay separate, not merged.
+    expect(rows1.map((r) => r.split('\t')[3])).toEqual(['https://a.example/x', 'https://b.example/y']);
+
+    // Re-running the same agent must not duplicate URLs already in the registry.
+    await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--agent-id', plan.agent.id, '--broker', broker], home);
+    expect(fs.readFileSync(registry, 'utf8').trim().split('\n')).toHaveLength(2);
+  });
+
+  it('creates the source registry on a fresh content-studio project (.sh parity)', async () => {
+    const home = makeHome();
+    const contentProject = path.join(home, 'fresh-content');
+    // No pre-existing sources/ dir: the .sh mkdir -p's it at startup, so URLs still register.
+    const { plan, planFile } = makePlan(home, port);
+    plan.output.useGlobalOutput = false;
+    plan.output.outputDir = path.join(contentProject, 'drafts/x');
+    plan.prompt = 'ref https://c.example/z';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+    fs.writeFileSync(path.join(home, '.shelly/agents/.env'), `LOCAL_LLM_URL='http://127.0.0.1:${port}'\nSHELLY_CONTENT_PROJECT='${contentProject}'\n`);
+
+    const result = await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--agent-id', plan.agent.id, '--broker', broker], home);
+    expect(result.status).toBe(0);
+    const registry = path.join(contentProject, 'sources', 'source-registry.tsv');
+    expect(fs.existsSync(registry)).toBe(true);
+    expect(fs.readFileSync(registry, 'utf8')).toContain('https://c.example/z');
+  });
+
   it('mirrors a content-studio draft into the keyword-routed Obsidian vault (.sh parity)', async () => {
     const home = makeHome();
     const vault = path.join(home, 'vault');

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -504,6 +504,52 @@ describe('shelly-plan-executor host smoke', () => {
     expect(brokerAudit).toContain('"decision":"allow"');
   });
 
+  it('mirrors a content-studio draft into the keyword-routed Obsidian vault (.sh parity)', async () => {
+    const home = makeHome();
+    const vault = path.join(home, 'vault');
+    fs.mkdirSync(vault, { recursive: true });
+    const { plan, planFile } = makePlan(home, port);
+    plan.output.useGlobalOutput = false;
+    plan.output.outputDir = path.join(home, 'projects/shelly-content-studio/drafts/x');
+    plan.output.outputNameTemplate = '{date}-{slug}';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+    fs.writeFileSync(path.join(home, '.shelly/agents/.env'), `LOCAL_LLM_URL='http://127.0.0.1:${port}'\nOBSIDIAN_VAULT_PATH='${vault}'\n`);
+
+    const result = await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--agent-id', plan.agent.id, '--broker', broker], home);
+    expect(result.status).toBe(0);
+
+    const primary = listMarkdownFiles(plan.output.outputDir);
+    expect(primary).toHaveLength(1);
+    // drafts/x -> 50_Drafts/X keyword route (lib/agent-executor.ts save_draft_result).
+    const mirror = listMarkdownFiles(path.join(vault, '50_Drafts/X'));
+    expect(mirror).toHaveLength(1);
+    expect(fs.readFileSync(mirror[0], 'utf8')).toBe(fs.readFileSync(primary[0], 'utf8'));
+    expect(fs.readFileSync(mirror[0], 'utf8')).toContain('fixture result: say hello');
+    // Both writes went through the broker's scoped.fs (root-jailed), not raw fs.
+    const brokerAudit = fs.readFileSync(path.join(home, `.shelly/agents/logs/${plan.agent.id}/agent-driver-audit.jsonl`), 'utf8');
+    const scopedWrites = brokerAudit.split('\n').filter((l) => l.includes('"kind":"scoped.fs"') && l.includes('"decision":"allow"'));
+    expect(scopedWrites.length).toBe(2);
+  });
+
+  it('skips the Obsidian mirror when no vault directory is present (silent, like the .sh)', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    plan.output.useGlobalOutput = false;
+    plan.output.outputDir = path.join(home, 'projects/shelly-content-studio/drafts/x');
+    plan.output.outputNameTemplate = '{date}-{slug}';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+    // OBSIDIAN_VAULT_PATH points at a non-existent dir: the mirror must be skipped, run still succeeds.
+    fs.writeFileSync(path.join(home, '.shelly/agents/.env'), `LOCAL_LLM_URL='http://127.0.0.1:${port}'\nOBSIDIAN_VAULT_PATH='${path.join(home, 'no-vault')}'\n`);
+
+    const result = await runExecutorWithApproval([executor, '--plan-file', planFile, '--home', home, '--agent-id', plan.agent.id, '--broker', broker], home);
+    expect(result.status).toBe(0);
+    expect(listMarkdownFiles(plan.output.outputDir)).toHaveLength(1);
+    expect(fs.existsSync(path.join(home, 'no-vault'))).toBe(false);
+    const runLogDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(runLogDir).filter((name) => /^\d+\.json$/.test(name));
+    expect(JSON.parse(fs.readFileSync(path.join(runLogDir, runLogs[0]), 'utf8')).status).toBe('success');
+  });
+
   it('recomputes cli safety in the executor and blocks critical command tampering', async () => {
     const home = makeHome();
     const { plan, planFile } = makePlan(home, port);

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -504,6 +504,34 @@ describe('shelly-plan-executor host smoke', () => {
     expect(brokerAudit).toContain('"decision":"allow"');
   });
 
+  it('saves the draft (primary + mirror) for a __suppressed__ orchestration step without approval or notification', async () => {
+    const home = makeHome();
+    const vault = path.join(home, 'vault');
+    fs.mkdirSync(vault, { recursive: true });
+    const { plan, planFile } = makePlan(home, port);
+    plan.action = { type: '__suppressed__' };
+    plan.output.useGlobalOutput = false;
+    plan.output.outputDir = path.join(home, 'projects/shelly-content-studio/drafts/x');
+    plan.output.outputNameTemplate = '{date}-{slug}';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+    fs.writeFileSync(path.join(home, '.shelly/agents/.env'), `LOCAL_LLM_URL='http://127.0.0.1:${port}'\nOBSIDIAN_VAULT_PATH='${vault}'\n`);
+
+    // No approval helper: a suppressed step must not request approval (else it would hang).
+    const result = await runExecutor([executor, '--plan-file', planFile, '--home', home, '--agent-id', plan.agent.id, '--broker', broker], home);
+    expect(result.status).toBe(0);
+
+    // Draft AND mirror written so the next orchestration step can read them (.sh parity)...
+    expect(listMarkdownFiles(plan.output.outputDir)).toHaveLength(1);
+    expect(listMarkdownFiles(path.join(vault, '50_Drafts/X'))).toHaveLength(1);
+    // ...but no approval request and no completion notification for a non-final step.
+    const approvalsDir = path.join(home, '.shelly/agents/action-approvals');
+    expect(fs.existsSync(approvalsDir) ? fs.readdirSync(approvalsDir) : []).toHaveLength(0);
+    expect(fs.existsSync(path.join(home, `.shelly/agents/logs/${plan.agent.id}/native-result-notification.json`))).toBe(false);
+    const runLogDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(runLogDir).filter((name) => /^\d+\.json$/.test(name));
+    expect(JSON.parse(fs.readFileSync(path.join(runLogDir, runLogs[0]), 'utf8')).status).toBe('success');
+  });
+
   it('mirrors a content-studio draft into the keyword-routed Obsidian vault (.sh parity)', async () => {
     const home = makeHome();
     const vault = path.join(home, 'vault');

--- a/__tests__/plan-executor.test.ts
+++ b/__tests__/plan-executor.test.ts
@@ -60,10 +60,14 @@ function listMarkdownFiles(dir: string): string[] {
   return out;
 }
 
-function runExecutor(args: string[], home: string): Promise<{ status: number | null; stdout: string; stderr: string }> {
+function runExecutor(
+  args: string[],
+  home: string,
+  envOverride: Record<string, string> = {},
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, args, {
-      env: { ...process.env, HOME: home },
+      env: { ...process.env, HOME: home, ...envOverride },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';
@@ -120,11 +124,33 @@ function runExecutorWithApproval(args: string[], home: string): Promise<{ status
   return run;
 }
 
+async function readNextActionRequest(home: string): Promise<{ file: string; request: any; sha: string }> {
+  const requestDir = path.join(home, '.shelly/agents/action-approvals');
+  for (let i = 0; i < 100; i += 1) {
+    const requests = fs.existsSync(requestDir)
+      ? fs.readdirSync(requestDir).filter((name) => name.startsWith('action-') && name.endsWith('.json'))
+      : [];
+    if (requests.length > 0) {
+      const file = path.join(requestDir, requests[0]);
+      const bytes = fs.readFileSync(file);
+      return {
+        file,
+        request: JSON.parse(bytes.toString('utf8')),
+        sha: crypto.createHash('sha256').update(bytes).digest('hex'),
+      };
+    }
+    await delay(50);
+  }
+  throw new Error('timed out waiting for action approval request');
+}
+
 describe('shelly-plan-executor host smoke', () => {
   let server: http.Server;
   let port = 0;
+  let requestCount = 0;
 
   beforeEach((done) => {
+    requestCount = 0;
     server = http.createServer((req, res) => {
       if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
         res.statusCode = 404;
@@ -137,6 +163,7 @@ describe('shelly-plan-executor host smoke', () => {
         body += chunk;
       });
       req.on('end', () => {
+        requestCount += 1;
         const parsed = JSON.parse(body);
         res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify({
@@ -216,6 +243,184 @@ describe('shelly-plan-executor host smoke', () => {
     expect(brokerAudit).toContain('"kind":"scoped.fs"');
     expect(brokerAudit).toContain('"decision":"deny"');
     expect(brokerAudit).toContain('outside-root');
+  });
+
+  it('requires the native agent id to match the PlanSpec agent id', async () => {
+    const home = makeHome();
+    const { planFile } = makePlan(home, port);
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', 'agent-other',
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(47);
+    expect(requestCount).toBe(0);
+    expect(listMarkdownFiles(path.join(home, 'agent-output'))).toHaveLength(0);
+    expect(result.stderr).toContain('plan agent id mismatch');
+  });
+
+  it('does not trust plan.paths.home as a runtime home fallback', async () => {
+    const home = makeHome();
+    const { planFile } = makePlan(home, port);
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--broker', broker,
+    ], '', { HOME: '' });
+
+    expect(result.status).toBe(47);
+    expect(requestCount).toBe(0);
+    expect(result.stderr).toContain('--home or absolute HOME is required');
+  });
+
+  it('fails closed before model IO for unattended runs without native low-risk trust', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--unattended', '1',
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(0);
+    expect(requestCount).toBe(0);
+    expect(listMarkdownFiles(path.join(home, 'agent-output'))).toHaveLength(0);
+    const requestDir = path.join(home, '.shelly/agents/action-approvals');
+    const approvalRequests = fs.existsSync(requestDir) ? fs.readdirSync(requestDir) : [];
+    expect(approvalRequests).toHaveLength(0);
+
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    expect(runLogs).toHaveLength(1);
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog.status).toBe('skipped');
+    expect(runLog.errorMessage).toContain('not trusted for unattended');
+  });
+
+  it('allows unattended local draft only when native supplies matching trusted action and tool', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--unattended', '1',
+      '--trusted-autonomous-agent-id', plan.agent.id,
+      '--trusted-autonomous-action', 'draft',
+      '--trusted-tool-type', 'local',
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(0);
+    expect(requestCount).toBe(1);
+    const outputFiles = listMarkdownFiles(path.join(home, 'agent-output'));
+    expect(outputFiles).toHaveLength(1);
+    expect(fs.readFileSync(outputFiles[0], 'utf8')).toContain('fixture result: say hello');
+
+    const planAudit = fs.readFileSync(path.join(home, `.shelly/agents/logs/${plan.agent.id}/plan-executor-audit.jsonl`), 'utf8');
+    expect(planAudit).toContain('"event":"action_trusted_allow"');
+    const requestDir = path.join(home, '.shelly/agents/action-approvals');
+    const approvalRequests = fs.existsSync(requestDir) ? fs.readdirSync(requestDir) : [];
+    expect(approvalRequests).toHaveLength(0);
+  });
+
+  it('does not let trusted action args authorize a tampered cloud tool in unattended mode', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    (plan as any).tool = { type: 'gemini-api', label: 'Gemini', model: 'gemini-2.5-flash', authRef: 'gemini' };
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--unattended', '1',
+      '--trusted-autonomous-agent-id', plan.agent.id,
+      '--trusted-autonomous-action', 'draft',
+      '--trusted-tool-type', 'local',
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(0);
+    expect(requestCount).toBe(0);
+    expect(listMarkdownFiles(path.join(home, 'agent-output'))).toHaveLength(0);
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    const runLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8'));
+    expect(runLog.status).toBe('skipped');
+    expect(runLog.errorMessage).toContain('not trusted for unattended');
+  });
+
+  it('redacts secret-like model text from action approval request previews', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    plan.prompt = 'return gsk_abcdefghijklmnopqrstuvwxyz1234567890';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const run = runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--broker', broker,
+    ], home);
+    const pending = await readNextActionRequest(home);
+    expect(pending.request.preview).toContain('<redacted>');
+    expect(pending.request.preview).not.toContain('gsk_abcdefghijklmnopqrstuvwxyz1234567890');
+
+    fs.mkdirSync(path.join(home, '.shelly/agents/action-approval-replies'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.shelly/agents/action-approval-replies', `action-${pending.request.runId}.reply.json`),
+      JSON.stringify({
+        runId: pending.request.runId,
+        decision: 'accept',
+        by: 'test',
+        requestSha256: pending.sha,
+        ts: new Date().toISOString(),
+      }) + '\n',
+    );
+    const result = await run;
+    expect(result.status).toBe(0);
+  });
+
+  it('redacts secret-like model text from previews and native notifications', async () => {
+    const home = makeHome();
+    const { plan, planFile } = makePlan(home, port);
+    plan.prompt = 'return sk-proj-abcdefghijklmnopqrstuvwxyz1234567890';
+    fs.writeFileSync(planFile, JSON.stringify(plan, null, 2));
+
+    const result = await runExecutor([
+      executor,
+      '--plan-file', planFile,
+      '--home', home,
+      '--agent-id', plan.agent.id,
+      '--trusted-autonomous-agent-id', plan.agent.id,
+      '--trusted-autonomous-action', 'draft',
+      '--trusted-tool-type', 'local',
+      '--broker', broker,
+    ], home);
+
+    expect(result.status).toBe(0);
+    const logDir = path.join(home, `.shelly/agents/logs/${plan.agent.id}`);
+    const runLogs = fs.readdirSync(logDir).filter((name) => /^\d+\.json$/.test(name));
+    const runLogRaw = fs.readFileSync(path.join(logDir, runLogs[0]), 'utf8');
+    const notifyRaw = fs.readFileSync(path.join(logDir, 'native-result-notification.json'), 'utf8');
+    expect(runLogRaw).toContain('<redacted>');
+    expect(notifyRaw).toContain('<redacted>');
+    expect(runLogRaw).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+    expect(notifyRaw).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
   });
 
   it('fails closed when the broker asset is missing', async () => {

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -13,7 +13,7 @@ import { buildAgentPolicy } from './agent-policy';
 const MAX_CONCURRENT = 2;
 
 const DEFAULT_TIMEOUT_SEC = 600; // 10 minutes
-const AGENT_SCRIPT_VERSION = 9;
+const AGENT_SCRIPT_VERSION = 10;
 const LOCAL_MODEL_LIGHT = 'Qwen3.5-0.8B-Q4_K_M';
 const LOCAL_MODEL_BALANCED = 'Qwen3.5-2B-Q4_K_M';
 const LOCAL_MODEL_QUALITY = 'Qwen3.5-4B-Q4_K_M';
@@ -551,6 +551,83 @@ write_webhook_payload() {
 PAYLOADEOF
 }
 
+cap_roots_file() {
+  roots_file="$TMP_DIR/cap-roots-$AGENT_ID.txt"
+  : > "$roots_file"
+  cap_add_root() {
+    root="$1"
+    [ -n "$root" ] || return 0
+    printf '%s\\n' "$root" >> "$roots_file"
+  }
+  cap_add_root "$HOME/agent-output"
+  cap_add_root "$TMP_DIR"
+  cap_add_root "$HOME/projects/shelly-content-studio"
+  cap_add_root "\${SHELLY_CONTENT_PROJECT:-$HOME/projects/shelly-content-studio}"
+  cap_add_root "\${OBSIDIAN_VAULT_PATH:-/sdcard/Documents/ObsidianVault}"
+  cap_add_root "\${SHELLY_AGENT_CUSTOM_PATH:-$HOME/agent-output}"
+  printf '%s\\n' "$roots_file"
+}
+
+cap_fs_write_file() {
+  dest="$1"
+  src="$2"
+  if [ "\${SHELLY_CAP_FS:-0}" = "1" ] && node_usable && [ -f "$HOME/.shelly-capability-broker.js" ]; then
+    roots_file="$(cap_roots_file)"
+    cap_out="$TMP_DIR/cap-fs-$AGENT_ID-$$.out"
+    cap_err="$TMP_DIR/cap-fs-$AGENT_ID-$$.err"
+    set +e
+    shelly_node "$HOME/.shelly-capability-broker.js" \\
+      --op fs.write --path "$dest" --input-file "$src" \\
+      --roots-file "$roots_file" \\
+      --audit-log "$LOG_DIR/agent-driver-audit.jsonl" \\
+      --out "$cap_out" --err "$cap_err"
+    cap_rc=$?
+    set -e
+    if [ "$cap_rc" -ne 0 ]; then
+      ACTION_DISPATCH_STATUS="error"
+      ACTION_DISPATCH_MESSAGE="Scoped filesystem write denied for $(basename "$dest"): $(head -c 240 "$cap_err" 2>/dev/null | tr '\\n' ' ')"
+      return "$cap_rc"
+    fi
+    return 0
+  fi
+  if [ "\${SHELLY_CAP_FS:-0}" = "1" ]; then
+    ACTION_DISPATCH_STATUS="error"
+    ACTION_DISPATCH_MESSAGE="Scoped filesystem broker requested but unavailable; refusing unbrokered write."
+    return 44
+  fi
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+}
+
+cap_workspace_exec() {
+  command_text="$1"
+  cwd="$2"
+  out_file="$3"
+  err_file="$4"
+  if [ "\${SHELLY_CAP_EXEC:-0}" = "1" ] && node_usable && [ -f "$HOME/.shelly-capability-broker.js" ]; then
+    roots_file="$(cap_roots_file)"
+    command_file="$TMP_DIR/cap-exec-command-$AGENT_ID-$$.sh"
+    printf '%s' "$command_text" > "$command_file"
+    set +e
+    shelly_node "$HOME/.shelly-capability-broker.js" \\
+      --op workspace.exec --command-file "$command_file" --cwd "$cwd" \\
+      --roots-file "$roots_file" \\
+      --audit-log "$LOG_DIR/agent-driver-audit.jsonl" \\
+      --timeout-seconds "$TIMEOUT" \\
+      --out "$out_file" --err "$err_file"
+    cap_rc=$?
+    set -e
+    rm -f "$command_file"
+    return "$cap_rc"
+  fi
+  if [ "\${SHELLY_CAP_EXEC:-0}" = "1" ]; then
+    echo "workspace.exec broker requested but unavailable; refusing unbrokered exec." > "$err_file"
+    return 44
+  fi
+  : > "$err_file"
+  bash -lc "$command_text" > "$out_file" 2>&1
+}
+
 webhook_destination_host() {
   url="$1"
   if node_usable; then
@@ -721,8 +798,7 @@ save_draft_result() {
         ;;
     esac
     SAVED_FILE="$OUT_BASE/$DATE/\${DATE}_$SLUG.md"
-    mkdir -p "$(dirname "$SAVED_FILE")"
-    cp "$result_file" "$SAVED_FILE"
+    cap_fs_write_file "$SAVED_FILE" "$result_file"
     register_source_urls "$result_file"
     return 0
   fi
@@ -738,8 +814,7 @@ save_draft_result() {
     *) REL_NAME="$REL_NAME.md" ;;
   esac
   SAVED_FILE="$OUTPUT_DIR/$REL_NAME"
-  mkdir -p "$(dirname "$SAVED_FILE")"
-  cp "$result_file" "$SAVED_FILE"
+  cap_fs_write_file "$SAVED_FILE" "$result_file"
 
   if [ -n "\${OBSIDIAN_VAULT_PATH:-}" ] && [ -d "$OBSIDIAN_VAULT_PATH" ]; then
     OBSIDIAN_TARGET="90_Log/Agent_Output"
@@ -752,8 +827,7 @@ save_draft_result() {
       *evals*) OBSIDIAN_TARGET="90_Log/Agent_Evals" ;;
     esac
     OBSIDIAN_DEST="$OBSIDIAN_VAULT_PATH/$OBSIDIAN_TARGET/$REL_NAME"
-    mkdir -p "$(dirname "$OBSIDIAN_DEST")"
-    cp "$SAVED_FILE" "$OBSIDIAN_DEST"
+    cap_fs_write_file "$OBSIDIAN_DEST" "$SAVED_FILE"
   fi
 
   register_source_urls "$result_file"
@@ -844,16 +918,37 @@ dispatch_agent_action() {
         write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
         return 1
       fi
+      if [ "\${SHELLY_CAP_EXEC:-0}" = "1" ] && [ "$ACTION_COMMAND_SAFETY_LEVEL" = "CRITICAL" ]; then
+        ACTION_DISPATCH_STATUS="error"
+        ACTION_DISPATCH_MESSAGE="CLI action was blocked by command safety: $ACTION_COMMAND_SAFETY_REASON"
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
       write_action_approval_request "cli" "$preview" "$result_file"
       wait_action_approval "cli" || return 1
       cli_output="$LOG_DIR/cli-action-output-$(date +%s).txt"
+      cli_error="$LOG_DIR/cli-action-error-$(date +%s).txt"
+      CLI_EXEC_CWD="\${SHELLY_AGENT_EXEC_CWD:-$PROJECT_DIR}"
+      if [ ! -d "$CLI_EXEC_CWD" ]; then
+        CLI_EXEC_CWD="$HOME/agent-output"
+        mkdir -p "$CLI_EXEC_CWD"
+      fi
       set +e
-      bash -lc "$ACTION_COMMAND" > "$cli_output" 2>&1
+      cap_workspace_exec "$ACTION_COMMAND" "$CLI_EXEC_CWD" "$cli_output" "$cli_error"
       cli_rc=$?
       set -e
+      if [ -s "$cli_error" ]; then
+        {
+          printf '\\n[stderr]\\n'
+          cat "$cli_error"
+        } >> "$cli_output"
+      fi
       {
         printf '\\n## CLI action\\n\\n'
         printf 'Safety: %s - %s\\n\\n' "$ACTION_COMMAND_SAFETY_LEVEL" "$ACTION_COMMAND_SAFETY_REASON"
+        if [ "\${SHELLY_CAP_EXEC:-0}" = "1" ]; then
+          printf 'Cwd: %s\\n\\n' "$CLI_EXEC_CWD"
+        fi
         printf 'Command:\\n\\n\`\`\`sh\\n%s\\n\`\`\`\\n\\n' "$ACTION_COMMAND"
         printf 'Exit code: %s\\n\\n' "$cli_rc"
         printf 'Output:\\n\\n\`\`\`text\\n'

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -10,6 +10,7 @@ import { resolveForAutonomous } from './agent-credential-policy';
 import { resolveEscalationLadder, attemptFailed, LadderEnv, EscalationLadder } from './agent-escalation-ladder';
 import { logWarn } from './debug-logger';
 import { generateRunScript, generateStopCommand, generateInstallCommands, getScriptPath } from './agent-executor';
+import { buildAgentPlanSpec, getPlanSpecPath } from './agent-plan-spec';
 import { installSchedule, uninstallSchedule } from './agent-scheduler';
 import { shouldTripCircuitBreaker, DEFAULT_CIRCUIT_BREAKER_THRESHOLD } from './agent-circuit-breaker';
 import {
@@ -316,15 +317,19 @@ async function materializeAgent(
   }
 
   const scriptPath = getScriptPath(agent.id);
+  const planSpecPath = getPlanSpecPath(agent.id);
   const metadataPath = `${agentsDir()}/${agent.id}.json`;
+  const planSpec = buildAgentPlanSpec(agentForRun, effectiveRunOpts);
   const commands = [
     `mkdir -p ${shellQuote(agentsDir())}`,
+    `mkdir -p ${shellQuote(`${agentsDir()}/plans`)}`,
     `rm -f ${shellQuote(`${deletedAgentsDir()}/${agent.id}`)}`,
     `rm -f "$HOME/.shelly/agents/${DELETED_AGENT_MARKER_DIR}/${agent.id}"`,
     // Metadata stores the ORIGINAL agent (no baked recall) so memory never
     // compounds across materializations; the script gets the effective prompt.
     writeFileCommand(metadataPath, JSON.stringify(agent, null, 2)),
     writeFileCommand(scriptPath, generateRunScript(agentForRun, effectiveRunOpts)),
+    writeFileCommand(planSpecPath, JSON.stringify(planSpec, null, 2)),
     ...generateInstallCommands(agent),
   ];
 
@@ -813,7 +818,7 @@ export async function deleteAgent(agentId: string): Promise<void> {
     `  mkdir -p "$d/audits"\n` +
     `  cp "$d/logs/${agentId}/agent-driver-audit.jsonl" "$d/audits/${agentId}-agent-driver-audit.jsonl"\n` +
     `fi\n` +
-    `rm -f "$d/${agentId}.json" "$d/run-agent-${agentId}.sh" "$d/locks/${agentId}.pid"\n` +
+    `rm -f "$d/${agentId}.json" "$d/run-agent-${agentId}.sh" "$d/plans/plan-agent-${agentId}.json" "$d/locks/${agentId}.pid"\n` +
     `rm -rf "$d/logs/${agentId}"\n` +
     // Phase 1 memory lives under memory/<id>; drop it with the agent so a deleted
     // agent leaves no orphaned memory behind (the Vault mirror is left in place
@@ -845,6 +850,7 @@ export async function cleanupOrphanAgentFiles(
   const cmd =
     `cd ${shellQuote(dir)} 2>/dev/null || exit 0\n` +
     `for s in run-agent-*.sh; do [ -e "\$s" ] || continue; id="\${s#run-agent-}"; id="\${id%.sh}"; [ -f "\$id.json" ] || rm -f "\$s"; done\n` +
+    `for p in plans/plan-agent-*.json; do [ -e "\$p" ] || continue; id="\${p#plans/plan-agent-}"; id="\${id%.json}"; [ -f "\$id.json" ] || rm -f "\$p"; done\n` +
     `for d in logs/*/; do [ -e "\$d" ] || continue; id="\$(basename "\$d")"; [ -f "\$id.json" ] || rm -rf "\$d"; done`;
   try {
     await runCommand(cmd);

--- a/lib/agent-plan-spec.ts
+++ b/lib/agent-plan-spec.ts
@@ -23,7 +23,7 @@ export type PlanToolType =
   | 'groq'
   | 'unsupported';
 
-export type PlanActionType = 'draft' | 'notify' | '__suppressed__' | 'unsupported';
+export type PlanActionType = 'draft' | 'notify' | 'webhook' | 'cli' | '__suppressed__' | 'unsupported';
 
 export interface AgentPlanSpecV1 {
   kind: typeof PLAN_SPEC_KIND;
@@ -146,16 +146,7 @@ export function buildAgentPlanSpec(
 
   const actionType: NonNullable<Agent['action']>['type'] | '__suppressed__' =
     opts.suppressAction ? '__suppressed__' : (agent.action?.type ?? 'draft');
-  const action: AgentPlanSpecV1['action'] =
-    actionType === 'draft' || actionType === 'notify' || actionType === '__suppressed__'
-      ? { type: actionType }
-      : {
-          type: 'unsupported' as const,
-          webhookUrl: agent.action?.webhookUrl,
-          command: agent.action?.command,
-          safety: evaluateAgentActionCommand(agent.action?.command ?? ''),
-          unsupportedReason: `PlanSpec executor does not support ${actionType} actions yet`,
-        };
+  const action: AgentPlanSpecV1['action'] = toPlanAction(actionType, agent.action);
 
   const slug = computeAgentSlug(agent.name, agent.id);
   const outputNameTemplate = sanitizeOutputTemplate(agent.outputTemplate);
@@ -205,6 +196,34 @@ export function buildAgentPlanSpec(
     policy: buildAgentPolicy(agent, agent.workspaceRoot || home),
     routeDecision,
   };
+}
+
+function toPlanAction(
+  actionType: NonNullable<Agent['action']>['type'] | '__suppressed__',
+  action?: Agent['action'],
+): AgentPlanSpecV1['action'] {
+  switch (actionType) {
+    case 'draft':
+    case 'notify':
+    case '__suppressed__':
+      return { type: actionType };
+    case 'webhook':
+      return { type: 'webhook', webhookUrl: action?.webhookUrl };
+    case 'cli':
+      return {
+        type: 'cli',
+        command: action?.command,
+        safety: evaluateAgentActionCommand(action?.command ?? ''),
+      };
+    default:
+      return {
+        type: 'unsupported',
+        webhookUrl: action?.webhookUrl,
+        command: action?.command,
+        safety: evaluateAgentActionCommand(action?.command ?? ''),
+        unsupportedReason: `PlanSpec executor does not support ${actionType} actions yet`,
+      };
+  }
 }
 
 function toPlanTool(tool: ToolChoice, unsupportedReason?: string): AgentPlanSpecV1['tool'] {

--- a/lib/agent-plan-spec.ts
+++ b/lib/agent-plan-spec.ts
@@ -1,0 +1,259 @@
+import type { Agent, AgentRouteDecision, ToolChoice } from '@/store/types';
+import { getHomePath } from '@/lib/home-path';
+import { detectRouteSignals } from './agent-router-scoring';
+import { resolveForAutonomous } from './agent-credential-policy';
+import { resolveAgentRoute, toolChoiceToLabel } from './agent-tool-router';
+import {
+  agentUsesStudioContext,
+  computeAgentSlug,
+  sanitizeOutputTemplate,
+  selectAutonomousLocalModel,
+} from './agent-executor';
+import { evaluateAgentActionCommand } from './agent-action-safety';
+import { buildAgentPolicy } from './agent-policy';
+
+export const PLAN_SPEC_SCHEMA_VERSION = 1;
+export const PLAN_SPEC_KIND = 'shelly.agent.plan';
+
+export type PlanToolType =
+  | 'local'
+  | 'gemini-api'
+  | 'perplexity'
+  | 'cerebras'
+  | 'groq'
+  | 'unsupported';
+
+export type PlanActionType = 'draft' | 'notify' | '__suppressed__' | 'unsupported';
+
+export interface AgentPlanSpecV1 {
+  kind: typeof PLAN_SPEC_KIND;
+  schemaVersion: typeof PLAN_SPEC_SCHEMA_VERSION;
+  generatedAt: number;
+  agent: {
+    id: string;
+    name: string;
+    autonomous: boolean;
+    autonomyLevel: NonNullable<Agent['autonomyLevel']>;
+  };
+  prompt: string;
+  tool: {
+    type: PlanToolType;
+    label: string;
+    model?: string;
+    authRef?: 'gemini' | 'perplexity' | 'cerebras' | 'groq';
+    unsupportedReason?: string;
+  };
+  action: {
+    type: PlanActionType;
+    webhookUrl?: string;
+    command?: string;
+    safety?: ReturnType<typeof evaluateAgentActionCommand>;
+    unsupportedReason?: string;
+  };
+  paths: {
+    home: string;
+    envFile: string;
+    tmpDir: string;
+    locksDir: string;
+    logsDir: string;
+    resultFile: string;
+    lockFile: string;
+    logDir: string;
+  };
+  output: {
+    outputDir: string;
+    outputNameTemplate: string;
+    slug: string;
+    useGlobalOutput: boolean;
+    suggestedRoots: string[];
+  };
+  limits: {
+    timeoutSeconds: number;
+    maxConcurrent: number;
+  };
+  policy: ReturnType<typeof buildAgentPolicy>;
+  routeDecision: AgentRouteDecision;
+}
+
+export type BuildAgentPlanSpecOptions = {
+  suppressAction?: boolean;
+  autonomousCloudConsent?: boolean;
+  autonomousCloudStop?: boolean;
+};
+
+function planPaths(home: string, agentId: string) {
+  const shellyDir = `${home}/.shelly`;
+  const agentsDir = `${shellyDir}/agents`;
+  const tmpDir = `${shellyDir}/tmp`;
+  const locksDir = `${agentsDir}/locks`;
+  const logsDir = `${agentsDir}/logs`;
+  return {
+    home,
+    shellyDir,
+    agentsDir,
+    plansDir: `${agentsDir}/plans`,
+    envFile: `${agentsDir}/.env`,
+    tmpDir,
+    locksDir,
+    logsDir,
+    resultFile: `${tmpDir}/agent-result-${agentId}.md`,
+    lockFile: `${locksDir}/${agentId}.pid`,
+    logDir: `${logsDir}/${agentId}`,
+  };
+}
+
+export function getPlanSpecPath(agentId: string): string {
+  return `${planPaths(getHomePath(), agentId).plansDir}/plan-agent-${agentId}.json`;
+}
+
+export function buildAgentPlanSpec(
+  agent: Agent,
+  opts: BuildAgentPlanSpecOptions = {},
+): AgentPlanSpecV1 {
+  const home = getHomePath();
+  const paths = planPaths(home, agent.id);
+  const routeResolution = resolveAgentRoute(agent);
+  const promptSignals = detectRouteSignals(agent.prompt);
+  let tool: ToolChoice = routeResolution.tool;
+  let unsupportedToolReason: string | undefined;
+
+  if (agent.autonomous) {
+    const consentWebTool =
+      opts.autonomousCloudConsent === true &&
+      promptSignals.needsWeb &&
+      (tool.type === 'gemini-api' || tool.type === 'perplexity');
+    if (!consentWebTool) {
+      const resolved = resolveForAutonomous(tool);
+      if (resolved) {
+        tool = resolved;
+      } else {
+        unsupportedToolReason = `autonomous mode does not allow ${tool.type}`;
+      }
+    }
+  }
+  if (agent.autonomous && tool.type === 'local' && !tool.model) {
+    tool = { ...tool, model: selectAutonomousLocalModel(agent.prompt) };
+  }
+
+  const toolSpec = toPlanTool(tool, unsupportedToolReason);
+  const toolLabel = toolSpec.label;
+  const routeDecision: AgentRouteDecision = {
+    ...routeResolution.decision,
+    toolType: tool.type,
+    toolLabel,
+    route: tool.type === 'local' ? 'on-device' : tool.type === 'ab-article-eval' ? 'hybrid' : 'cloud',
+  };
+
+  const actionType: NonNullable<Agent['action']>['type'] | '__suppressed__' =
+    opts.suppressAction ? '__suppressed__' : (agent.action?.type ?? 'draft');
+  const action: AgentPlanSpecV1['action'] =
+    actionType === 'draft' || actionType === 'notify' || actionType === '__suppressed__'
+      ? { type: actionType }
+      : {
+          type: 'unsupported' as const,
+          webhookUrl: agent.action?.webhookUrl,
+          command: agent.action?.command,
+          safety: evaluateAgentActionCommand(agent.action?.command ?? ''),
+          unsupportedReason: `PlanSpec executor does not support ${actionType} actions yet`,
+        };
+
+  const slug = computeAgentSlug(agent.name, agent.id);
+  const outputNameTemplate = sanitizeOutputTemplate(agent.outputTemplate);
+  const outputDir = agent.outputPath.replace(/^~/, home).replace(/^\$HOME/, home);
+  const useGlobalOutput = !agentUsesStudioContext(agent);
+
+  return {
+    kind: PLAN_SPEC_KIND,
+    schemaVersion: PLAN_SPEC_SCHEMA_VERSION,
+    generatedAt: Date.now(),
+    agent: {
+      id: agent.id,
+      name: agent.name,
+      autonomous: agent.autonomous === true,
+      autonomyLevel: agent.autonomyLevel ?? 'L2',
+    },
+    prompt: buildExecutorPrompt(agent.prompt),
+    tool: toolSpec,
+    action,
+    paths: {
+      home: paths.home,
+      envFile: paths.envFile,
+      tmpDir: paths.tmpDir,
+      locksDir: paths.locksDir,
+      logsDir: paths.logsDir,
+      resultFile: paths.resultFile,
+      lockFile: paths.lockFile,
+      logDir: paths.logDir,
+    },
+    output: {
+      outputDir,
+      outputNameTemplate,
+      slug,
+      useGlobalOutput,
+      suggestedRoots: [
+        `${home}/agent-output`,
+        paths.tmpDir,
+        `${home}/projects/shelly-content-studio`,
+        outputDir,
+        '/sdcard/Documents/ObsidianVault',
+      ],
+    },
+    limits: {
+      timeoutSeconds: 600,
+      maxConcurrent: 2,
+    },
+    policy: buildAgentPolicy(agent, agent.workspaceRoot || home),
+    routeDecision,
+  };
+}
+
+function toPlanTool(tool: ToolChoice, unsupportedReason?: string): AgentPlanSpecV1['tool'] {
+  if (unsupportedReason) {
+    return { type: 'unsupported', label: toolChoiceToLabel(tool), unsupportedReason };
+  }
+  switch (tool.type) {
+    case 'local':
+      return { type: 'local', label: toolChoiceToLabel(tool), model: tool.model || 'Qwen3.5-0.8B-Q4_K_M' };
+    case 'gemini-api':
+      return { type: 'gemini-api', label: toolChoiceToLabel(tool), model: tool.model || 'gemini-2.5-flash', authRef: 'gemini' };
+    case 'perplexity':
+      return { type: 'perplexity', label: toolChoiceToLabel(tool), model: tool.model || 'sonar', authRef: 'perplexity' };
+    case 'cerebras':
+      return { type: 'cerebras', label: toolChoiceToLabel(tool), model: tool.model || 'qwen-3-235b-a22b-instruct-2507', authRef: 'cerebras' };
+    case 'groq':
+      return { type: 'groq', label: toolChoiceToLabel(tool), model: tool.model || 'llama-3.3-70b-versatile', authRef: 'groq' };
+    default:
+      return {
+        type: 'unsupported',
+        label: toolChoiceToLabel(tool),
+        unsupportedReason: `PlanSpec executor does not support ${tool.type} tools yet`,
+      };
+  }
+}
+
+function buildExecutorPrompt(prompt: string): string {
+  const signals = detectRouteSignals(prompt);
+  if (!signals.needsWeb) return prompt;
+  return [
+    'You are a research-collection agent. Execute this task now.',
+    'Return only a Markdown bullet list with real primary-source URLs.',
+    '',
+    'Task:',
+    prompt,
+  ].join('\n');
+}
+
+export function validateAgentPlanSpec(value: unknown): { ok: true; spec: AgentPlanSpecV1 } | { ok: false; reason: string } {
+  if (!value || typeof value !== 'object') return { ok: false, reason: 'plan is not an object' };
+  const spec = value as Partial<AgentPlanSpecV1>;
+  if (spec.kind !== PLAN_SPEC_KIND) return { ok: false, reason: 'plan kind mismatch' };
+  if (spec.schemaVersion !== PLAN_SPEC_SCHEMA_VERSION) return { ok: false, reason: 'plan schema version mismatch' };
+  if (!spec.agent || typeof spec.agent.id !== 'string' || !/^[A-Za-z0-9_-]+$/.test(spec.agent.id)) {
+    return { ok: false, reason: 'plan agent id is invalid' };
+  }
+  if (typeof spec.prompt !== 'string') return { ok: false, reason: 'plan prompt is invalid' };
+  if (!spec.tool || typeof spec.tool.type !== 'string') return { ok: false, reason: 'plan tool is invalid' };
+  if (!spec.action || typeof spec.action.type !== 'string') return { ok: false, reason: 'plan action is invalid' };
+  if (!spec.paths || typeof spec.paths.home !== 'string') return { ok: false, reason: 'plan paths are invalid' };
+  return { ok: true, spec: spec as AgentPlanSpecV1 };
+}

--- a/lib/capability-exec.ts
+++ b/lib/capability-exec.ts
@@ -1,0 +1,306 @@
+/**
+ * EXEC-001 workspace.exec pure core.
+ *
+ * The runtime broker performs the actual spawn; this module owns the
+ * deterministic allow/deny decision so tests can cover command safety and cwd
+ * jail behaviour without executing shell.
+ */
+import { isWithinRoot, normalizePath } from '@/lib/agent-boundary-policy';
+import { checkCommandSafety, DangerLevel } from '@/lib/command-safety';
+import { redactSecrets } from '@/lib/redact-secrets';
+
+export type ExecDecision = 'allow' | 'deny';
+
+export type ExecSignal =
+  | 'inside-root'
+  | 'outside-root'
+  | 'invalid-cwd'
+  | 'critical-command'
+  | 'unsupported-command'
+  | 'unsafe-shell-syntax'
+  | 'no-roots';
+
+export type ExecTemplate = 'env' | 'printenv' | 'pwd' | 'printf' | 'sleep' | 'cat' | 'ls' | 'grep' | 'true' | 'false';
+
+export interface CuratedExecCommand {
+  template: ExecTemplate;
+  argv: string[];
+  pathArgs: string[];
+}
+
+type CuratedExecParseResult =
+  | { ok: true; command: CuratedExecCommand }
+  | { ok: false; reason: string; signal: 'unsupported-command' | 'unsafe-shell-syntax' };
+
+export interface ExecVerdict {
+  decision: ExecDecision;
+  reason: string;
+  signals: ExecSignal[];
+  cwd: string | null;
+  matchedRoot: string | null;
+  dangerLevel: DangerLevel;
+  command: CuratedExecCommand | null;
+}
+
+export interface ExecAuditEntry {
+  ts: string;
+  kind: 'workspace.exec';
+  cwd: string;
+  root: string | null;
+  decision: ExecDecision;
+  signals: ExecSignal[];
+  dangerLevel: DangerLevel;
+  timeoutSeconds: number;
+  ok?: boolean;
+  exitCode?: number;
+  reason?: string;
+}
+
+function canonicalizeCwd(value: string, fallbackRoot: string): string {
+  if (!value || !value.trim() || value.includes('\0')) throw new Error('cwd is invalid');
+  if (value.startsWith('~')) throw new Error('cwd must not be home-relative');
+  const base = fallbackRoot && fallbackRoot.startsWith('/') ? fallbackRoot : '/';
+  return normalizePath(value.startsWith('/') ? value : `${base}/${value}`);
+}
+
+function canonicalizeRoots(roots: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const root of roots) {
+    if (!root || !root.trim() || root.includes('\0') || root.startsWith('~')) continue;
+    const canonical = normalizePath(root.startsWith('/') ? root : `/${root}`);
+    if (!out.includes(canonical)) out.push(canonical);
+  }
+  return out;
+}
+
+function splitCuratedCommand(command: string): { argv: string[] } | { error: string; signal: 'unsupported-command' | 'unsafe-shell-syntax' } {
+  const text = String(command || '').trim();
+  if (!text) return { error: 'command is empty', signal: 'unsupported-command' };
+  if (/[\0\r\n]/.test(text)) return { error: 'multi-line shell commands are not supported by workspace.exec', signal: 'unsafe-shell-syntax' };
+  if (/[|&;()<>`$\\*?\[\]{}!~]/.test(text)) return { error: 'shell expansion and control operators are not supported by workspace.exec', signal: 'unsafe-shell-syntax' };
+
+  const argv: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        argv.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (quote) return { error: 'unterminated quote in workspace.exec command', signal: 'unsafe-shell-syntax' };
+  if (current) argv.push(current);
+  if (!argv.length) return { error: 'command is empty', signal: 'unsupported-command' };
+  return { argv };
+}
+
+function parseCuratedExecCommand(command: string): CuratedExecParseResult {
+  const split = splitCuratedCommand(command);
+  if ('error' in split) return { ok: false, reason: split.error, signal: split.signal };
+  const argv = split.argv;
+  const name = argv[0];
+  const pathArgs: string[] = [];
+
+  if (name === 'env') {
+    if (argv.length !== 1) return { ok: false, reason: 'env template does not accept arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'env', argv, pathArgs } };
+  }
+  if (name === 'printenv') {
+    if (argv.length > 2 || (argv[1] && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(argv[1]))) {
+      return { ok: false, reason: 'printenv template accepts at most one variable name', signal: 'unsupported-command' };
+    }
+    return { ok: true, command: { template: 'printenv', argv, pathArgs } };
+  }
+  if (name === 'pwd' || name === 'true' || name === 'false') {
+    if (argv.length !== 1) return { ok: false, reason: `${name} template does not accept arguments`, signal: 'unsupported-command' };
+    return { ok: true, command: { template: name, argv, pathArgs } };
+  }
+  if (name === 'printf') {
+    if (argv.length < 2 || argv.length > 8) return { ok: false, reason: 'printf template requires 1-7 literal arguments', signal: 'unsupported-command' };
+    if (argv.slice(1).some((arg) => arg.startsWith('-'))) return { ok: false, reason: 'printf template only accepts literal arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'printf', argv, pathArgs } };
+  }
+  if (name === 'sleep') {
+    if (argv.length !== 2 || !/^\d+(?:\.\d+)?$/.test(argv[1])) return { ok: false, reason: 'sleep template requires one numeric duration', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'sleep', argv, pathArgs } };
+  }
+  if (name === 'cat') {
+    const args = argv.slice(1).filter((arg) => arg !== '--');
+    if (!args.length || args.some((arg) => arg.startsWith('-'))) return { ok: false, reason: 'cat template requires one or more file paths', signal: 'unsupported-command' };
+    pathArgs.push(...args);
+    return { ok: true, command: { template: 'cat', argv, pathArgs } };
+  }
+  if (name === 'ls') {
+    const args = argv.slice(1);
+    for (const arg of args) {
+      if (arg.startsWith('-')) {
+        if (!['-a', '-l', '-la', '-al'].includes(arg)) return { ok: false, reason: 'ls template only supports -a/-l/-la/-al', signal: 'unsupported-command' };
+      } else {
+        pathArgs.push(arg);
+      }
+    }
+    return { ok: true, command: { template: 'ls', argv, pathArgs } };
+  }
+  if (name === 'grep') {
+    const args = argv.slice(1);
+    const rest: string[] = [];
+    for (const arg of args) {
+      if (arg.startsWith('-')) {
+        if (!['-n', '-i', '-r', '-R'].includes(arg)) return { ok: false, reason: 'grep template only supports -n/-i/-r/-R', signal: 'unsupported-command' };
+      } else {
+        rest.push(arg);
+      }
+    }
+    if (rest.length < 2) return { ok: false, reason: 'grep template requires a literal query and at least one path', signal: 'unsupported-command' };
+    pathArgs.push(...rest.slice(1));
+    return { ok: true, command: { template: 'grep', argv, pathArgs } };
+  }
+  return { ok: false, reason: `workspace.exec command is not in the curated template allowlist: ${name}`, signal: 'unsupported-command' };
+}
+
+export function classifyWorkspaceExec(opts: {
+  command: string;
+  cwd: string;
+  roots: readonly string[];
+}): ExecVerdict {
+  const safety = checkCommandSafety(opts.command);
+  const roots = canonicalizeRoots(opts.roots);
+  const curated = parseCuratedExecCommand(opts.command);
+  let cwd: string;
+  try {
+    cwd = canonicalizeCwd(opts.cwd, roots[0] || '/');
+  } catch (error) {
+    return {
+      decision: 'deny',
+      reason: error instanceof Error ? error.message : 'cwd is invalid',
+      signals: ['invalid-cwd'],
+      cwd: null,
+      matchedRoot: null,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+
+  if (safety.level === 'CRITICAL') {
+    return {
+      decision: 'deny',
+      reason: safety.reason || 'critical command denied',
+      signals: ['critical-command'],
+      cwd,
+      matchedRoot: null,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+
+  if (roots.length === 0) {
+    return {
+      decision: 'deny',
+      reason: 'no workspace exec roots were declared',
+      signals: ['no-roots'],
+      cwd,
+      matchedRoot: null,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+
+  const matchedRoot = roots.find((root) => isWithinRoot(root, cwd)) || null;
+  if (!matchedRoot) {
+    return {
+      decision: 'deny',
+      reason: 'cwd is outside the declared workspace exec roots',
+      signals: ['outside-root'],
+      cwd,
+      matchedRoot: null,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+
+  if (curated.ok === false) {
+    return {
+      decision: 'deny',
+      reason: curated.reason,
+      signals: [curated.signal],
+      cwd,
+      matchedRoot,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+
+  for (const rawPath of curated.command.pathArgs) {
+    let resolved: string;
+    try {
+      resolved = canonicalizeCwd(rawPath, cwd);
+    } catch (error) {
+      return {
+        decision: 'deny',
+        reason: error instanceof Error ? error.message : 'path argument is invalid',
+        signals: ['invalid-cwd'],
+        cwd,
+        matchedRoot,
+        dangerLevel: safety.level,
+        command: null,
+      };
+    }
+    if (!roots.some((root) => isWithinRoot(root, resolved))) {
+      return {
+        decision: 'deny',
+        reason: 'workspace.exec path argument is outside the declared roots',
+        signals: ['outside-root'],
+        cwd,
+        matchedRoot,
+        dangerLevel: safety.level,
+        command: null,
+      };
+    }
+  }
+
+  return {
+    decision: 'allow',
+    reason: safety.reason || 'curated command allowed inside workspace root',
+    signals: ['inside-root'],
+    cwd,
+    matchedRoot,
+    dangerLevel: safety.level,
+    command: curated.command,
+  };
+}
+
+export function buildExecAudit(opts: {
+  ts: string;
+  verdict: ExecVerdict;
+  timeoutSeconds: number;
+  ok?: boolean;
+  exitCode?: number;
+}): ExecAuditEntry {
+  return {
+    ts: opts.ts,
+    kind: 'workspace.exec',
+    cwd: opts.verdict.cwd || '<invalid>',
+    root: opts.verdict.matchedRoot,
+    decision: opts.verdict.decision,
+    signals: opts.verdict.signals,
+    dangerLevel: opts.verdict.dangerLevel,
+    timeoutSeconds: opts.timeoutSeconds,
+    ok: opts.ok,
+    exitCode: opts.exitCode,
+    reason: String(redactSecrets(opts.verdict.reason)),
+  };
+}

--- a/lib/capability-fs.ts
+++ b/lib/capability-fs.ts
@@ -1,0 +1,137 @@
+/**
+ * FS-001 scoped.fs pure core.
+ *
+ * This deliberately reuses the existing boundary-policy path primitives so the
+ * new brokered filesystem surface and the older autonomy gate agree on the one
+ * root-containment rule. Runtime symlink resolution happens in the node broker;
+ * this module stays side-effect free for cheap tests and generated-shell gates.
+ */
+import { isWithinRoot, normalizePath } from '@/lib/agent-boundary-policy';
+import { redactSecrets } from '@/lib/redact-secrets';
+
+export type FsOperation = 'read' | 'write' | 'list' | 'search';
+
+export type FsDecision = 'allow' | 'deny';
+
+export type FsSignal =
+  | 'inside-root'
+  | 'outside-root'
+  | 'invalid-path'
+  | 'no-roots';
+
+export interface FsVerdict {
+  decision: FsDecision;
+  reason: string;
+  signals: FsSignal[];
+  canonicalPath: string | null;
+  matchedRoot: string | null;
+}
+
+export interface FsAuditEntry {
+  ts: string;
+  kind: 'scoped.fs';
+  op: FsOperation;
+  path: string;
+  root: string | null;
+  decision: FsDecision;
+  signals: FsSignal[];
+  ok?: boolean;
+  reason?: string;
+}
+
+function assertUsablePath(value: string, label: string): void {
+  if (!value || !value.trim()) throw new Error(`${label} is empty`);
+  if (value.includes('\0')) throw new Error(`${label} contains NUL`);
+  if (value.startsWith('~')) throw new Error(`${label} must be absolute or workspace-relative, not home-relative`);
+}
+
+export function canonicalizePath(value: string, cwd: string): string {
+  assertUsablePath(value, 'path');
+  assertUsablePath(cwd, 'cwd');
+  if (cwd.startsWith('~')) throw new Error('cwd must not be home-relative');
+  const base = normalizePath(cwd.startsWith('/') ? cwd : `/${cwd}`);
+  const raw = value.startsWith('/') ? value : `${base}/${value}`;
+  return normalizePath(raw);
+}
+
+export function canonicalizeRoots(roots: readonly string[], cwd = '/'): string[] {
+  const out: string[] = [];
+  for (const root of roots) {
+    if (!root || !root.trim()) continue;
+    const canonical = canonicalizePath(root, cwd);
+    if (!out.includes(canonical)) out.push(canonical);
+  }
+  return out;
+}
+
+export function classifyFsAccess(opts: {
+  op: FsOperation;
+  path: string;
+  roots: readonly string[];
+  cwd?: string;
+}): FsVerdict {
+  const cwd = opts.cwd || '/';
+  let target: string;
+  let roots: string[];
+  try {
+    target = canonicalizePath(opts.path, cwd);
+    roots = canonicalizeRoots(opts.roots, cwd);
+  } catch (error) {
+    return {
+      decision: 'deny',
+      reason: error instanceof Error ? error.message : 'invalid path',
+      signals: ['invalid-path'],
+      canonicalPath: null,
+      matchedRoot: null,
+    };
+  }
+
+  if (roots.length === 0) {
+    return {
+      decision: 'deny',
+      reason: 'no scoped filesystem roots were declared',
+      signals: ['no-roots'],
+      canonicalPath: target,
+      matchedRoot: null,
+    };
+  }
+
+  const matchedRoot = roots.find((root) => isWithinRoot(root, target)) || null;
+  if (!matchedRoot) {
+    return {
+      decision: 'deny',
+      reason: `${opts.op} path is outside the declared scoped filesystem roots`,
+      signals: ['outside-root'],
+      canonicalPath: target,
+      matchedRoot: null,
+    };
+  }
+
+  return {
+    decision: 'allow',
+    reason: `${opts.op} path is inside scoped filesystem root`,
+    signals: ['inside-root'],
+    canonicalPath: target,
+    matchedRoot,
+  };
+}
+
+export function buildFsAudit(opts: {
+  ts: string;
+  op: FsOperation;
+  path: string;
+  verdict: FsVerdict;
+  ok?: boolean;
+}): FsAuditEntry {
+  return {
+    ts: opts.ts,
+    kind: 'scoped.fs',
+    op: opts.op,
+    path: opts.verdict.canonicalPath || '<invalid>',
+    root: opts.verdict.matchedRoot,
+    decision: opts.verdict.decision,
+    signals: opts.verdict.signals,
+    ok: opts.ok,
+    reason: String(redactSecrets(opts.verdict.reason)),
+  };
+}

--- a/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-capability-broker.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /*
- * shelly-capability-broker.js — CAP-001 / SECRET-001 / HTTP-001 runtime broker.
+ * shelly-capability-broker.js — CAP-001 / SECRET-001 / HTTP-001 / FS-001 /
+ * EXEC-001 runtime broker.
  *
  * Phase 0 「床」of the L1/L2 Capability Catalog
  * (docs/superpowers/specs/2026-07-01-l1-l2-capability-catalog.md). The generated
@@ -28,6 +29,8 @@
  *   42  budget exhausted
  *   43  auth_ref could not be resolved (missing/empty secret)
  *   44  usage error
+ *   45  scoped.fs denied or failed
+ *   46  workspace.exec denied
  *   127 internal error
  */
 
@@ -36,6 +39,7 @@
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
+const path = require('path');
 
 // ---------------------------------------------------------------------------
 // Mirror of lib/capability-envelope.ts — keep in sync (parity-tested).
@@ -73,6 +77,8 @@ const EXIT = {
   BUDGET: 42,
   NO_SECRET: 43,
   USAGE: 44,
+  FS_DENY: 45,
+  EXEC_DENY: 46,
   INTERNAL: 127,
 };
 
@@ -159,6 +165,291 @@ function classifyEgress(url, authRef, tainted) {
     return { decision: 'approve', reason: 'tainted input plus a live secret "' + authRef + '" to ' + host + ' requires human approval', signals: signals };
   }
   return { decision: 'allow', reason: 'host ' + host + ' is allowlisted', signals: signals };
+}
+
+// ---------------------------------------------------------------------------
+// FS-001 / EXEC-001 path policy
+// ---------------------------------------------------------------------------
+
+function normalizePath(p) {
+  const text = String(p == null ? '' : p);
+  const isAbs = text[0] === '/';
+  const out = [];
+  for (const seg of text.split('/')) {
+    if (!seg || seg === '.') continue;
+    if (seg === '..') {
+      if (out.length && out[out.length - 1] !== '..') out.pop();
+      else if (!isAbs) out.push('..');
+    } else {
+      out.push(seg);
+    }
+  }
+  return (isAbs ? '/' : '') + out.join('/');
+}
+
+function isWithinRoot(root, target) {
+  if (!root || !target || String(target).startsWith('~')) return false;
+  const r = normalizePath(root).replace(/\/$/, '');
+  const t = normalizePath(String(target)[0] === '/' ? target : r + '/' + target);
+  return t === r || t.indexOf(r + '/') === 0;
+}
+
+function lexicalAbsolute(p, cwd) {
+  const value = String(p == null ? '' : p);
+  if (!value || value.indexOf('\0') !== -1 || value[0] === '~') throw new Error('invalid path');
+  const base = cwd && cwd[0] === '/' ? cwd : '/';
+  return normalizePath(value[0] === '/' ? value : base + '/' + value);
+}
+
+function realpathWithMissingTail(target) {
+  const absolute = lexicalAbsolute(target, '/');
+  return resolveRealPathNoDanglingSymlink(absolute, 0);
+}
+
+function resolveRealPathNoDanglingSymlink(absoluteTarget, depth) {
+  if (depth > 40) throw new Error('too many symbolic links');
+  const absolute = lexicalAbsolute(absoluteTarget, '/');
+  const parts = absolute.split('/').filter(Boolean);
+  let current = '/';
+  for (let i = 0; i < parts.length; i += 1) {
+    const candidate = normalizePath(path.join(current, parts[i]));
+    let stat;
+    try {
+      stat = fs.lstatSync(candidate);
+    } catch (e) {
+      if (e && e.code === 'ENOENT') {
+        return normalizePath(path.join(current, ...parts.slice(i)));
+      }
+      throw e;
+    }
+    if (stat.isSymbolicLink()) {
+      const link = fs.readlinkSync(candidate);
+      if (!link || link.indexOf('\0') !== -1) throw new Error('invalid symbolic link target');
+      const resolved = normalizePath(path.isAbsolute(link) ? link : path.join(path.dirname(candidate), link));
+      const remaining = parts.slice(i + 1);
+      return resolveRealPathNoDanglingSymlink(path.join(resolved, ...remaining), depth + 1);
+    }
+    current = candidate;
+  }
+  try {
+    return normalizePath(fs.realpathSync.native ? fs.realpathSync.native(absolute) : fs.realpathSync(absolute));
+  } catch (_) {
+    return normalizePath(absolute);
+  }
+}
+
+function readRoots(args) {
+  const roots = [];
+  if (args['roots-file']) {
+    try {
+      for (const line of fs.readFileSync(args['roots-file'], 'utf8').split('\n')) {
+        const root = line.trim();
+        if (root) roots.push(root);
+      }
+    } catch (_) {
+      /* handled as no roots below */
+    }
+  }
+  if (args.root) roots.push(args.root);
+  const out = [];
+  for (const root of roots) {
+    try {
+      const real = realpathWithMissingTail(root);
+      if (out.indexOf(real) === -1) out.push(real);
+    } catch (_) {
+      /* skip invalid roots */
+    }
+  }
+  return out;
+}
+
+function classifyScopedPath(op, targetPath, roots, cwd) {
+  let canonical;
+  try {
+    canonical = realpathWithMissingTail(lexicalAbsolute(targetPath, cwd || '/'));
+  } catch (e) {
+    return { decision: 'deny', reason: e && e.message ? e.message : 'invalid path', signals: ['invalid-path'], path: '<invalid>', root: null };
+  }
+  if (!roots.length) {
+    return { decision: 'deny', reason: 'no scoped roots declared', signals: ['no-roots'], path: canonical, root: null };
+  }
+  const matched = roots.find((root) => isWithinRoot(root, canonical)) || null;
+  if (!matched) {
+    return { decision: 'deny', reason: op + ' path is outside declared roots', signals: ['outside-root'], path: canonical, root: null };
+  }
+  return { decision: 'allow', reason: op + ' path is inside declared root', signals: ['inside-root'], path: canonical, root: matched };
+}
+
+function classifyWorkspaceExec(command, cwd, roots) {
+  const safety = classifyCommandSafety(command);
+  const verdict = classifyScopedPath('workspace.exec cwd', cwd, roots, roots[0] || '/');
+  verdict.dangerLevel = safety.level;
+  verdict.command = null;
+  if (safety.level === 'CRITICAL') {
+    return {
+      decision: 'deny',
+      reason: safety.reason,
+      signals: ['critical-command'],
+      path: verdict.path,
+      root: verdict.root,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+  if (verdict.decision !== 'allow') return verdict;
+  const curated = parseCuratedExecCommand(command);
+  if (!curated.ok) {
+    return {
+      decision: 'deny',
+      reason: curated.reason,
+      signals: [curated.signal],
+      path: verdict.path,
+      root: verdict.root,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+  for (const rawPath of curated.command.pathArgs) {
+    const pathVerdict = classifyScopedPath('workspace.exec path argument', rawPath, roots, verdict.path);
+    if (pathVerdict.decision !== 'allow') {
+      return {
+        decision: 'deny',
+        reason: pathVerdict.reason,
+        signals: pathVerdict.signals,
+        path: verdict.path,
+        root: verdict.root,
+        dangerLevel: safety.level,
+        command: null,
+      };
+    }
+  }
+  verdict.reason = safety.reason || 'curated command allowed inside workspace root';
+  verdict.command = curated.command;
+  return verdict;
+}
+
+function splitCuratedCommand(command) {
+  const text = String(command || '').trim();
+  if (!text) return { error: 'command is empty', signal: 'unsupported-command' };
+  if (/[\0\r\n]/.test(text)) return { error: 'multi-line shell commands are not supported by workspace.exec', signal: 'unsafe-shell-syntax' };
+  if (/[|&;()<>`$\\*?\[\]{}!~]/.test(text)) return { error: 'shell expansion and control operators are not supported by workspace.exec', signal: 'unsafe-shell-syntax' };
+  const argv = [];
+  let current = '';
+  let quote = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        argv.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (quote) return { error: 'unterminated quote in workspace.exec command', signal: 'unsafe-shell-syntax' };
+  if (current) argv.push(current);
+  if (!argv.length) return { error: 'command is empty', signal: 'unsupported-command' };
+  return { argv: argv };
+}
+
+function parseCuratedExecCommand(command) {
+  const split = splitCuratedCommand(command);
+  if (split.error) return { ok: false, reason: split.error, signal: split.signal };
+  const argv = split.argv;
+  const name = argv[0];
+  const pathArgs = [];
+
+  if (name === 'env') {
+    if (argv.length !== 1) return { ok: false, reason: 'env template does not accept arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'env', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'printenv') {
+    if (argv.length > 2 || (argv[1] && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(argv[1]))) {
+      return { ok: false, reason: 'printenv template accepts at most one variable name', signal: 'unsupported-command' };
+    }
+    return { ok: true, command: { template: 'printenv', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'pwd' || name === 'true' || name === 'false') {
+    if (argv.length !== 1) return { ok: false, reason: name + ' template does not accept arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: name, argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'printf') {
+    if (argv.length < 2 || argv.length > 8) return { ok: false, reason: 'printf template requires 1-7 literal arguments', signal: 'unsupported-command' };
+    if (argv.slice(1).some((arg) => arg[0] === '-')) return { ok: false, reason: 'printf template only accepts literal arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'printf', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'sleep') {
+    if (argv.length !== 2 || !/^\d+(?:\.\d+)?$/.test(argv[1])) return { ok: false, reason: 'sleep template requires one numeric duration', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'sleep', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'cat') {
+    const args = argv.slice(1).filter((arg) => arg !== '--');
+    if (!args.length || args.some((arg) => arg[0] === '-')) return { ok: false, reason: 'cat template requires one or more file paths', signal: 'unsupported-command' };
+    pathArgs.push.apply(pathArgs, args);
+    return { ok: true, command: { template: 'cat', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'ls') {
+    for (const arg of argv.slice(1)) {
+      if (arg[0] === '-') {
+        if (['-a', '-l', '-la', '-al'].indexOf(arg) === -1) return { ok: false, reason: 'ls template only supports -a/-l/-la/-al', signal: 'unsupported-command' };
+      } else {
+        pathArgs.push(arg);
+      }
+    }
+    return { ok: true, command: { template: 'ls', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'grep') {
+    const rest = [];
+    for (const arg of argv.slice(1)) {
+      if (arg[0] === '-') {
+        if (['-n', '-i', '-r', '-R'].indexOf(arg) === -1) return { ok: false, reason: 'grep template only supports -n/-i/-r/-R', signal: 'unsupported-command' };
+      } else {
+        rest.push(arg);
+      }
+    }
+    if (rest.length < 2) return { ok: false, reason: 'grep template requires a literal query and at least one path', signal: 'unsupported-command' };
+    pathArgs.push.apply(pathArgs, rest.slice(1));
+    return { ok: true, command: { template: 'grep', argv: argv, pathArgs: pathArgs } };
+  }
+  return { ok: false, reason: 'workspace.exec command is not in the curated template allowlist: ' + name, signal: 'unsupported-command' };
+}
+
+function classifyCommandSafety(command) {
+  const cleaned = String(command || '').replace(/#[^\n]*/g, '').trim();
+  if (!cleaned) return { level: 'SAFE', reason: 'empty command' };
+  const critical = [
+    { re: /rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(\/|~\/?\s*$|\/\*|~\/\*)/i, reason: 'recursive removal of root or home is forbidden' },
+    { re: /rm\s+-rf\s+\/(?:usr|bin|lib|etc|boot|sys|proc|dev|sbin)/i, reason: 'system directory removal is forbidden' },
+    { re: /:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;?\s*:/, reason: 'fork bomb is forbidden' },
+    { re: /dd\s+if=\/dev\/(?:zero|random|urandom)\s+of=\/dev\/(?:sd[a-z]|nvme|mmcblk)/i, reason: 'raw storage overwrite is forbidden' },
+    { re: /mkfs\s+.*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i, reason: 'device formatting is forbidden' },
+    { re: />\s*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i, reason: 'direct device write is forbidden' },
+    { re: /shred\s+.*\/dev\//i, reason: 'device shredding is forbidden' },
+  ];
+  for (const item of critical) {
+    if (item.re.test(cleaned)) return { level: 'CRITICAL', reason: item.reason };
+  }
+  const high = [
+    { re: /curl\s+.*\|\s*(?:bash|sh|zsh|fish|python3?|node|ruby|perl)/i, reason: 'remote script pipe is high risk' },
+    { re: /wget\s+.*-O\s*-\s*\|\s*(?:bash|sh|zsh|fish)/i, reason: 'remote script pipe is high risk' },
+    { re: /rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+/i, reason: 'recursive force removal is high risk' },
+    { re: /git\s+reset\s+--hard/i, reason: 'hard reset is high risk' },
+    { re: /git\s+(?:push\s+.*--force|push\s+-f)\b/i, reason: 'force push is high risk' },
+  ];
+  for (const item of high) {
+    if (item.re.test(cleaned)) return { level: 'HIGH', reason: item.reason };
+  }
+  return { level: 'SAFE', reason: 'No risky command pattern matched.' };
 }
 
 // ---------------------------------------------------------------------------
@@ -275,6 +566,60 @@ function buildAudit(nowIso, method, url, authRef, tainted, verdict, extra) {
   return entry;
 }
 
+function buildFsAudit(nowIso, op, verdict, extra) {
+  const entry = {
+    ts: nowIso,
+    kind: 'scoped.fs',
+    op: op,
+    path: verdict.path || '<invalid>',
+    root: verdict.root || null,
+    decision: verdict.decision,
+    signals: verdict.signals || [],
+    reason: redact(verdict.reason),
+  };
+  if (extra && typeof extra.ok === 'boolean') entry.ok = extra.ok;
+  if (extra && extra.reason) entry.reason = redact(extra.reason);
+  return entry;
+}
+
+function writeFileNoFollowFromFile(srcPath, destPath) {
+  const noFollow = fs.constants.O_NOFOLLOW || 0;
+  const inFd = fs.openSync(srcPath, fs.constants.O_RDONLY);
+  let outFd = null;
+  try {
+    outFd = fs.openSync(destPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | noFollow, 0o600);
+    const buf = Buffer.allocUnsafe(64 * 1024);
+    while (true) {
+      const n = fs.readSync(inFd, buf, 0, buf.length, null);
+      if (n <= 0) break;
+      fs.writeSync(outFd, buf, 0, n);
+    }
+  } finally {
+    try { fs.closeSync(inFd); } catch (_) {}
+    if (outFd !== null) {
+      try { fs.closeSync(outFd); } catch (_) {}
+    }
+  }
+}
+
+function buildExecAudit(nowIso, verdict, timeoutSeconds, extra) {
+  const entry = {
+    ts: nowIso,
+    kind: 'workspace.exec',
+    cwd: verdict.path || '<invalid>',
+    root: verdict.root || null,
+    decision: verdict.decision,
+    signals: verdict.signals || [],
+    dangerLevel: verdict.dangerLevel || 'SAFE',
+    timeoutSeconds: Number(timeoutSeconds || 0),
+    reason: redact(verdict.reason),
+  };
+  if (extra && typeof extra.ok === 'boolean') entry.ok = extra.ok;
+  if (extra && typeof extra.exitCode === 'number') entry.exitCode = extra.exitCode;
+  if (extra && extra.reason) entry.reason = redact(extra.reason);
+  return entry;
+}
+
 // ---------------------------------------------------------------------------
 // HTTP send (mirrors the http_post_json node contract in agent-executor.ts)
 // ---------------------------------------------------------------------------
@@ -338,6 +683,413 @@ function sendRequest(opts, cb) {
 }
 
 // ---------------------------------------------------------------------------
+// FS-001 scoped.fs operations
+// ---------------------------------------------------------------------------
+
+function openOutErr(outFile, errFile) {
+  if (!outFile || !errFile) throw new Error('out and err files are required');
+  return {
+    outFd: fs.openSync(outFile, 'w'),
+    errFd: fs.openSync(errFile, 'w'),
+  };
+}
+
+function runFsOp(args, nowIso) {
+  const op = args.op || '';
+  const targetPath = args.path || '';
+  const auditFile = args['audit-log'] || '';
+  let fds;
+  try {
+    fds = openOutErr(args.out || '', args.err || '');
+  } catch (e) {
+    process.stderr.write('cannot open out/err files\n');
+    process.exit(EXIT.INTERNAL);
+  }
+  const finish = (code, verdict, extra) => {
+    appendAudit(auditFile, buildFsAudit(nowIso, op, verdict, extra));
+    try { fs.closeSync(fds.outFd); } catch (_) {}
+    try { fs.closeSync(fds.errFd); } catch (_) {}
+    process.exit(code);
+  };
+
+  const roots = readRoots(args);
+  const verdict = classifyScopedPath(op, targetPath, roots, args.cwd || '/');
+  if (verdict.decision !== 'allow') {
+    fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(verdict.reason) + '\n');
+    return finish(EXIT.FS_DENY, verdict, { ok: false });
+  }
+
+  try {
+    if (op === 'fs.read') {
+      const data = fs.readFileSync(verdict.path);
+      fs.writeSync(fds.outFd, data);
+      return finish(EXIT.OK, verdict, { ok: true });
+    }
+    if (op === 'fs.write') {
+      const inputFile = args['input-file'] || '';
+      if (!inputFile) {
+        fs.writeSync(fds.errFd, 'scoped.fs: --input-file is required for fs.write\n');
+        return finish(EXIT.USAGE, verdict, { ok: false });
+      }
+      const inputVerdict = classifyScopedPath('fs.write input', inputFile, roots, args.cwd || '/');
+      if (inputVerdict.decision !== 'allow') {
+        const reason = 'fs.write input file is outside declared roots';
+        const denyVerdict = {
+          decision: 'deny',
+          reason: reason,
+          signals: inputVerdict.signals || ['outside-root'],
+          path: verdict.path,
+          root: verdict.root,
+        };
+        fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(reason) + '\n');
+        return finish(EXIT.FS_DENY, denyVerdict, { ok: false });
+      }
+      fs.mkdirSync(path.dirname(verdict.path), { recursive: true });
+      const writeVerdict = classifyScopedPath(op, verdict.path, roots, args.cwd || '/');
+      if (writeVerdict.decision !== 'allow') {
+        fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(writeVerdict.reason) + '\n');
+        return finish(EXIT.FS_DENY, writeVerdict, { ok: false });
+      }
+      writeFileNoFollowFromFile(inputVerdict.path, writeVerdict.path);
+      fs.writeSync(fds.outFd, verdict.path + '\n');
+      return finish(EXIT.OK, writeVerdict, { ok: true });
+    }
+    if (op === 'fs.list') {
+      const entries = fs.readdirSync(verdict.path, { withFileTypes: true }).map((entry) => ({
+        name: entry.name,
+        type: entry.isDirectory() ? 'directory' : entry.isFile() ? 'file' : entry.isSymbolicLink() ? 'symlink' : 'other',
+      }));
+      fs.writeSync(fds.outFd, JSON.stringify(entries) + '\n');
+      return finish(EXIT.OK, verdict, { ok: true });
+    }
+    if (op === 'fs.search') {
+      const query = String(args.query || '');
+      if (!query) {
+        fs.writeSync(fds.errFd, 'scoped.fs: --query is required for fs.search\n');
+        return finish(EXIT.USAGE, verdict, { ok: false });
+      }
+      const results = [];
+      searchFiles(verdict.path, query, verdict.root, results, 200);
+      fs.writeSync(fds.outFd, JSON.stringify(results) + '\n');
+      return finish(EXIT.OK, verdict, { ok: true });
+    }
+    fs.writeSync(fds.errFd, 'scoped.fs: unknown op ' + op + '\n');
+    return finish(EXIT.USAGE, verdict, { ok: false });
+  } catch (e) {
+    const reason = e && e.message ? e.message : String(e);
+    fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(reason) + '\n');
+    return finish(EXIT.FS_DENY, verdict, { ok: false, reason: reason });
+  }
+}
+
+function searchFiles(rootPath, query, allowedRoot, results, maxResults) {
+  if (results.length >= maxResults) return;
+  let stat;
+  try {
+    stat = fs.lstatSync(rootPath);
+  } catch (_) {
+    return;
+  }
+  const real = realpathWithMissingTail(rootPath);
+  if (!isWithinRoot(allowedRoot, real)) return;
+  if (stat.isSymbolicLink()) return;
+  if (stat.isDirectory()) {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(rootPath);
+    } catch (_) {
+      return;
+    }
+    for (const entry of entries) {
+      if (results.length >= maxResults) return;
+      searchFiles(path.join(rootPath, entry), query, allowedRoot, results, maxResults);
+    }
+    return;
+  }
+  if (!stat.isFile() || stat.size > 1024 * 1024) return;
+  try {
+    const text = fs.readFileSync(rootPath, 'utf8');
+    const idx = text.indexOf(query);
+    if (idx !== -1) {
+      results.push({ path: real, index: idx, preview: text.slice(Math.max(0, idx - 80), idx + query.length + 80) });
+    }
+  } catch (_) {
+    /* binary/unreadable */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EXEC-001 workspace.exec
+// ---------------------------------------------------------------------------
+
+function safeExecEnv() {
+  const env = {};
+  for (const key of ['HOME', 'PATH', 'TMPDIR', 'LANG', 'LC_ALL', 'TERM']) {
+    if (process.env[key]) env[key] = process.env[key];
+  }
+  if (!env.PATH) env.PATH = '/system/bin:/bin:/usr/bin';
+  return env;
+}
+
+function writeSafeEnv(outFd, variableName) {
+  const env = safeExecEnv();
+  const keys = Object.keys(env).sort();
+  if (variableName) {
+    if (Object.prototype.hasOwnProperty.call(env, variableName)) {
+      fs.writeSync(outFd, variableName + '=' + env[variableName] + '\n');
+      return 0;
+    }
+    return 1;
+  }
+  for (const key of keys) {
+    fs.writeSync(outFd, key + '=' + env[key] + '\n');
+  }
+  return 0;
+}
+
+function safeReadScopedFile(filePath, roots, cwd) {
+  const verdict = classifyScopedPath('workspace.exec file', filePath, roots, cwd);
+  if (verdict.decision !== 'allow') return { ok: false, verdict: verdict, reason: verdict.reason };
+  let stat;
+  try {
+    stat = fs.statSync(verdict.path);
+  } catch (e) {
+    return { ok: false, verdict: verdict, reason: e && e.message ? e.message : 'cannot stat file' };
+  }
+  if (!stat.isFile()) return { ok: false, verdict: verdict, reason: 'path is not a regular file' };
+  if (stat.size > 1024 * 1024) return { ok: false, verdict: verdict, reason: 'file exceeds workspace.exec 1MiB read limit' };
+  try {
+    return { ok: true, path: verdict.path, data: fs.readFileSync(verdict.path) };
+  } catch (e) {
+    return { ok: false, verdict: verdict, reason: e && e.message ? e.message : 'cannot read file' };
+  }
+}
+
+function renderScopedList(targetPath, roots, cwd, longFormat, allEntries) {
+  const verdict = classifyScopedPath('workspace.exec list', targetPath || '.', roots, cwd);
+  if (verdict.decision !== 'allow') return { ok: false, reason: verdict.reason };
+  let stat;
+  try {
+    stat = fs.lstatSync(verdict.path);
+  } catch (e) {
+    return { ok: false, reason: e && e.message ? e.message : 'cannot stat path' };
+  }
+  if (!stat.isDirectory()) {
+    return { ok: true, text: verdict.path + '\n' };
+  }
+  let entries;
+  try {
+    entries = fs.readdirSync(verdict.path, { withFileTypes: true });
+  } catch (e) {
+    return { ok: false, reason: e && e.message ? e.message : 'cannot list directory' };
+  }
+  const lines = entries
+    .filter((entry) => allEntries || entry.name[0] !== '.')
+    .map((entry) => {
+      const suffix = entry.isDirectory() ? '/' : entry.isSymbolicLink() ? '@' : '';
+      if (!longFormat) return entry.name + suffix;
+      const full = path.join(verdict.path, entry.name);
+      let size = 0;
+      try { size = fs.lstatSync(full).size; } catch (_) {}
+      return String(size).padStart(8, ' ') + ' ' + entry.name + suffix;
+    })
+    .sort();
+  return { ok: true, text: lines.join('\n') + (lines.length ? '\n' : '') };
+}
+
+function renderScopedGrep(argv, roots, cwd) {
+  let ignoreCase = false;
+  const rest = [];
+  for (const arg of argv.slice(1)) {
+    if (arg === '-i') ignoreCase = true;
+    else if (arg === '-n' || arg === '-r' || arg === '-R') {
+      /* accepted for template compatibility; output is path:index:preview */
+    } else {
+      rest.push(arg);
+    }
+  }
+  const query = rest[0];
+  const paths = rest.slice(1);
+  const needle = ignoreCase ? query.toLowerCase() : query;
+  const results = [];
+  for (const rawPath of paths) {
+    const verdict = classifyScopedPath('workspace.exec grep', rawPath, roots, cwd);
+    if (verdict.decision !== 'allow') return { ok: false, reason: verdict.reason };
+    if (ignoreCase) {
+      collectCaseInsensitiveMatches(verdict.path, needle, verdict.root, results, 200);
+    } else {
+      searchFiles(verdict.path, query, verdict.root, results, 200);
+    }
+    if (results.length >= 200) break;
+  }
+  const text = results.slice(0, 200).map((item) => item.path + ':' + item.index + ':' + item.preview.replace(/\n/g, '\\n')).join('\n');
+  return { ok: true, text: text + (text ? '\n' : '') };
+}
+
+function collectCaseInsensitiveMatches(rootPath, needle, allowedRoot, results, maxResults) {
+  if (results.length >= maxResults) return;
+  let stat;
+  try {
+    stat = fs.lstatSync(rootPath);
+  } catch (_) {
+    return;
+  }
+  const real = realpathWithMissingTail(rootPath);
+  if (!isWithinRoot(allowedRoot, real)) return;
+  if (stat.isSymbolicLink()) return;
+  if (stat.isDirectory()) {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(rootPath);
+    } catch (_) {
+      return;
+    }
+    for (const entry of entries) {
+      if (results.length >= maxResults) return;
+      collectCaseInsensitiveMatches(path.join(rootPath, entry), needle, allowedRoot, results, maxResults);
+    }
+    return;
+  }
+  if (!stat.isFile() || stat.size > 1024 * 1024) return;
+  try {
+    const text = fs.readFileSync(rootPath, 'utf8');
+    const idx = text.toLowerCase().indexOf(needle);
+    if (idx !== -1) {
+      results.push({ path: real, index: idx, preview: text.slice(Math.max(0, idx - 80), idx + needle.length + 80) });
+    }
+  } catch (_) {
+    /* binary/unreadable */
+  }
+}
+
+function runWorkspaceExec(args, nowIso) {
+  const auditFile = args['audit-log'] || '';
+  const outFile = args.out || '';
+  const errFile = args.err || '';
+  const commandFile = args['command-file'] || '';
+  const timeoutSeconds = Number(args['timeout-seconds'] || '600');
+  const roots = readRoots(args);
+  const commandFileVerdict = classifyScopedPath('workspace.exec command file', commandFile, roots, roots[0] || '/');
+  if (commandFileVerdict.decision !== 'allow') {
+    process.stderr.write('workspace.exec: command file is outside declared roots\n');
+    appendAudit(auditFile, buildExecAudit(nowIso, {
+      decision: 'deny',
+      reason: commandFileVerdict.reason,
+      signals: commandFileVerdict.signals,
+      path: commandFileVerdict.path,
+      root: commandFileVerdict.root,
+      dangerLevel: 'SAFE',
+      command: null,
+    }, timeoutSeconds, { ok: false }));
+    process.exit(EXIT.EXEC_DENY);
+  }
+  let command = '';
+  try {
+    command = fs.readFileSync(commandFile, 'utf8');
+  } catch (_) {
+    process.stderr.write('workspace.exec: cannot read command file\n');
+    process.exit(EXIT.USAGE);
+  }
+  let fds;
+  try {
+    fds = openOutErr(outFile, errFile);
+  } catch (_) {
+    process.stderr.write('cannot open out/err files\n');
+    process.exit(EXIT.INTERNAL);
+  }
+  const verdict = classifyWorkspaceExec(command, args.cwd || '', roots);
+  const finish = (code, extra) => {
+    appendAudit(auditFile, buildExecAudit(nowIso, verdict, timeoutSeconds, extra));
+    try { fs.closeSync(fds.outFd); } catch (_) {}
+    try { fs.closeSync(fds.errFd); } catch (_) {}
+    process.exit(code);
+  };
+  if (verdict.decision !== 'allow') {
+    fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(verdict.reason) + '\n');
+    return finish(EXIT.EXEC_DENY, { ok: false });
+  }
+
+  const cmd = verdict.command;
+  if (!cmd) {
+    fs.writeSync(fds.errFd, 'workspace.exec: command template missing\n');
+    return finish(EXIT.EXEC_DENY, { ok: false, reason: 'command template missing' });
+  }
+
+  try {
+    if (cmd.template === 'env') {
+      return finish(writeSafeEnv(fds.outFd, null), { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'printenv') {
+      const rc = writeSafeEnv(fds.outFd, cmd.argv[1] || null);
+      return finish(rc, { ok: rc === 0, exitCode: rc });
+    }
+    if (cmd.template === 'pwd') {
+      fs.writeSync(fds.outFd, verdict.path + '\n');
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'true') return finish(0, { ok: true, exitCode: 0 });
+    if (cmd.template === 'false') return finish(1, { ok: false, exitCode: 1 });
+    if (cmd.template === 'printf') {
+      fs.writeSync(fds.outFd, cmd.argv.slice(1).join(''));
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'sleep') {
+      const seconds = Number(cmd.argv[1]);
+      if (Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 && seconds > timeoutSeconds) {
+        setTimeout(() => {
+          fs.writeSync(fds.errFd, 'workspace.exec: timed out\n');
+          finish(124, { ok: false, exitCode: 124, reason: 'timed out' });
+        }, timeoutSeconds * 1000);
+        return;
+      }
+      setTimeout(() => finish(0, { ok: true, exitCode: 0 }), Math.max(0, seconds * 1000));
+      return;
+    }
+    if (cmd.template === 'cat') {
+      for (const rawPath of cmd.pathArgs) {
+        const read = safeReadScopedFile(rawPath, roots, verdict.path);
+        if (!read.ok) {
+          fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(read.reason) + '\n');
+          return finish(EXIT.EXEC_DENY, { ok: false, reason: read.reason });
+        }
+        fs.writeSync(fds.outFd, read.data);
+      }
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'ls') {
+      const longFormat = cmd.argv.indexOf('-l') !== -1 || cmd.argv.indexOf('-la') !== -1 || cmd.argv.indexOf('-al') !== -1;
+      const allEntries = cmd.argv.indexOf('-a') !== -1 || cmd.argv.indexOf('-la') !== -1 || cmd.argv.indexOf('-al') !== -1;
+      const targets = cmd.pathArgs.length ? cmd.pathArgs : ['.'];
+      for (const target of targets) {
+        const listed = renderScopedList(target, roots, verdict.path, longFormat, allEntries);
+        if (!listed.ok) {
+          fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(listed.reason) + '\n');
+          return finish(EXIT.EXEC_DENY, { ok: false, reason: listed.reason });
+        }
+        fs.writeSync(fds.outFd, listed.text);
+      }
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'grep') {
+      const rendered = renderScopedGrep(cmd.argv, roots, verdict.path);
+      if (!rendered.ok) {
+        fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(rendered.reason) + '\n');
+        return finish(EXIT.EXEC_DENY, { ok: false, reason: rendered.reason });
+      }
+      fs.writeSync(fds.outFd, rendered.text);
+      return finish(rendered.text ? 0 : 1, { ok: Boolean(rendered.text), exitCode: rendered.text ? 0 : 1 });
+    }
+  } catch (e) {
+    const reason = e && e.message ? e.message : String(e);
+    fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(reason) + '\n');
+    return finish(EXIT.EXEC_DENY, { ok: false, reason: reason });
+  }
+
+  fs.writeSync(fds.errFd, 'workspace.exec: unsupported command template\n');
+  return finish(EXIT.EXEC_DENY, { ok: false, reason: 'unsupported command template' });
+}
+
+// ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
 
@@ -361,6 +1113,21 @@ function parseArgs(argv) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
+  const op = args.op || 'http.request';
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  if (op === 'fs.read' || op === 'fs.write' || op === 'fs.list' || op === 'fs.search') {
+    return runFsOp(args, nowIso);
+  }
+  if (op === 'workspace.exec') {
+    return runWorkspaceExec(args, nowIso);
+  }
+  if (op !== 'http.request') {
+    process.stderr.write('unknown capability op: ' + op + '\n');
+    process.exit(EXIT.USAGE);
+  }
+
   const method = (args.method || 'POST').toUpperCase();
   const url = args.url || '';
   const authRef = args['auth-ref'] || '';
@@ -373,9 +1140,6 @@ function main() {
   const errFile = args.err || '';
   const bodyFile = args['body-file'] || '';
   const timeoutSeconds = args['timeout-seconds'] || '30';
-
-  const nowMs = Date.now();
-  const nowIso = new Date(nowMs).toISOString();
 
   if (!url || !outFile || !errFile) {
     process.stderr.write('usage: --url <u> --out <f> --err <f> [--method] [--body-file] [--auth-ref] [--tainted 0|1] [--approved 0|1] [--secret-env-file] [--audit-log] [--budget-file] [--timeout-seconds]\n');

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -197,16 +197,6 @@ function previewText(text) {
   return String(text || '').replace(/\s+/g, ' ').trim().slice(0, 500);
 }
 
-function lexicalNormalize(p) {
-  return path.resolve('/', String(p || ''));
-}
-
-function isWithin(root, target) {
-  const r = lexicalNormalize(root).replace(/\/$/, '');
-  const t = lexicalNormalize(target);
-  return t === r || t.startsWith(r + '/');
-}
-
 function sanitizeRelPath(value) {
   const cleaned = String(value || '')
     .replace(/[^A-Za-z0-9 _./{}-]+/g, '')
@@ -227,21 +217,16 @@ function uniqueRoots(roots) {
   return out;
 }
 
-function scopedRoots(paths, config, plan) {
+function scopedRoots(paths, config) {
   const obsidianRoot = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
   const customRoot = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
-  const baseRoots = uniqueRoots([
+  return uniqueRoots([
     paths.tmpDir,
     path.join(paths.home, 'agent-output'),
     path.join(paths.home, 'projects/shelly-content-studio'),
     obsidianRoot,
     customRoot,
   ]);
-  const outputDir = plan.output && plan.output.outputDir;
-  if (outputDir && baseRoots.some((root) => isWithin(root, outputDir))) {
-    baseRoots.push(outputDir);
-  }
-  return uniqueRoots(baseRoots);
 }
 
 function writeRootsFile(paths, roots) {
@@ -595,7 +580,7 @@ function dispatchAction(paths, opts, plan, config, roots, resultText) {
   if (actionType !== 'draft' && actionType !== 'notify') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
-  if (!plan.agent.autonomous) requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   if (actionType === 'draft') {
     const dest = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
@@ -628,7 +613,7 @@ function run(args) {
   ensureDir(paths.logDir);
 
   const config = parseConfigEnv(paths.envFile);
-  const roots = scopedRoots(paths, config, plan);
+  const roots = scopedRoots(paths, config);
   const startedAt = Date.now();
   appendJsonl(paths.planAuditFile, {
     ts: new Date().toISOString(),

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -579,6 +579,9 @@ function sha256File(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 }
 
+// Mirrors the .sh save_draft_result destination logic (lib/agent-executor.ts).
+// Returns { dest, rel, useGlobalOutput }: `rel` is the content-studio relative
+// filename reused by the Obsidian mirror; it is empty for the global-output path.
 function resolveDraftDestination(paths, plan, config) {
   const now = new Date();
   const date = now.toISOString().slice(0, 10);
@@ -588,9 +591,10 @@ function resolveDraftDestination(paths, plan, config) {
     const target = config.SHELLY_AGENT_OUTPUT_TARGET || 'local';
     if (target === 'obsidian') base = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
     if (target === 'custom') base = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
-    const topic = sanitizeRelPath(config.SHELLY_AGENT_TOPIC_FOLDER || '');
+    // The .sh appends SHELLY_AGENT_TOPIC_FOLDER only for obsidian/custom, never local.
+    const topic = target === 'obsidian' || target === 'custom' ? sanitizeRelPath(config.SHELLY_AGENT_TOPIC_FOLDER || '') : '';
     const topicPart = topic && topic !== '{date}-{slug}' ? topic : '';
-    return path.join(base, topicPart, date, `${date}_${plan.output.slug}.md`);
+    return { dest: path.join(base, topicPart, date, `${date}_${plan.output.slug}.md`), rel: '', useGlobalOutput: true };
   }
   const template = sanitizeRelPath(plan.output && plan.output.outputNameTemplate);
   let rel = template
@@ -598,7 +602,35 @@ function resolveDraftDestination(paths, plan, config) {
     .replace(/\{slug\}/g, plan.output && plan.output.slug ? plan.output.slug : plan.agent.id)
     .replace(/\{time\}/g, time);
   if (!/\.(md|markdown|txt)$/i.test(rel)) rel += '.md';
-  return path.join(plan.output.outputDir, rel);
+  return { dest: path.join(plan.output.outputDir, rel), rel, useGlobalOutput: false };
+}
+
+// Keyword-routed Obsidian subfolder for content-studio agents. Mirrors the
+// `case "$OUTPUT_DIR"` map in the .sh save_draft_result (order-sensitive: first
+// match wins, matching bash `case`).
+function obsidianTargetFor(outputDir) {
+  const dir = String(outputDir || '');
+  if (dir.includes('drafts/substack')) return '50_Drafts/Substack';
+  if (dir.includes('drafts/x')) return '50_Drafts/X';
+  if (dir.includes('drafts/articles')) return '50_Drafts/Substack';
+  if (dir.includes('sources')) return '20_Literature/Papers';
+  if (dir.includes('images/prompts')) return '60_Experiments/Image_Prompts';
+  if (dir.includes('evals')) return '90_Log/Agent_Evals';
+  return '90_Log/Agent_Output';
+}
+
+// The content-studio Obsidian mirror destination, or null when no vault is
+// configured/present (the .sh guards on `[ -n "$OBSIDIAN_VAULT_PATH" ] && [ -d ]`
+// and silently skips otherwise). The write itself is broker-routed and root-jailed.
+function resolveObsidianMirror(plan, config, rel) {
+  const vault = String(config.OBSIDIAN_VAULT_PATH || '').trim();
+  if (!vault || !rel) return null;
+  try {
+    if (!fs.statSync(vault).isDirectory()) return null;
+  } catch (_) {
+    return null;
+  }
+  return path.join(vault, obsidianTargetFor(plan.output && plan.output.outputDir), rel);
 }
 
 function webhookDestinationHost(urlText) {
@@ -854,8 +886,15 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   }
   if (actionType === 'draft') {
-    const dest = resolveDraftDestination(paths, plan, config);
+    const { dest, rel, useGlobalOutput } = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
+    if (!useGlobalOutput) {
+      // Content-studio agents also mirror the draft into the Obsidian vault.
+      // Fatal on failure when the vault exists (parity with the .sh, which runs
+      // the mirror under `set -euo pipefail` with no `|| true`).
+      const mirror = resolveObsidianMirror(plan, config, rel);
+      if (mirror) brokerFsWrite(paths, opts, roots, mirror, paths.resultFile);
+    }
   }
   if (actionType === 'draft' || actionType === 'notify') {
     writeNotification(paths, plan, 'success', preview);

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -194,7 +194,7 @@ function sleepMs(ms) {
 }
 
 function previewText(text) {
-  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+  return redact(String(text || '')).replace(/\s+/g, ' ').trim().slice(0, 500);
 }
 
 function sanitizeRelPath(value) {
@@ -573,14 +573,54 @@ function resolveDraftDestination(paths, plan, config) {
   return path.join(plan.output.outputDir, rel);
 }
 
-function dispatchAction(paths, opts, plan, config, roots, resultText) {
+function argTruthy(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function trustedNativeLowRiskAction(args, plan, actionType) {
+  const trustedAgentId = String(args['trusted-autonomous-agent-id'] || '').trim();
+  const trustedAction = String(args['trusted-autonomous-action'] || '').trim();
+  const trustedTool = String(args['trusted-tool-type'] || '').trim();
+  if (trustedAgentId !== plan.agent.id) return false;
+  if (trustedAction !== 'draft' && trustedAction !== 'notify') return false;
+  if (trustedAction !== actionType) return false;
+  // Native only emits this for deterministic local autonomous agents. This keeps
+  // a tampered plan from turning a low-risk file/notify action into key spend.
+  return trustedTool === 'local' && plan.tool.type === 'local';
+}
+
+function unattendedPreflightFailure(args, plan) {
+  if (!argTruthy(args.unattended)) return '';
+  const actionType = plan.action.type;
+  if (actionType === '__suppressed__') return '';
+  if (actionType !== 'draft' && actionType !== 'notify') {
+    return `unsupported unattended PlanSpec action: ${actionType}`;
+  }
+  if (!trustedNativeLowRiskAction(args, plan, actionType)) {
+    return `${actionType} action is not trusted for unattended PlanSpec execution`;
+  }
+  return '';
+}
+
+function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args) {
   const actionType = plan.action.type;
   const preview = previewText(resultText);
   if (actionType === '__suppressed__') return { status: 'success', preview };
   if (actionType !== 'draft' && actionType !== 'notify') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
-  requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  if (trustedNativeLowRiskAction(args, plan, actionType)) {
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'action_trusted_allow',
+      agentId: plan.agent.id,
+      actionType,
+      toolType: plan.tool.type,
+    });
+  } else {
+    requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  }
   if (actionType === 'draft') {
     const dest = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
@@ -602,7 +642,14 @@ function mirrorBrokerAudit(paths, plan) {
 
 function run(args) {
   const plan = loadPlan(args['plan-file']);
-  const home = args.home || process.env.HOME || (plan.paths && plan.paths.home);
+  const expectedAgentId = String(args['agent-id'] || '').trim();
+  if (expectedAgentId && expectedAgentId !== plan.agent.id) {
+    throw new PlanFailure(`plan agent id mismatch: expected ${expectedAgentId}`, { exitCode: EXIT.PLAN_DENY });
+  }
+  const home = args.home || process.env.HOME;
+  if (!home || !path.isAbsolute(home)) {
+    throw new PlanFailure('--home or absolute HOME is required', { exitCode: EXIT.PLAN_DENY });
+  }
   const paths = runtimePaths(home, plan.agent.id);
   const opts = {
     libDir: args['lib-dir'] || process.env.SHELLY_LIB_DIR || '',
@@ -623,7 +670,24 @@ function run(args) {
     schemaVersion: plan.schemaVersion,
     toolType: plan.tool.type,
     actionType: plan.action.type,
+    unattended: argTruthy(args.unattended),
   });
+
+  const unattendedFailure = unattendedPreflightFailure(args, plan);
+  if (unattendedFailure) {
+    const message = redact(unattendedFailure);
+    writeNotification(paths, plan, 'skipped', message);
+    writeRunLog(paths, plan, 'skipped', message, Date.now() - startedAt, message);
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status: 'skipped',
+      reason: message,
+      durationMs: Date.now() - startedAt,
+    });
+    return EXIT.OK;
+  }
 
   if (!acquireLock(paths)) {
     const message = 'previous run still active';
@@ -643,7 +707,7 @@ function run(args) {
     const response = brokerHttp(paths, opts, plan, request);
     const resultText = extractModelContent(plan.tool.type, response);
     writeAtomic(paths.resultFile, resultText + (resultText.endsWith('\n') ? '' : '\n'));
-    const action = dispatchAction(paths, opts, plan, config, roots, resultText);
+    const action = dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args);
     const durationMs = Date.now() - startedAt;
     writeRunLog(paths, plan, action.status, action.preview, durationMs, '');
     appendJsonl(paths.planAuditFile, {

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -36,6 +36,7 @@ const CONFIG_ENV_KEYS = new Set([
   'SHELLY_AGENT_CUSTOM_PATH',
   'SHELLY_AGENT_EXEC_CWD',
   'SHELLY_CONTENT_PROJECT',
+  'SOURCE_REGISTRY_FILE',
   'OBSIDIAN_VAULT_PATH',
   'SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS',
   'WEBHOOK_TIMEOUT_SECONDS',
@@ -649,8 +650,85 @@ function writeDraftOutputs(paths, opts, plan, config, roots, bestEffort) {
   // aborts before the mirror). The terminal draft path lets the failure propagate.
   try {
     for (const target of targets) brokerFsWrite(paths, opts, roots, target, paths.resultFile);
+    // save_draft_result appends source URLs to the shared dedup registry AFTER the
+    // write, inside set -e — a failed write aborts before it. Keep it inside the try
+    // so a swallowed bestEffort write failure also skips the registry (parity).
+    registerSourceUrls(paths, config, plan);
   } catch (e) {
     if (!bestEffort) throw e;
+  }
+}
+
+// Mirror of the .sh register_source_urls: append https URLs found in the draft to a
+// shared per-project registry TSV (timestamp, agentId, toolLabel, url), deduped on
+// the url column, under a mkdir mutex. Fixed path (no model-controlled path), best
+// effort — a registry hiccup must never fail the run. No-op when the sources/ dir is
+// absent (parity with the .sh, whose `>>` silently fails without it).
+function registerSourceUrls(paths, config, plan) {
+  try {
+    const contentProject = config.SHELLY_CONTENT_PROJECT || path.join(paths.home, 'projects/shelly-content-studio');
+    const registryFile = config.SOURCE_REGISTRY_FILE || path.join(contentProject, 'sources', 'source-registry.tsv');
+
+    let text = '';
+    try {
+      text = fs.readFileSync(paths.resultFile, 'utf8');
+    } catch (_) {
+      return;
+    }
+    const seen = new Set();
+    // The .sh uses line-oriented `grep -Eo`, so a match never spans a newline; exclude
+    // \t\r\n from the class so adjacent-line URLs don't merge into one bogus entry.
+    const matches = text.match(/https?:\/\/[^\][ )<>"'\t\r\n]+/g) || [];
+    for (const raw of matches) {
+      // Match the .sh: `sed 's/[.,;)]$//'` strips exactly one trailing char.
+      const url = raw.replace(/[.,;)]$/, '');
+      if (url) seen.add(url);
+    }
+    // `sort -u` in the .sh: unique + sorted before appending.
+    const urls = Array.from(seen).sort();
+    if (!urls.length) return;
+
+    // The .sh creates the registry dir/file unconditionally at startup (mkdir -p +
+    // touch, lib/agent-executor.ts), so register_source_urls always has a target.
+    fs.mkdirSync(path.dirname(registryFile), { recursive: true });
+    const lockDir = `${registryFile}.lock`;
+    let locked = false;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      try {
+        fs.mkdirSync(lockDir);
+        locked = true;
+        break;
+      } catch (_) {
+        sleepMs(1000);
+      }
+    }
+    try {
+      let existing = '';
+      try {
+        existing = fs.readFileSync(registryFile, 'utf8');
+      } catch (_) {
+        /* first write */
+      }
+      const known = new Set(existing.split('\n').map((line) => line.split('\t')[3]).filter(Boolean));
+      const toolLabel = (plan.tool && plan.tool.label) || '';
+      const ts = new Date().toISOString();
+      let append = '';
+      for (const url of urls) {
+        if (!known.has(url)) {
+          append += `${ts}\t${plan.agent.id}\t${toolLabel}\t${url}\n`;
+          known.add(url);
+        }
+      }
+      if (append) fs.appendFileSync(registryFile, append);
+    } finally {
+      if (locked) {
+        try {
+          fs.rmdirSync(lockDir);
+        } catch (_) {}
+      }
+    }
+  } catch (_) {
+    /* best-effort registry bookkeeping — never fail the run */
   }
 }
 

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -633,6 +633,27 @@ function resolveObsidianMirror(plan, config, rel) {
   return path.join(vault, obsidianTargetFor(plan.output && plan.output.outputDir), rel);
 }
 
+// Write the draft to its primary destination and (for content-studio) the Obsidian
+// mirror, both through the root-jailed broker fs.write. `bestEffort` mirrors the .sh:
+// the terminal `draft` action runs save_draft_result under `set -e` (fatal), while an
+// orchestration `__suppressed__` step runs it `2>/dev/null || true` (swallow errors).
+function writeDraftOutputs(paths, opts, plan, config, roots, bestEffort) {
+  const { dest, rel, useGlobalOutput } = resolveDraftDestination(paths, plan, config);
+  const targets = [dest];
+  if (!useGlobalOutput) {
+    const mirror = resolveObsidianMirror(plan, config, rel);
+    if (mirror) targets.push(mirror);
+  }
+  // In bestEffort mode the whole sequence is swallowed on the FIRST failure, matching
+  // the .sh `save_draft_result ... || true` under `set -e` (a failed primary write
+  // aborts before the mirror). The terminal draft path lets the failure propagate.
+  try {
+    for (const target of targets) brokerFsWrite(paths, opts, roots, target, paths.resultFile);
+  } catch (e) {
+    if (!bestEffort) throw e;
+  }
+}
+
 function webhookDestinationHost(urlText) {
   try {
     const u = new URL(String(urlText || ''));
@@ -808,7 +829,12 @@ function unattendedPreflightFailure(args, plan) {
 function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args) {
   const actionType = plan.action.type;
   const preview = previewText(resultText);
-  if (actionType === '__suppressed__') return { status: 'success', preview };
+  if (actionType === '__suppressed__') {
+    // Orchestration non-final step: still save the draft (so the next step can read
+    // it) but request no approval and fire no notification. Best-effort, like the .sh.
+    writeDraftOutputs(paths, opts, plan, config, roots, true);
+    return { status: 'success', preview };
+  }
   if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
@@ -886,15 +912,9 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   }
   if (actionType === 'draft') {
-    const { dest, rel, useGlobalOutput } = resolveDraftDestination(paths, plan, config);
-    brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
-    if (!useGlobalOutput) {
-      // Content-studio agents also mirror the draft into the Obsidian vault.
-      // Fatal on failure when the vault exists (parity with the .sh, which runs
-      // the mirror under `set -euo pipefail` with no `|| true`).
-      const mirror = resolveObsidianMirror(plan, config, rel);
-      if (mirror) brokerFsWrite(paths, opts, roots, mirror, paths.resultFile);
-    }
+    // Terminal draft: primary + (content-studio) Obsidian mirror, fatal on failure
+    // (parity with the .sh save_draft_result under `set -euo pipefail`).
+    writeDraftOutputs(paths, opts, plan, config, roots, false);
   }
   if (actionType === 'draft' || actionType === 'notify') {
     writeNotification(paths, plan, 'success', preview);

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -129,6 +129,7 @@ function runtimePaths(home, agentId) {
     logsDir,
     logDir,
     envFile: path.join(agentsDir, '.env'),
+    haltSentinel: path.join(agentsDir, '.halted'),
     resultFile: path.join(tmpDir, `agent-result-${agentId}.md`),
     lockFile: path.join(locksDir, `${agentId}.pid`),
     notifyFile: path.join(logDir, 'native-result-notification.json'),
@@ -873,6 +874,23 @@ function mirrorBrokerAudit(paths, plan) {
   }
 }
 
+// Shared epilogue for the pre-run refuse paths (kill-switch, unattended-not-trusted):
+// notify + run log + a `plan_finish status:skipped` audit line, then exit cleanly.
+function finishSkipped(paths, plan, startedAt, message) {
+  const durationMs = Date.now() - startedAt;
+  writeNotification(paths, plan, 'skipped', message);
+  writeRunLog(paths, plan, 'skipped', message, durationMs, message);
+  appendJsonl(paths.planAuditFile, {
+    ts: new Date().toISOString(),
+    kind: 'plan.executor',
+    event: 'plan_finish',
+    status: 'skipped',
+    reason: message,
+    durationMs,
+  });
+  return EXIT.OK;
+}
+
 function run(args) {
   const plan = loadPlan(args['plan-file']);
   const expectedAgentId = String(args['agent-id'] || '').trim();
@@ -906,20 +924,17 @@ function run(args) {
     unattended: argTruthy(args.unattended),
   });
 
+  // Global kill-switch (STOP ALL). haltAllAgents drops a `.halted` sentinel and
+  // uninstalls schedules; this is the native/executor-side defense in depth so a
+  // still-in-flight alarm or a direct `am` fire is refused before any model IO,
+  // not just JS-initiated runs. Fail-closed: refuse (skip), never run.
+  if (fs.existsSync(paths.haltSentinel)) {
+    return finishSkipped(paths, plan, startedAt, 'All agents are stopped (global kill-switch is on).');
+  }
+
   const unattendedFailure = unattendedPreflightFailure(args, plan);
   if (unattendedFailure) {
-    const message = redact(unattendedFailure);
-    writeNotification(paths, plan, 'skipped', message);
-    writeRunLog(paths, plan, 'skipped', message, Date.now() - startedAt, message);
-    appendJsonl(paths.planAuditFile, {
-      ts: new Date().toISOString(),
-      kind: 'plan.executor',
-      event: 'plan_finish',
-      status: 'skipped',
-      reason: message,
-      durationMs: Date.now() - startedAt,
-    });
-    return EXIT.OK;
+    return finishSkipped(paths, plan, startedAt, redact(unattendedFailure));
   }
 
   if (!acquireLock(paths)) {

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -1,0 +1,729 @@
+#!/usr/bin/env node
+/*
+ * shelly-plan-executor.js - Phase 0 PlanSpec executor canary.
+ *
+ * This intentionally supports a narrow first slice. It runs one PlanSpec without
+ * sourcing run-agent-*.sh, but delegates HTTP and filesystem effects to the
+ * capability broker so the broker remains the final security boundary.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PLAN_SPEC_SCHEMA_VERSION = 1;
+const PLAN_SPEC_KIND = 'shelly.agent.plan';
+
+const EXIT = {
+  OK: 0,
+  PLAN_DENY: 47,
+  TOOL_DENY: 48,
+  INTERNAL: 127,
+};
+
+const CONFIG_ENV_KEYS = new Set([
+  'LOCAL_LLM_URL',
+  'LOCAL_LLM_MODEL',
+  'GEMINI_MODEL',
+  'PERPLEXITY_MODEL',
+  'CEREBRAS_MODEL',
+  'GROQ_MODEL',
+  'SHELLY_AGENT_OUTPUT_TARGET',
+  'SHELLY_AGENT_TOPIC_FOLDER',
+  'SHELLY_AGENT_CUSTOM_PATH',
+  'OBSIDIAN_VAULT_PATH',
+  'SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS',
+]);
+
+const REDACT_PATTERNS = [
+  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-proj-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bAIza[0-9A-Za-z_-]{25,}\b/g,
+  /\bgsk_[A-Za-z0-9_-]{20,}\b/g,
+  /\bcsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi,
+];
+
+class PlanFailure extends Error {
+  constructor(message, options) {
+    super(message);
+    this.name = 'PlanFailure';
+    this.status = options && options.status ? options.status : 'error';
+    this.exitCode = options && typeof options.exitCode === 'number' ? options.exitCode : EXIT.PLAN_DENY;
+    this.handled = options && options.handled === true;
+  }
+}
+
+class ActionSkipped extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ActionSkipped';
+  }
+}
+
+function redact(text) {
+  let out = String(text == null ? '' : text);
+  for (const pattern of REDACT_PATTERNS) out = out.replace(pattern, '<redacted>');
+  return out;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const current = argv[i];
+    if (!current.startsWith('--')) continue;
+    const key = current.slice(2);
+    const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) {
+      args[key] = '1';
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeAtomic(file, text) {
+  ensureDir(path.dirname(file));
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`);
+  fs.writeFileSync(tmp, text);
+  fs.renameSync(tmp, file);
+}
+
+function appendJsonl(file, entry) {
+  if (!file) return;
+  try {
+    ensureDir(path.dirname(file));
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n');
+  } catch (_) {
+    // best-effort audit only
+  }
+}
+
+function runtimePaths(home, agentId) {
+  const shellyDir = path.join(home, '.shelly');
+  const agentsDir = path.join(shellyDir, 'agents');
+  const tmpDir = path.join(shellyDir, 'tmp');
+  const locksDir = path.join(agentsDir, 'locks');
+  const logsDir = path.join(agentsDir, 'logs');
+  const logDir = path.join(logsDir, agentId);
+  return {
+    home,
+    shellyDir,
+    agentsDir,
+    tmpDir,
+    locksDir,
+    logsDir,
+    logDir,
+    envFile: path.join(agentsDir, '.env'),
+    resultFile: path.join(tmpDir, `agent-result-${agentId}.md`),
+    lockFile: path.join(locksDir, `${agentId}.pid`),
+    notifyFile: path.join(logDir, 'native-result-notification.json'),
+    brokerAuditFile: path.join(logDir, 'agent-driver-audit.jsonl'),
+    planAuditFile: path.join(logDir, 'plan-executor-audit.jsonl'),
+    actionApprovalDir: path.join(agentsDir, 'action-approvals'),
+    actionApprovalReplyDir: path.join(agentsDir, 'action-approval-replies'),
+  };
+}
+
+function parseConfigEnv(file) {
+  const out = {};
+  let text = '';
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch (_) {
+    return out;
+  }
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line || line[0] === '#') continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    let key = line.slice(0, eq).trim().replace(/^export\s+/, '');
+    if (!CONFIG_ENV_KEYS.has(key)) continue;
+    let val = line.slice(eq + 1).trim();
+    if (val.length >= 2 && val[0] === "'" && val[val.length - 1] === "'") {
+      val = val.slice(1, -1).replace(/'\\''/g, "'");
+    } else if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
+      val = val.slice(1, -1).replace(/\\(["\\])/g, '$1');
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+function validatePlan(raw) {
+  if (!raw || typeof raw !== 'object') throw new PlanFailure('plan is not an object');
+  if (raw.kind !== PLAN_SPEC_KIND) throw new PlanFailure('plan kind mismatch');
+  if (raw.schemaVersion !== PLAN_SPEC_SCHEMA_VERSION) throw new PlanFailure('plan schema version mismatch');
+  if (!raw.agent || typeof raw.agent.id !== 'string' || !/^[A-Za-z0-9_-]+$/.test(raw.agent.id)) {
+    throw new PlanFailure('plan agent id is invalid');
+  }
+  if (typeof raw.prompt !== 'string') throw new PlanFailure('plan prompt is invalid');
+  if (!raw.tool || typeof raw.tool.type !== 'string') throw new PlanFailure('plan tool is invalid');
+  if (!raw.action || typeof raw.action.type !== 'string') throw new PlanFailure('plan action is invalid');
+  if (raw.tool.type === 'unsupported') throw new PlanFailure(redact(raw.tool.unsupportedReason || 'unsupported tool'), { exitCode: EXIT.TOOL_DENY });
+  if (raw.action.type === 'unsupported') throw new PlanFailure(redact(raw.action.unsupportedReason || 'unsupported action'), { exitCode: EXIT.TOOL_DENY });
+  return raw;
+}
+
+function loadPlan(planFile) {
+  if (!planFile) throw new PlanFailure('--plan-file is required');
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(planFile, 'utf8'));
+  } catch (e) {
+    throw new PlanFailure(`cannot read plan: ${e && e.message ? e.message : e}`);
+  }
+  return validatePlan(parsed);
+}
+
+function sleepMs(ms) {
+  const shared = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(shared), 0, 0, ms);
+}
+
+function previewText(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function lexicalNormalize(p) {
+  return path.resolve('/', String(p || ''));
+}
+
+function isWithin(root, target) {
+  const r = lexicalNormalize(root).replace(/\/$/, '');
+  const t = lexicalNormalize(target);
+  return t === r || t.startsWith(r + '/');
+}
+
+function sanitizeRelPath(value) {
+  const cleaned = String(value || '')
+    .replace(/[^A-Za-z0-9 _./{}-]+/g, '')
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter((segment) => segment && segment !== '.' && segment !== '..')
+    .join('/');
+  return cleaned || '{date}-{slug}';
+}
+
+function uniqueRoots(roots) {
+  const out = [];
+  for (const root of roots) {
+    const value = String(root || '').trim();
+    if (!value || value[0] !== '/') continue;
+    if (!out.includes(value)) out.push(value);
+  }
+  return out;
+}
+
+function scopedRoots(paths, config, plan) {
+  const obsidianRoot = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
+  const customRoot = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
+  const baseRoots = uniqueRoots([
+    paths.tmpDir,
+    path.join(paths.home, 'agent-output'),
+    path.join(paths.home, 'projects/shelly-content-studio'),
+    obsidianRoot,
+    customRoot,
+  ]);
+  const outputDir = plan.output && plan.output.outputDir;
+  if (outputDir && baseRoots.some((root) => isWithin(root, outputDir))) {
+    baseRoots.push(outputDir);
+  }
+  return uniqueRoots(baseRoots);
+}
+
+function writeRootsFile(paths, roots) {
+  const rootsFile = path.join(paths.tmpDir, `plan-roots-${process.pid}-${Date.now()}.txt`);
+  writeAtomic(rootsFile, roots.join('\n') + '\n');
+  return rootsFile;
+}
+
+function childEnv(paths, opts) {
+  const libDir = opts.libDir || process.env.SHELLY_LIB_DIR || process.env.LD_LIBRARY_PATH || '';
+  const env = Object.assign({}, process.env, {
+    HOME: paths.home,
+    SHELLY_LIB_DIR: libDir,
+  });
+  if (libDir) {
+    env.LD_LIBRARY_PATH = libDir;
+    env.PATH = `${libDir}:${libDir}/node_modules/npm/bin:${libDir}/node_modules/.bin:${env.PATH || ''}`;
+    const preload = path.join(libDir, 'libexec_wrapper.so');
+    if (fs.existsSync(preload)) env.LD_PRELOAD = preload;
+  }
+  return env;
+}
+
+function nodeInvocation(script, args, paths, opts) {
+  const libDir = opts.libDir || process.env.SHELLY_LIB_DIR || '';
+  const androidNode = libDir ? path.join(libDir, 'node') : '';
+  if (androidNode && fs.existsSync(androidNode) && fs.existsSync('/system/bin/linker64')) {
+    return { file: '/system/bin/linker64', args: [androidNode, script].concat(args) };
+  }
+  return { file: process.execPath, args: [script].concat(args) };
+}
+
+function runBroker(paths, opts, brokerArgs) {
+  const broker = opts.broker || path.join(paths.home, '.shelly-capability-broker.js');
+  if (!fs.existsSync(broker)) throw new PlanFailure('capability broker is missing', { exitCode: EXIT.TOOL_DENY });
+  const invocation = nodeInvocation(broker, brokerArgs, paths, opts);
+  const result = spawnSync(invocation.file, invocation.args, {
+    env: childEnv(paths, opts),
+    encoding: 'utf8',
+    timeout: 700000,
+  });
+  if (result.error) {
+    throw new PlanFailure(`capability broker spawn failed: ${redact(result.error.message)}`, { exitCode: EXIT.TOOL_DENY });
+  }
+  return result.status == null ? EXIT.INTERNAL : result.status;
+}
+
+function writeJsonRequest(file, payload) {
+  writeAtomic(file, JSON.stringify(payload));
+}
+
+function chatEndpoint(base) {
+  const url = String(base || '').trim().replace(/\/+$/, '');
+  if (!url) return 'http://127.0.0.1:8080/v1/chat/completions';
+  if (/\/v1\/chat\/completions$/.test(url)) return url;
+  return `${url}/v1/chat/completions`;
+}
+
+function isLoopbackUrl(urlText) {
+  try {
+    const u = new URL(urlText);
+    return (u.protocol === 'http:' || u.protocol === 'https:') && (u.hostname === '127.0.0.1' || u.hostname === 'localhost');
+  } catch (_) {
+    return false;
+  }
+}
+
+function modelRequest(plan, config) {
+  const prompt = plan.prompt;
+  switch (plan.tool.type) {
+    case 'local': {
+      const url = chatEndpoint(config.LOCAL_LLM_URL || 'http://127.0.0.1:8080');
+      if (!isLoopbackUrl(url)) throw new PlanFailure('local PlanSpec endpoint must be loopback', { exitCode: EXIT.TOOL_DENY });
+      return {
+        url,
+        authRef: '',
+        body: {
+          model: config.LOCAL_LLM_MODEL || plan.tool.model || 'Qwen3.5-0.8B-Q4_K_M',
+          messages: [{ role: 'user', content: prompt }],
+          max_tokens: 2048,
+          chat_template_kwargs: { enable_thinking: false },
+        },
+      };
+    }
+    case 'gemini-api': {
+      const model = config.GEMINI_MODEL || plan.tool.model || 'gemini-2.5-flash';
+      return {
+        url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
+        authRef: 'gemini',
+        body: { contents: [{ parts: [{ text: prompt }] }] },
+      };
+    }
+    case 'perplexity':
+      return openAiCompatRequest('https://api.perplexity.ai/chat/completions', 'perplexity', config.PERPLEXITY_MODEL || plan.tool.model || 'sonar', prompt);
+    case 'cerebras':
+      return openAiCompatRequest('https://api.cerebras.ai/v1/chat/completions', 'cerebras', config.CEREBRAS_MODEL || plan.tool.model || 'qwen-3-235b-a22b-instruct-2507', prompt);
+    case 'groq':
+      return openAiCompatRequest('https://api.groq.com/openai/v1/chat/completions', 'groq', config.GROQ_MODEL || plan.tool.model || 'llama-3.3-70b-versatile', prompt);
+    default:
+      throw new PlanFailure(`unsupported PlanSpec tool: ${plan.tool.type}`, { exitCode: EXIT.TOOL_DENY });
+  }
+}
+
+function openAiCompatRequest(url, authRef, model, prompt) {
+  return {
+    url,
+    authRef,
+    body: {
+      model,
+      messages: [{ role: 'user', content: prompt }],
+    },
+  };
+}
+
+function brokerHttp(paths, opts, plan, request) {
+  const bodyFile = path.join(paths.tmpDir, `plan-request-${plan.agent.id}-${process.pid}.json`);
+  const outFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.json`);
+  const errFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.err`);
+  writeJsonRequest(bodyFile, request.body);
+  const args = [
+    '--op', 'http.request',
+    '--method', 'POST',
+    '--url', request.url,
+    '--body-file', bodyFile,
+    '--secret-env-file', paths.envFile,
+    '--audit-log', paths.brokerAuditFile,
+    '--budget-file', path.join(paths.tmpDir, `cap-budget-${plan.agent.id}.json`),
+    '--timeout-seconds', String(plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600),
+    '--out', outFile,
+    '--err', errFile,
+  ];
+  if (request.authRef) args.push('--auth-ref', request.authRef);
+  const rc = runBroker(paths, opts, args);
+  const response = readFile(outFile);
+  const errorText = readFile(errFile);
+  try {
+    fs.unlinkSync(bodyFile);
+  } catch (_) {}
+  if (rc !== 0) {
+    const status = rc === 23 ? 'unavailable' : 'error';
+    throw new PlanFailure(`HTTP broker failed rc=${rc}: ${redact(errorText || response).slice(0, 300)}`, {
+      status,
+      exitCode: EXIT.OK,
+      handled: true,
+    });
+  }
+  return response;
+}
+
+function extractModelContent(toolType, raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_) {
+    const text = String(raw || '').trim();
+    if (text) return text;
+    throw new PlanFailure('model response was empty', { handled: true });
+  }
+  if (toolType === 'gemini-api') {
+    const candidates = Array.isArray(parsed.candidates) ? parsed.candidates : [];
+    const parts = candidates.flatMap((candidate) => {
+      const content = candidate && candidate.content;
+      return content && Array.isArray(content.parts) ? content.parts : [];
+    });
+    const text = parts.map((part) => (part && typeof part.text === 'string' ? part.text : '')).join('\n').trim();
+    if (text) return text;
+  } else {
+    const choice = Array.isArray(parsed.choices) ? parsed.choices[0] : null;
+    const content = choice && choice.message && typeof choice.message.content === 'string'
+      ? choice.message.content
+      : choice && typeof choice.text === 'string'
+        ? choice.text
+        : '';
+    if (content.trim()) return content.trim();
+  }
+  throw new PlanFailure('model response did not contain assistant content', { handled: true });
+}
+
+function brokerFsWrite(paths, opts, roots, dest, src) {
+  const rootsFile = writeRootsFile(paths, roots);
+  const outFile = path.join(paths.tmpDir, `plan-fs-${process.pid}.out`);
+  const errFile = path.join(paths.tmpDir, `plan-fs-${process.pid}.err`);
+  const rc = runBroker(paths, opts, [
+    '--op', 'fs.write',
+    '--path', dest,
+    '--input-file', src,
+    '--roots-file', rootsFile,
+    '--audit-log', paths.brokerAuditFile,
+    '--out', outFile,
+    '--err', errFile,
+  ]);
+  const err = readFile(errFile);
+  try {
+    fs.unlinkSync(rootsFile);
+  } catch (_) {}
+  if (rc !== 0) {
+    throw new PlanFailure(`scoped filesystem write denied: ${redact(err).slice(0, 300)}`, {
+      exitCode: EXIT.OK,
+      handled: true,
+    });
+  }
+}
+
+function readFile(file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (_) {
+    return '';
+  }
+}
+
+function acquireLock(paths) {
+  ensureDir(path.dirname(paths.lockFile));
+  if (fs.existsSync(paths.lockFile)) {
+    const pid = Number(readFile(paths.lockFile).trim());
+    if (pid > 0) {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (_) {
+        // stale
+      }
+    }
+    try {
+      fs.unlinkSync(paths.lockFile);
+    } catch (_) {}
+  }
+  writeAtomic(paths.lockFile, `${process.pid}\n`);
+  return true;
+}
+
+function releaseLock(paths) {
+  try {
+    if (readFile(paths.lockFile).trim() === String(process.pid)) fs.unlinkSync(paths.lockFile);
+  } catch (_) {}
+}
+
+function writeNotification(paths, plan, status, preview) {
+  writeAtomic(paths.notifyFile, JSON.stringify({
+    agentId: plan.agent.id,
+    agentName: plan.agent.name,
+    toolLabel: plan.tool.label,
+    status,
+    preview,
+    timestamp: Math.floor(Date.now() / 1000),
+  }) + '\n');
+}
+
+function writeRunLog(paths, plan, status, preview, durationMs, errorMessage) {
+  const ts = Date.now();
+  const log = {
+    agentId: plan.agent.id,
+    timestamp: ts,
+    status,
+    outputPreview: previewText(preview),
+    durationMs,
+    toolUsed: plan.tool.label,
+    errorMessage: errorMessage ? previewText(errorMessage) : '',
+    routeDecision: plan.routeDecision,
+    executor: 'planspec',
+  };
+  writeAtomic(path.join(paths.logDir, `${Math.floor(ts / 1000)}.json`), JSON.stringify(log) + '\n');
+}
+
+function requestActionApproval(paths, plan, actionType, preview, resultFile, config) {
+  ensureDir(paths.actionApprovalDir);
+  ensureDir(paths.actionApprovalReplyDir);
+  const runId = `${plan.agent.id}-${Math.floor(Date.now() / 1000)}-${process.pid}`;
+  const requestFile = path.join(paths.actionApprovalDir, `action-${safeFilePart(runId)}.json`);
+  const replyFile = path.join(paths.actionApprovalReplyDir, `action-${safeFilePart(runId)}.reply.json`);
+  const timeoutSeconds = Number(config.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || process.env.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || 120);
+  const request = {
+    runId,
+    agentId: plan.agent.id,
+    agentName: plan.agent.name,
+    toolLabel: plan.tool.label,
+    actionType,
+    preview,
+    destinationHost: '',
+    command: '',
+    safetyLevel: '',
+    safetyReason: '',
+    payloadPath: '',
+    resultPath: resultFile,
+    ts: new Date().toISOString(),
+    expiresAt: Date.now() + Math.max(1, timeoutSeconds) * 1000,
+  };
+  writeAtomic(requestFile, JSON.stringify(request) + '\n');
+  const requestSha256 = sha256File(requestFile);
+  const deadline = Date.now() + Math.max(1, timeoutSeconds) * 1000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(replyFile)) {
+      let reply = null;
+      try {
+        reply = JSON.parse(readFile(replyFile));
+      } catch (_) {
+        reply = null;
+      }
+      try {
+        fs.unlinkSync(replyFile);
+        fs.unlinkSync(requestFile);
+      } catch (_) {}
+      if (!reply || reply.runId !== runId || reply.requestSha256 !== requestSha256) {
+        continue;
+      }
+      if (reply.decision === 'accept') return;
+      throw new ActionSkipped(`${actionType} action declined`);
+    }
+    sleepMs(500);
+  }
+  try {
+    fs.unlinkSync(requestFile);
+  } catch (_) {}
+  throw new ActionSkipped(`${actionType} action approval timed out`);
+}
+
+function safeFilePart(value) {
+  return String(value || '').slice(0, 160).replace(/[^A-Za-z0-9_.=-]/g, '_') || 'request';
+}
+
+function sha256File(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function resolveDraftDestination(paths, plan, config) {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const time = now.toISOString().slice(11, 19).replace(/:/g, '');
+  if (plan.output && plan.output.useGlobalOutput) {
+    let base = path.join(paths.home, 'agent-output');
+    const target = config.SHELLY_AGENT_OUTPUT_TARGET || 'local';
+    if (target === 'obsidian') base = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
+    if (target === 'custom') base = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
+    const topic = sanitizeRelPath(config.SHELLY_AGENT_TOPIC_FOLDER || '');
+    const topicPart = topic && topic !== '{date}-{slug}' ? topic : '';
+    return path.join(base, topicPart, date, `${date}_${plan.output.slug}.md`);
+  }
+  const template = sanitizeRelPath(plan.output && plan.output.outputNameTemplate);
+  let rel = template
+    .replace(/\{date\}/g, date)
+    .replace(/\{slug\}/g, plan.output && plan.output.slug ? plan.output.slug : plan.agent.id)
+    .replace(/\{time\}/g, time);
+  if (!/\.(md|markdown|txt)$/i.test(rel)) rel += '.md';
+  return path.join(plan.output.outputDir, rel);
+}
+
+function dispatchAction(paths, opts, plan, config, roots, resultText) {
+  const actionType = plan.action.type;
+  const preview = previewText(resultText);
+  if (actionType === '__suppressed__') return { status: 'success', preview };
+  if (actionType !== 'draft' && actionType !== 'notify') {
+    throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
+  }
+  if (!plan.agent.autonomous) requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  if (actionType === 'draft') {
+    const dest = resolveDraftDestination(paths, plan, config);
+    brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
+  }
+  writeNotification(paths, plan, 'success', preview);
+  return { status: 'success', preview };
+}
+
+function mirrorBrokerAudit(paths, plan) {
+  if (!fs.existsSync(paths.brokerAuditFile)) return;
+  try {
+    const auditDir = path.join(paths.agentsDir, 'audits');
+    ensureDir(auditDir);
+    fs.copyFileSync(paths.brokerAuditFile, path.join(auditDir, `${plan.agent.id}-agent-driver-audit.jsonl`));
+  } catch (_) {
+    // best-effort parity with the shell path
+  }
+}
+
+function run(args) {
+  const plan = loadPlan(args['plan-file']);
+  const home = args.home || process.env.HOME || (plan.paths && plan.paths.home);
+  const paths = runtimePaths(home, plan.agent.id);
+  const opts = {
+    libDir: args['lib-dir'] || process.env.SHELLY_LIB_DIR || '',
+    broker: args.broker || '',
+  };
+  ensureDir(paths.tmpDir);
+  ensureDir(paths.locksDir);
+  ensureDir(paths.logDir);
+
+  const config = parseConfigEnv(paths.envFile);
+  const roots = scopedRoots(paths, config, plan);
+  const startedAt = Date.now();
+  appendJsonl(paths.planAuditFile, {
+    ts: new Date().toISOString(),
+    kind: 'plan.executor',
+    event: 'plan_start',
+    agentId: plan.agent.id,
+    schemaVersion: plan.schemaVersion,
+    toolType: plan.tool.type,
+    actionType: plan.action.type,
+  });
+
+  if (!acquireLock(paths)) {
+    const message = 'previous run still active';
+    writeRunLog(paths, plan, 'skipped', message, 0, message);
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status: 'skipped',
+      reason: message,
+    });
+    return EXIT.OK;
+  }
+
+  try {
+    const request = modelRequest(plan, config);
+    const response = brokerHttp(paths, opts, plan, request);
+    const resultText = extractModelContent(plan.tool.type, response);
+    writeAtomic(paths.resultFile, resultText + (resultText.endsWith('\n') ? '' : '\n'));
+    const action = dispatchAction(paths, opts, plan, config, roots, resultText);
+    const durationMs = Date.now() - startedAt;
+    writeRunLog(paths, plan, action.status, action.preview, durationMs, '');
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status: action.status,
+      durationMs,
+    });
+    return EXIT.OK;
+  } catch (e) {
+    const durationMs = Date.now() - startedAt;
+    if (e instanceof ActionSkipped) {
+      const message = redact(e.message);
+      writeNotification(paths, plan, 'skipped', message);
+      writeRunLog(paths, plan, 'skipped', message, durationMs, message);
+      appendJsonl(paths.planAuditFile, {
+        ts: new Date().toISOString(),
+        kind: 'plan.executor',
+        event: 'plan_finish',
+        status: 'skipped',
+        reason: message,
+        durationMs,
+      });
+      return EXIT.OK;
+    }
+    const status = e instanceof PlanFailure && e.status ? e.status : 'error';
+    const message = redact(e && e.message ? e.message : String(e));
+    writeAtomic(paths.resultFile, message + '\n');
+    writeNotification(paths, plan, status, message);
+    writeRunLog(paths, plan, status, message, durationMs, message);
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status,
+      reason: message,
+      durationMs,
+    });
+    if (e instanceof PlanFailure && e.handled) return EXIT.OK;
+    return e instanceof PlanFailure ? e.exitCode : EXIT.INTERNAL;
+  } finally {
+    mirrorBrokerAudit(paths, plan);
+    releaseLock(paths);
+  }
+}
+
+function main() {
+  try {
+    process.exit(run(parseArgs(process.argv.slice(2))));
+  } catch (e) {
+    process.stderr.write(redact(e && e.stack ? e.stack : e && e.message ? e.message : String(e)) + '\n');
+    process.exit(e instanceof PlanFailure ? e.exitCode : EXIT.INTERNAL);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  PLAN_SPEC_SCHEMA_VERSION,
+  PLAN_SPEC_KIND,
+  validatePlan,
+  runtimePaths,
+  parseConfigEnv,
+  isLoopbackUrl,
+};

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -249,9 +249,16 @@ function childEnv(paths, opts) {
   if (libDir) {
     env.LD_LIBRARY_PATH = libDir;
     env.PATH = `${libDir}:${libDir}/node_modules/npm/bin:${libDir}/node_modules/.bin:${env.PATH || ''}`;
-    const preload = path.join(libDir, 'libexec_wrapper.so');
-    if (fs.existsSync(preload)) env.LD_PRELOAD = preload;
   }
+  // The broker is a leaf bionic-node process: its workspace.exec curates commands
+  // in-node (cat/ls/grep/printf/… implemented in JS) and never execs an app-data
+  // binary, so it does NOT need the Knox exec-wrapper. Inheriting
+  // LD_PRELOAD=libexec_wrapper.so (set globally by shelly-exec.c on the launching
+  // shell) BREAKS node's OpenSSL config load on-device — verified on hardware:
+  // "BIO_new_file:Bad file descriptor" on openssl.cnf → node aborts → every broker
+  // call fails. Drop it here (mirrors the llama-server launcher, which unsets
+  // LD_PRELOAD before its own linker64 launch for the same class of reason).
+  delete env.LD_PRELOAD;
   return env;
 }
 

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -614,6 +614,58 @@ function writeWebhookPayload(file, plan, status, preview, resultText) {
   }) + '\n');
 }
 
+const CRITICAL_COMMAND_PATTERNS = [
+  {
+    pattern: /rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(\/|~\/?\s*$|\/\*|~\/\*)/i,
+    reason: 'Root or home directory recursive removal is critical.',
+  },
+  {
+    pattern: /rm\s+-rf\s+\/(?:usr|bin|lib|etc|boot|sys|proc|dev|sbin)/i,
+    reason: 'System directory removal is critical.',
+  },
+  {
+    pattern: /:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;?\s*:/,
+    reason: 'Fork bomb command is critical.',
+  },
+  {
+    pattern: /dd\s+if=\/dev\/(?:zero|random|urandom)\s+of=\/dev\/(?:sd[a-z]|nvme|mmcblk)/i,
+    reason: 'Direct storage overwrite is critical.',
+  },
+  {
+    pattern: /mkfs\s+.*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i,
+    reason: 'Storage device format is critical.',
+  },
+  {
+    pattern: />\s*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i,
+    reason: 'Direct storage device write is critical.',
+  },
+  {
+    pattern: /shred\s+.*\/dev\//i,
+    reason: 'Device shred command is critical.',
+  },
+];
+
+function recomputeCliSafety(commandText, declaredSafety) {
+  const cleaned = String(commandText || '').replace(/#[^\n]*/g, '').trim();
+  for (const { pattern, reason } of CRITICAL_COMMAND_PATTERNS) {
+    if (pattern.test(cleaned)) {
+      return {
+        level: 'CRITICAL',
+        reason,
+        message: 'Executor-side command safety blocked a critical command.',
+        matchedPattern: pattern.source,
+      };
+    }
+  }
+  const safety = declaredSafety && typeof declaredSafety === 'object' ? declaredSafety : {};
+  return {
+    level: safety.level || 'SAFE',
+    reason: safety.reason || 'No critical command pattern matched.',
+    message: safety.message || '',
+    matchedPattern: safety.matchedPattern || '',
+  };
+}
+
 function resolveCliCwd(paths, plan, config) {
   const wanted =
     config.SHELLY_AGENT_EXEC_CWD ||
@@ -747,7 +799,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
       writeWebhookPayload(payloadFile, plan, 'success', preview, resultText);
       requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
         destinationHost: host,
-        payloadPath: payloadFile,
+        payloadPath: path.basename(payloadFile),
       });
       try {
         brokerHttpBodyFile(paths, opts, plan, {
@@ -765,7 +817,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     }
     if (actionType === 'cli') {
       const commandText = String(plan.action.command || '').trim();
-      const safety = plan.action.safety || {};
+      const safety = recomputeCliSafety(commandText, plan.action.safety || {});
       if (!commandText) {
         const message = 'CLI action is missing a command.';
         writeNotification(paths, plan, 'error', message);

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -34,8 +34,11 @@ const CONFIG_ENV_KEYS = new Set([
   'SHELLY_AGENT_OUTPUT_TARGET',
   'SHELLY_AGENT_TOPIC_FOLDER',
   'SHELLY_AGENT_CUSTOM_PATH',
+  'SHELLY_AGENT_EXEC_CWD',
+  'SHELLY_CONTENT_PROJECT',
   'OBSIDIAN_VAULT_PATH',
   'SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS',
+  'WEBHOOK_TIMEOUT_SECONDS',
 ]);
 
 const REDACT_PATTERNS = [
@@ -220,10 +223,12 @@ function uniqueRoots(roots) {
 function scopedRoots(paths, config) {
   const obsidianRoot = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
   const customRoot = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
+  const contentProject = config.SHELLY_CONTENT_PROJECT || path.join(paths.home, 'projects/shelly-content-studio');
   return uniqueRoots([
     paths.tmpDir,
     path.join(paths.home, 'agent-output'),
     path.join(paths.home, 'projects/shelly-content-studio'),
+    contentProject,
     obsidianRoot,
     customRoot,
   ]);
@@ -343,28 +348,42 @@ function openAiCompatRequest(url, authRef, model, prompt) {
 
 function brokerHttp(paths, opts, plan, request) {
   const bodyFile = path.join(paths.tmpDir, `plan-request-${plan.agent.id}-${process.pid}.json`);
+  writeJsonRequest(bodyFile, request.body);
+  try {
+    return brokerHttpBodyFile(paths, opts, plan, {
+      url: request.url,
+      authRef: request.authRef,
+      bodyFile,
+      approved: request.approved,
+      timeoutSeconds: request.timeoutSeconds,
+    });
+  } finally {
+    try {
+      fs.unlinkSync(bodyFile);
+    } catch (_) {}
+  }
+}
+
+function brokerHttpBodyFile(paths, opts, plan, request) {
   const outFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.json`);
   const errFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.err`);
-  writeJsonRequest(bodyFile, request.body);
   const args = [
     '--op', 'http.request',
     '--method', 'POST',
     '--url', request.url,
-    '--body-file', bodyFile,
+    '--body-file', request.bodyFile,
     '--secret-env-file', paths.envFile,
     '--audit-log', paths.brokerAuditFile,
     '--budget-file', path.join(paths.tmpDir, `cap-budget-${plan.agent.id}.json`),
-    '--timeout-seconds', String(plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600),
+    '--timeout-seconds', String(request.timeoutSeconds || (plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600)),
     '--out', outFile,
     '--err', errFile,
   ];
   if (request.authRef) args.push('--auth-ref', request.authRef);
+  if (request.approved) args.push('--approved', '1');
   const rc = runBroker(paths, opts, args);
   const response = readFile(outFile);
   const errorText = readFile(errFile);
-  try {
-    fs.unlinkSync(bodyFile);
-  } catch (_) {}
   if (rc !== 0) {
     const status = rc === 23 ? 'unavailable' : 'error';
     throw new PlanFailure(`HTTP broker failed rc=${rc}: ${redact(errorText || response).slice(0, 300)}`, {
@@ -491,13 +510,14 @@ function writeRunLog(paths, plan, status, preview, durationMs, errorMessage) {
   writeAtomic(path.join(paths.logDir, `${Math.floor(ts / 1000)}.json`), JSON.stringify(log) + '\n');
 }
 
-function requestActionApproval(paths, plan, actionType, preview, resultFile, config) {
+function requestActionApproval(paths, plan, actionType, preview, resultFile, config, details) {
   ensureDir(paths.actionApprovalDir);
   ensureDir(paths.actionApprovalReplyDir);
   const runId = `${plan.agent.id}-${Math.floor(Date.now() / 1000)}-${process.pid}`;
   const requestFile = path.join(paths.actionApprovalDir, `action-${safeFilePart(runId)}.json`);
   const replyFile = path.join(paths.actionApprovalReplyDir, `action-${safeFilePart(runId)}.reply.json`);
   const timeoutSeconds = Number(config.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || process.env.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || 120);
+  const extra = details || {};
   const request = {
     runId,
     agentId: plan.agent.id,
@@ -505,11 +525,11 @@ function requestActionApproval(paths, plan, actionType, preview, resultFile, con
     toolLabel: plan.tool.label,
     actionType,
     preview,
-    destinationHost: '',
-    command: '',
-    safetyLevel: '',
-    safetyReason: '',
-    payloadPath: '',
+    destinationHost: extra.destinationHost || '',
+    command: extra.command || '',
+    safetyLevel: extra.safetyLevel || '',
+    safetyReason: extra.safetyReason || '',
+    payloadPath: extra.payloadPath || '',
     resultPath: resultFile,
     ts: new Date().toISOString(),
     expiresAt: Date.now() + Math.max(1, timeoutSeconds) * 1000,
@@ -573,6 +593,97 @@ function resolveDraftDestination(paths, plan, config) {
   return path.join(plan.output.outputDir, rel);
 }
 
+function webhookDestinationHost(urlText) {
+  try {
+    const u = new URL(String(urlText || ''));
+    if (u.protocol !== 'https:') return '';
+    return u.host;
+  } catch (_) {
+    return '';
+  }
+}
+
+function writeWebhookPayload(file, plan, status, preview, resultText) {
+  writeAtomic(file, JSON.stringify({
+    agentId: plan.agent.id,
+    status,
+    preview,
+    toolUsed: plan.tool.label,
+    timestamp: Math.floor(Date.now() / 1000),
+    result: resultText,
+  }) + '\n');
+}
+
+function resolveCliCwd(paths, plan, config) {
+  const wanted =
+    config.SHELLY_AGENT_EXEC_CWD ||
+    config.SHELLY_CONTENT_PROJECT ||
+    path.join(paths.home, 'projects/shelly-content-studio');
+  try {
+    if (wanted && path.isAbsolute(wanted) && fs.existsSync(wanted) && fs.statSync(wanted).isDirectory()) return wanted;
+  } catch (_) {
+    // fall through to the known local output directory
+  }
+  const fallback = path.join(paths.home, 'agent-output');
+  ensureDir(fallback);
+  return fallback;
+}
+
+function brokerWorkspaceExec(paths, opts, roots, plan, commandText, cwd) {
+  const commandFile = path.join(paths.tmpDir, `plan-exec-command-${plan.agent.id}-${process.pid}.txt`);
+  const rootsFile = writeRootsFile(paths, roots);
+  const outFile = path.join(paths.logDir, `cli-action-output-${Date.now()}.txt`);
+  const errFile = path.join(paths.logDir, `cli-action-error-${Date.now()}.txt`);
+  writeAtomic(commandFile, commandText);
+  const rc = runBroker(paths, opts, [
+    '--op', 'workspace.exec',
+    '--command-file', commandFile,
+    '--cwd', cwd,
+    '--roots-file', rootsFile,
+    '--audit-log', paths.brokerAuditFile,
+    '--timeout-seconds', String(plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600),
+    '--out', outFile,
+    '--err', errFile,
+  ]);
+  try {
+    fs.unlinkSync(commandFile);
+  } catch (_) {}
+  try {
+    fs.unlinkSync(rootsFile);
+  } catch (_) {}
+  return { rc, outFile, errFile, out: readFile(outFile), err: readFile(errFile) };
+}
+
+function appendCliActionReport(resultFile, commandText, cwd, safety, execResult) {
+  const errorText = execResult.err ? `\n[stderr]\n${execResult.err}` : '';
+  const combined = `${execResult.out || ''}${errorText}`;
+  const safetyLevel = safety && safety.level ? safety.level : '';
+  const safetyReason = safety && safety.reason ? safety.reason : '';
+  fs.appendFileSync(resultFile, [
+    '',
+    '## CLI action',
+    '',
+    `Safety: ${safetyLevel} - ${safetyReason}`,
+    '',
+    `Cwd: ${cwd}`,
+    '',
+    'Command:',
+    '',
+    '```sh',
+    commandText,
+    '```',
+    '',
+    `Exit code: ${execResult.rc}`,
+    '',
+    'Output:',
+    '',
+    '```text',
+    redact(combined).slice(0, 4000),
+    '```',
+    '',
+  ].join('\n'));
+}
+
 function argTruthy(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
 }
@@ -606,7 +717,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
   const actionType = plan.action.type;
   const preview = previewText(resultText);
   if (actionType === '__suppressed__') return { status: 'success', preview };
-  if (actionType !== 'draft' && actionType !== 'notify') {
+  if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
   if (trustedNativeLowRiskAction(args, plan, actionType)) {
@@ -619,13 +730,76 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
       toolType: plan.tool.type,
     });
   } else {
+    if (actionType === 'webhook') {
+      const webhookUrl = String(plan.action.webhookUrl || '').trim();
+      const host = webhookDestinationHost(webhookUrl);
+      if (!webhookUrl) {
+        const message = 'Webhook action is missing an https URL.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      if (!host) {
+        const message = 'Webhook action requires a valid https URL.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      const payloadFile = path.join(paths.logDir, `webhook-payload-${Date.now()}.json`);
+      writeWebhookPayload(payloadFile, plan, 'success', preview, resultText);
+      requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
+        destinationHost: host,
+        payloadPath: payloadFile,
+      });
+      try {
+        brokerHttpBodyFile(paths, opts, plan, {
+          url: webhookUrl,
+          bodyFile: payloadFile,
+          approved: true,
+          timeoutSeconds: Number(config.WEBHOOK_TIMEOUT_SECONDS || 30),
+        });
+      } catch (e) {
+        const message = e instanceof PlanFailure ? redact(e.message) : redact(String(e));
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      return { status: 'success', preview };
+    }
+    if (actionType === 'cli') {
+      const commandText = String(plan.action.command || '').trim();
+      const safety = plan.action.safety || {};
+      if (!commandText) {
+        const message = 'CLI action is missing a command.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      if (safety.level === 'CRITICAL') {
+        const message = `CLI action was blocked by command safety: ${safety.reason || 'critical command'}`;
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
+        command: commandText,
+        safetyLevel: safety.level || '',
+        safetyReason: safety.reason || '',
+      });
+      const cwd = resolveCliCwd(paths, plan, config);
+      const execResult = brokerWorkspaceExec(paths, opts, roots, plan, commandText, cwd);
+      appendCliActionReport(paths.resultFile, commandText, cwd, safety, execResult);
+      if (execResult.rc !== 0) {
+        const message = `CLI action failed with exit ${execResult.rc}.`;
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      return { status: 'success', preview };
+    }
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   }
   if (actionType === 'draft') {
     const dest = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
   }
-  writeNotification(paths, plan, 'success', preview);
+  if (actionType === 'draft' || actionType === 'notify') {
+    writeNotification(paths, plan, 'success', preview);
+  }
   return { status: 'success', preview };
 }
 
@@ -709,7 +883,7 @@ function run(args) {
     writeAtomic(paths.resultFile, resultText + (resultText.endsWith('\n') ? '' : '\n'));
     const action = dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args);
     const durationMs = Date.now() - startedAt;
-    writeRunLog(paths, plan, action.status, action.preview, durationMs, '');
+    writeRunLog(paths, plan, action.status, action.preview, durationMs, action.errorMessage || '');
     appendJsonl(paths.planAuditFile, {
       ts: new Date().toISOString(),
       kind: 'plan.executor',

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -1087,6 +1087,15 @@ function run(args) {
     return EXIT.OK;
   }
 
+  // Each run opens a fresh CAP-001 egress budget envelope. The broker's budget file
+  // (cap-budget-<agentId>.json) is keyed per-agent and persists across runs; without
+  // this reset the wall-time budget is measured from the first-ever run, so every run
+  // spuriously fails rc=42 "wall-time budget exhausted" ~10 min after the first
+  // (found in device-verify). The .sh path already rm's it at run start; mirror it.
+  try {
+    fs.rmSync(path.join(paths.tmpDir, `cap-budget-${plan.agent.id}.json`), { force: true });
+  } catch (_) {}
+
   try {
     const request = modelRequest(plan, config);
     const response = brokerHttp(paths, opts, plan, request);

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmReceiver.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmReceiver.kt
@@ -42,6 +42,8 @@ class AgentAlarmReceiver : BroadcastReceiver() {
             val serviceIntent = Intent(app, TerminalSessionService::class.java).apply {
                 action = TerminalSessionService.ACTION_RUN_AGENT
                 putExtra(TerminalSessionService.EXTRA_AGENT_ID, agentId)
+                putExtra(TerminalSessionService.EXTRA_INTERVAL_MS, intervalMs)
+                if (!cron.isNullOrBlank()) putExtra(TerminalSessionService.EXTRA_CRON, cron)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 app.startForegroundService(serviceIntent)

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -31,7 +31,17 @@ object AgentRuntime {
     private const val CURRENT_SCRIPT_VERSION = 10
     private const val CURRENT_PLAN_SPEC_VERSION = 1
 
-    fun runAgent(context: Context, agentId: String, tainted: Boolean = false): AgentRunResult {
+    private data class TrustedPlanLaunch(
+        val actionType: String,
+        val toolType: String
+    )
+
+    fun runAgent(
+        context: Context,
+        agentId: String,
+        tainted: Boolean = false,
+        unattended: Boolean = false
+    ): AgentRunResult {
         val appContext = context.applicationContext
         HomeInitializer.initialize(appContext)
         val homeDir = HomeInitializer.getHomeDir(appContext)
@@ -46,7 +56,7 @@ object AgentRuntime {
         val bashPath = LibExtractor.getBashPath(appContext)
 
         if (shouldRunPlanExecutor(homeDir, agentId)) {
-            return runPlanAgent(appContext, homeDir, libDir, bashPath, agentId)
+            return runPlanAgent(appContext, homeDir, libDir, bashPath, agentId, unattended)
         }
 
         val scriptPath = File(homeDir, ".shelly/agents/run-agent-$agentId.sh").absolutePath
@@ -142,7 +152,8 @@ object AgentRuntime {
         homeDir: File,
         libDir: File,
         bashPath: String,
-        agentId: String
+        agentId: String,
+        unattended: Boolean
     ): AgentRunResult {
         val libPath = libDir.absolutePath
         val planPath = File(homeDir, ".shelly/agents/plans/plan-agent-$agentId.json").absolutePath
@@ -167,6 +178,14 @@ object AgentRuntime {
             NotificationDispatcher(context).notifyAgentResult(agentId, "error", message)
             return AgentRunResult(agentId, 126, "", message)
         }
+        val planAgentId = readPlanSpecAgentId(plan)
+        if (planAgentId != agentId) {
+            val message = "PlanSpec agent id mismatch: plan=$planAgentId expected=$agentId"
+            Log.e(TAG, message)
+            writeReceiverLog(homeDir, agentId, "error", message)
+            NotificationDispatcher(context).notifyAgentResult(agentId, "error", message)
+            return AgentRunResult(agentId, 127, "", message)
+        }
         if (!executor.isFile || !broker.isFile) {
             val message = "PlanSpec executor assets missing: executor=${executor.isFile} broker=${broker.isFile}"
             Log.e(TAG, message)
@@ -174,6 +193,7 @@ object AgentRuntime {
             NotificationDispatcher(context).notifyAgentResult(agentId, "error", message)
             return AgentRunResult(agentId, 127, "", message)
         }
+        val trustedLaunch = trustedPlanLaunch(homeDir, agentId)
 
         val command = buildString {
             append("export PATH=")
@@ -197,15 +217,28 @@ object AgentRuntime {
             append(shellQuote(executorPath))
             append(" --plan-file ")
             append(shellQuote(planPath))
+            append(" --agent-id ")
+            append(shellQuote(agentId))
             append(" --home ")
             append(shellQuote(homeDir.absolutePath))
             append(" --lib-dir ")
             append(shellQuote(libPath))
             append(" --broker ")
             append(shellQuote(brokerPath))
+            if (unattended) {
+                append(" --unattended 1")
+            }
+            if (trustedLaunch != null) {
+                append(" --trusted-autonomous-agent-id ")
+                append(shellQuote(agentId))
+                append(" --trusted-autonomous-action ")
+                append(shellQuote(trustedLaunch.actionType))
+                append(" --trusted-tool-type ")
+                append(shellQuote(trustedLaunch.toolType))
+            }
         }
 
-        Log.i(TAG, "Agent $agentId starting via PlanSpec executor plan=$planPath version=$planVersion")
+        Log.i(TAG, "Agent $agentId starting via PlanSpec executor plan=$planPath version=$planVersion unattended=$unattended trustedAction=${trustedLaunch?.actionType ?: "-"} trustedTool=${trustedLaunch?.toolType ?: "-"}")
         val actionApprovalNotifierStop = AtomicBoolean(false)
         val actionApprovalNotifier = startActionApprovalNotifier(context, actionApprovalNotifierStop)
         val result = try {
@@ -330,10 +363,45 @@ object AgentRuntime {
         }
     }
 
+    private fun readPlanSpecAgentId(plan: File): String {
+        return try {
+            JSONObject(plan.readText()).optJSONObject("agent")?.optString("id").orEmpty()
+        } catch (_: Exception) {
+            ""
+        }
+    }
+
     private fun shouldRunPlanExecutor(homeDir: File, agentId: String): Boolean {
         val flags = readAgentEnvFlags(homeDir)
         if (!isTruthy(flags["SHELLY_PLAN_EXECUTOR"])) return false
         return flags["SHELLY_PLAN_EXECUTOR_AGENT_ID"] == agentId
+    }
+
+    private fun trustedPlanLaunch(homeDir: File, agentId: String): TrustedPlanLaunch? {
+        val agentFile = File(homeDir, ".shelly/agents/$agentId.json")
+        if (!agentFile.isFile) return null
+        return try {
+            val json = JSONObject(agentFile.readText())
+            if (json.optString("id") != agentId) return null
+            if (!json.optBoolean("autonomous", false)) return null
+            val actionType = json.optJSONObject("action")
+                ?.optString("type")
+                ?.takeIf { it.isNotBlank() }
+                ?: "draft"
+            if (actionType != "draft" && actionType != "notify") return null
+            val toolType = json.optJSONObject("tool")
+                ?.optString("type")
+                ?.takeIf { it.isNotBlank() }
+                ?: return null
+            // Phase 0 canary only trusts deterministic local unattended effects.
+            // Cloud/web/auto routes stay manual-gated until PlanSpec integrity is
+            // signed or native can recompute the full TS route decision.
+            if (toolType != "local") return null
+            TrustedPlanLaunch(actionType = actionType, toolType = toolType)
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to read trusted PlanSpec launch state for $agentId", e)
+            null
+        }
     }
 
     private fun readAgentEnvFlags(homeDir: File): Map<String, String> {

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -29,6 +29,7 @@ object AgentRuntime {
     private const val TAG = "AgentRuntime"
     private const val DEFAULT_TIMEOUT_MS = 30 * 60 * 1000
     private const val CURRENT_SCRIPT_VERSION = 10
+    private const val CURRENT_PLAN_SPEC_VERSION = 1
 
     fun runAgent(context: Context, agentId: String, tainted: Boolean = false): AgentRunResult {
         val appContext = context.applicationContext
@@ -43,6 +44,11 @@ object AgentRuntime {
             return AgentRunResult(agentId, 125, "", message)
         }
         val bashPath = LibExtractor.getBashPath(appContext)
+
+        if (shouldRunPlanExecutor(homeDir, agentId)) {
+            return runPlanAgent(appContext, homeDir, libDir, bashPath, agentId)
+        }
+
         val scriptPath = File(homeDir, ".shelly/agents/run-agent-$agentId.sh").absolutePath
         val script = File(scriptPath)
 
@@ -131,6 +137,116 @@ object AgentRuntime {
         return AgentRunResult(agentId, exitCode, stdout, stderr)
     }
 
+    private fun runPlanAgent(
+        context: Context,
+        homeDir: File,
+        libDir: File,
+        bashPath: String,
+        agentId: String
+    ): AgentRunResult {
+        val libPath = libDir.absolutePath
+        val planPath = File(homeDir, ".shelly/agents/plans/plan-agent-$agentId.json").absolutePath
+        val executorPath = File(homeDir, ".shelly-plan-executor.js").absolutePath
+        val brokerPath = File(homeDir, ".shelly-capability-broker.js").absolutePath
+        val plan = File(planPath)
+        val executor = File(executorPath)
+        val broker = File(brokerPath)
+
+        if (!plan.isFile) {
+            val message = "missing PlanSpec: $planPath"
+            Log.e(TAG, message)
+            writeReceiverLog(homeDir, agentId, "error", message)
+            NotificationDispatcher(context).notifyAgentResult(agentId, "error", message)
+            return AgentRunResult(agentId, 127, "", message)
+        }
+        val planVersion = readPlanSpecVersion(plan)
+        if (planVersion != CURRENT_PLAN_SPEC_VERSION) {
+            val message = "stale PlanSpec: $planPath version=$planVersion expected=$CURRENT_PLAN_SPEC_VERSION. Open Shelly or run the agent manually once to regenerate it."
+            Log.e(TAG, message)
+            writeReceiverLog(homeDir, agentId, "error", message)
+            NotificationDispatcher(context).notifyAgentResult(agentId, "error", message)
+            return AgentRunResult(agentId, 126, "", message)
+        }
+        if (!executor.isFile || !broker.isFile) {
+            val message = "PlanSpec executor assets missing: executor=${executor.isFile} broker=${broker.isFile}"
+            Log.e(TAG, message)
+            writeReceiverLog(homeDir, agentId, "error", message)
+            NotificationDispatcher(context).notifyAgentResult(agentId, "error", message)
+            return AgentRunResult(agentId, 127, "", message)
+        }
+
+        val command = buildString {
+            append("export PATH=")
+            append(shellQuote("$libPath:$libPath/node_modules/npm/bin:$libPath/node_modules/.bin:/usr/bin:/usr/sbin:/bin:/sbin"))
+            append(" && export LD_LIBRARY_PATH=")
+            append(shellQuote(libPath))
+            append(" && export HOME=")
+            append(shellQuote(homeDir.absolutePath))
+            append(" && export SHELLY_LIB_DIR=")
+            append(shellQuote(libPath))
+            append(" && export SHELLY_CAP_BROKER=1 SHELLY_CAP_FS=1 SHELLY_CAP_EXEC=1")
+            append(" && export SSL_CERT_FILE=")
+            append(shellQuote("${homeDir.absolutePath}/.shelly-ssl/ca-certificates.crt"))
+            append(" && export CURL_CA_BUNDLE=")
+            append(shellQuote("${homeDir.absolutePath}/.shelly-ssl/ca-certificates.crt"))
+            append(" && export NODE_EXTRA_CA_CERTS=")
+            append(shellQuote("${homeDir.absolutePath}/.shelly-ssl/ca-certificates.crt"))
+            append(" && /system/bin/linker64 ")
+            append(shellQuote("$libPath/node"))
+            append(" ")
+            append(shellQuote(executorPath))
+            append(" --plan-file ")
+            append(shellQuote(planPath))
+            append(" --home ")
+            append(shellQuote(homeDir.absolutePath))
+            append(" --lib-dir ")
+            append(shellQuote(libPath))
+            append(" --broker ")
+            append(shellQuote(brokerPath))
+        }
+
+        Log.i(TAG, "Agent $agentId starting via PlanSpec executor plan=$planPath version=$planVersion")
+        val actionApprovalNotifierStop = AtomicBoolean(false)
+        val actionApprovalNotifier = startActionApprovalNotifier(context, actionApprovalNotifierStop)
+        val result = try {
+            ShellyJNI.execSubprocess(
+                "/system/bin/linker64",
+                bashPath,
+                libPath,
+                homeDir.absolutePath,
+                command,
+                DEFAULT_TIMEOUT_MS
+            )
+        } finally {
+            actionApprovalNotifierStop.set(true)
+            runCatching { actionApprovalNotifier.join(1000) }
+        }
+
+        val exitCode = result.getOrNull(0)?.toIntOrNull() ?: 1
+        val stdout = result.getOrNull(1).orEmpty()
+        val stderr = result.getOrNull(2).orEmpty()
+        val notificationPosted = postAgentResultNotificationIfRequested(context, homeDir, agentId)
+        if (exitCode == 0) {
+            Log.i(TAG, "Agent $agentId completed via PlanSpec executor")
+        } else {
+            Log.e(TAG, "Agent $agentId failed via PlanSpec executor: exit=$exitCode stderr=${stderr.take(300)}")
+            if (!notificationPosted) {
+                NotificationDispatcher(context).notifyAgentResult(
+                    agentId = agentId,
+                    status = "error",
+                    preview = "PlanSpec executor failed. exit=$exitCode stderr=${stderr.take(300)}"
+                )
+            }
+            writeReceiverLog(
+                homeDir,
+                agentId,
+                "error",
+                "plan-executor exit=$exitCode stderr=${stderr.take(500)} stdout=${stdout.take(500)}"
+            )
+        }
+        return AgentRunResult(agentId, exitCode, stdout, stderr)
+    }
+
     private fun postAgentResultNotificationIfRequested(context: Context, homeDir: File, agentId: String): Boolean {
         val request = File(homeDir, ".shelly/agents/logs/$agentId/native-result-notification.json")
         if (!request.isFile) return false
@@ -205,6 +321,57 @@ object AgentRuntime {
             0
         }
     }
+
+    private fun readPlanSpecVersion(plan: File): Int {
+        return try {
+            JSONObject(plan.readText()).optInt("schemaVersion", 0)
+        } catch (_: Exception) {
+            0
+        }
+    }
+
+    private fun shouldRunPlanExecutor(homeDir: File, agentId: String): Boolean {
+        val flags = readAgentEnvFlags(homeDir)
+        if (!isTruthy(flags["SHELLY_PLAN_EXECUTOR"])) return false
+        return flags["SHELLY_PLAN_EXECUTOR_AGENT_ID"] == agentId
+    }
+
+    private fun readAgentEnvFlags(homeDir: File): Map<String, String> {
+        val envFile = File(homeDir, ".shelly/agents/.env")
+        if (!envFile.isFile) return emptyMap()
+        val wanted = setOf("SHELLY_PLAN_EXECUTOR", "SHELLY_PLAN_EXECUTOR_AGENT_ID")
+        val out = mutableMapOf<String, String>()
+        try {
+            envFile.forEachLine { raw ->
+                val line = raw.trim()
+                if (line.isEmpty() || line.startsWith("#")) return@forEachLine
+                val eq = line.indexOf('=')
+                if (eq <= 0) return@forEachLine
+                val key = line.substring(0, eq).trim().removePrefix("export ").trim()
+                if (!wanted.contains(key)) return@forEachLine
+                out[key] = stripEnvValue(line.substring(eq + 1).trim())
+            }
+        } catch (_: Exception) {
+            return emptyMap()
+        }
+        return out
+    }
+
+    private fun stripEnvValue(value: String): String {
+        if (value.length >= 2 && value.first() == '\'' && value.last() == '\'') {
+            return value.substring(1, value.length - 1)
+        }
+        if (value.length >= 2 && value.first() == '"' && value.last() == '"') {
+            return value.substring(1, value.length - 1)
+        }
+        return value
+    }
+
+    private fun isTruthy(value: String?): Boolean =
+        when (value?.trim()?.lowercase()) {
+            "1", "true", "yes", "on" -> true
+            else -> false
+        }
 
     private fun writeReceiverLog(homeDir: File, agentId: String, status: String, message: String) {
         try {

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -28,7 +28,7 @@ data class AgentRunResult(
 object AgentRuntime {
     private const val TAG = "AgentRuntime"
     private const val DEFAULT_TIMEOUT_MS = 30 * 60 * 1000
-    private const val CURRENT_SCRIPT_VERSION = 9
+    private const val CURRENT_SCRIPT_VERSION = 10
 
     fun runAgent(context: Context, agentId: String, tainted: Boolean = false): AgentRunResult {
         val appContext = context.applicationContext

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -224,7 +224,20 @@ object AgentRuntime {
             append(shellQuote("${homeDir.absolutePath}/.shelly-ssl/ca-certificates.crt"))
             append(" && export NODE_EXTRA_CA_CERTS=")
             append(shellQuote("${homeDir.absolutePath}/.shelly-ssl/ca-certificates.crt"))
-            append(" && /system/bin/linker64 ")
+            // Drop the exec-wrapper LD_PRELOAD (set globally by shelly-exec.c on this
+            // launching shell) before the linker64 node launch. Inherited into bionic
+            // node, the wrapper's fs/open interposition corrupts node's file-descriptor
+            // ops and SIGABRTs it: reading the .js entry module aborts on
+            // "Assertion failed: (0) == uv_fs_close(...)" in node::ReadFileSync
+            // (shouldUseESMLoader), and OpenSSL's config read fails with
+            // "BIO_new_file:Bad file descriptor" on openssl.cnf — so the executor never
+            // runs on-device. Confirmed on hardware: the identical launch aborts (134)
+            // with LD_PRELOAD and succeeds (0) without it. The executor and broker are
+            // leaf node processes that never exec an app-data binary, so they do not
+            // need the wrapper. Mirrors the llama-server launcher and the broker
+            // childEnv (which also drops it). Device-only bug — the host harness spawns
+            // the executor without this inherited preload, so it cannot reproduce it.
+            append(" && unset LD_PRELOAD && /system/bin/linker64 ")
             append(shellQuote("$libPath/node"))
             append(" ")
             append(shellQuote(executorPath))

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -163,6 +163,19 @@ object AgentRuntime {
         val executor = File(executorPath)
         val broker = File(brokerPath)
 
+        // Global kill-switch (STOP ALL). haltAllAgents uninstalls schedules and drops
+        // this sentinel; refuse here so a still-in-flight alarm or a direct `am` fire
+        // never launches the executor. Fail-closed. This native gate stays silent
+        // (halt is user-initiated and schedules are already torn down — avoid per-fire
+        // notification spam); the executor's own kill-switch skip still records a
+        // skipped run log/notification if it is ever invoked directly (am/harness).
+        if (File(homeDir, ".shelly/agents/.halted").isFile) {
+            val message = "All agents are stopped (global kill-switch is on)."
+            Log.i(TAG, "Agent $agentId refused: $message")
+            writeReceiverLog(homeDir, agentId, "skipped", message)
+            return AgentRunResult(agentId, 130, "", message)
+        }
+
         if (!plan.isFile) {
             val message = "missing PlanSpec: $planPath"
             Log.e(TAG, message)

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/HomeInitializer.kt
@@ -1214,6 +1214,17 @@ patchCodex(libDir);
             android.util.Log.e("HomeInitializer", "shelly-capability-broker.js extract failed: ${e.message}")
         }
 
+        // Phase 0 PlanSpec executor canary. Invoked via node from AgentRuntime
+        // when SHELLY_PLAN_EXECUTOR=1 for a targeted agent.
+        val planExecutorScript = File(home, ".shelly-plan-executor.js")
+        try {
+            context.assets.open("shelly-plan-executor.js").use { input ->
+                planExecutorScript.outputStream().use { output -> input.copyTo(output) }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("HomeInitializer", "shelly-plan-executor.js extract failed: ${e.message}")
+        }
+
         val agentEscalationDir = File(home, ".shelly/agents/escalations")
         agentEscalationDir.mkdirs()
         val agentEscalationReplyDir = File(context.noBackupFilesDir, "shelly-agent-escalation-replies")

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalSessionService.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalSessionService.kt
@@ -107,13 +107,14 @@ class TerminalSessionService : Service() {
                     return START_STICKY
                 }
                 val tainted = intent.getBooleanExtra(EXTRA_TAINTED, false)
+                val intervalMs = intent.getLongExtra(EXTRA_INTERVAL_MS, 0L)
+                val cron = intent.getStringExtra(EXTRA_CRON)
+                val unattended = intervalMs > 0 || !cron.isNullOrBlank()
                 startForegroundWithNotification("Agent running in background")
-                runAgentInBackground(agentId, tainted)
+                runAgentInBackground(agentId, tainted, unattended)
                 // Alarm-fired runs carry interval/cron — re-arm the next fire here now
                 // that the alarm targets this service directly (no receiver in the
                 // loop). A manual run (no interval/cron extras) is a no-op.
-                val intervalMs = intent.getLongExtra(EXTRA_INTERVAL_MS, 0L)
-                val cron = intent.getStringExtra(EXTRA_CRON)
                 if (intervalMs > 0 || !cron.isNullOrBlank()) {
                     try {
                         AgentAlarmScheduler.scheduleNext(applicationContext, agentId, intervalMs, cron)
@@ -248,7 +249,7 @@ class TerminalSessionService : Service() {
         nm.notify(NOTIFICATION_ID, notification)
     }
 
-    private fun runAgentInBackground(agentId: String, tainted: Boolean = false) {
+    private fun runAgentInBackground(agentId: String, tainted: Boolean, unattended: Boolean) {
         activeAgentRuns.incrementAndGet()
         Thread {
             val wakeLock = acquireAgentWakeLock(agentId)
@@ -260,7 +261,12 @@ class TerminalSessionService : Service() {
             try {
                 // AgentRuntime announces the run outcome itself (agent-result /
                 // error notification); we don't need its return value here.
-                AgentRuntime.runAgent(applicationContext, agentId, tainted)
+                AgentRuntime.runAgent(
+                    applicationContext,
+                    agentId,
+                    tainted = tainted,
+                    unattended = unattended
+                )
             } catch (e: Exception) {
                 Log.e(TAG, "Agent $agentId crashed while running", e)
             } finally {

--- a/scripts/shelly-capability-broker.js
+++ b/scripts/shelly-capability-broker.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /*
- * shelly-capability-broker.js — CAP-001 / SECRET-001 / HTTP-001 runtime broker.
+ * shelly-capability-broker.js — CAP-001 / SECRET-001 / HTTP-001 / FS-001 /
+ * EXEC-001 runtime broker.
  *
  * Phase 0 「床」of the L1/L2 Capability Catalog
  * (docs/superpowers/specs/2026-07-01-l1-l2-capability-catalog.md). The generated
@@ -28,6 +29,8 @@
  *   42  budget exhausted
  *   43  auth_ref could not be resolved (missing/empty secret)
  *   44  usage error
+ *   45  scoped.fs denied or failed
+ *   46  workspace.exec denied
  *   127 internal error
  */
 
@@ -36,6 +39,7 @@
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
+const path = require('path');
 
 // ---------------------------------------------------------------------------
 // Mirror of lib/capability-envelope.ts — keep in sync (parity-tested).
@@ -73,6 +77,8 @@ const EXIT = {
   BUDGET: 42,
   NO_SECRET: 43,
   USAGE: 44,
+  FS_DENY: 45,
+  EXEC_DENY: 46,
   INTERNAL: 127,
 };
 
@@ -159,6 +165,291 @@ function classifyEgress(url, authRef, tainted) {
     return { decision: 'approve', reason: 'tainted input plus a live secret "' + authRef + '" to ' + host + ' requires human approval', signals: signals };
   }
   return { decision: 'allow', reason: 'host ' + host + ' is allowlisted', signals: signals };
+}
+
+// ---------------------------------------------------------------------------
+// FS-001 / EXEC-001 path policy
+// ---------------------------------------------------------------------------
+
+function normalizePath(p) {
+  const text = String(p == null ? '' : p);
+  const isAbs = text[0] === '/';
+  const out = [];
+  for (const seg of text.split('/')) {
+    if (!seg || seg === '.') continue;
+    if (seg === '..') {
+      if (out.length && out[out.length - 1] !== '..') out.pop();
+      else if (!isAbs) out.push('..');
+    } else {
+      out.push(seg);
+    }
+  }
+  return (isAbs ? '/' : '') + out.join('/');
+}
+
+function isWithinRoot(root, target) {
+  if (!root || !target || String(target).startsWith('~')) return false;
+  const r = normalizePath(root).replace(/\/$/, '');
+  const t = normalizePath(String(target)[0] === '/' ? target : r + '/' + target);
+  return t === r || t.indexOf(r + '/') === 0;
+}
+
+function lexicalAbsolute(p, cwd) {
+  const value = String(p == null ? '' : p);
+  if (!value || value.indexOf('\0') !== -1 || value[0] === '~') throw new Error('invalid path');
+  const base = cwd && cwd[0] === '/' ? cwd : '/';
+  return normalizePath(value[0] === '/' ? value : base + '/' + value);
+}
+
+function realpathWithMissingTail(target) {
+  const absolute = lexicalAbsolute(target, '/');
+  return resolveRealPathNoDanglingSymlink(absolute, 0);
+}
+
+function resolveRealPathNoDanglingSymlink(absoluteTarget, depth) {
+  if (depth > 40) throw new Error('too many symbolic links');
+  const absolute = lexicalAbsolute(absoluteTarget, '/');
+  const parts = absolute.split('/').filter(Boolean);
+  let current = '/';
+  for (let i = 0; i < parts.length; i += 1) {
+    const candidate = normalizePath(path.join(current, parts[i]));
+    let stat;
+    try {
+      stat = fs.lstatSync(candidate);
+    } catch (e) {
+      if (e && e.code === 'ENOENT') {
+        return normalizePath(path.join(current, ...parts.slice(i)));
+      }
+      throw e;
+    }
+    if (stat.isSymbolicLink()) {
+      const link = fs.readlinkSync(candidate);
+      if (!link || link.indexOf('\0') !== -1) throw new Error('invalid symbolic link target');
+      const resolved = normalizePath(path.isAbsolute(link) ? link : path.join(path.dirname(candidate), link));
+      const remaining = parts.slice(i + 1);
+      return resolveRealPathNoDanglingSymlink(path.join(resolved, ...remaining), depth + 1);
+    }
+    current = candidate;
+  }
+  try {
+    return normalizePath(fs.realpathSync.native ? fs.realpathSync.native(absolute) : fs.realpathSync(absolute));
+  } catch (_) {
+    return normalizePath(absolute);
+  }
+}
+
+function readRoots(args) {
+  const roots = [];
+  if (args['roots-file']) {
+    try {
+      for (const line of fs.readFileSync(args['roots-file'], 'utf8').split('\n')) {
+        const root = line.trim();
+        if (root) roots.push(root);
+      }
+    } catch (_) {
+      /* handled as no roots below */
+    }
+  }
+  if (args.root) roots.push(args.root);
+  const out = [];
+  for (const root of roots) {
+    try {
+      const real = realpathWithMissingTail(root);
+      if (out.indexOf(real) === -1) out.push(real);
+    } catch (_) {
+      /* skip invalid roots */
+    }
+  }
+  return out;
+}
+
+function classifyScopedPath(op, targetPath, roots, cwd) {
+  let canonical;
+  try {
+    canonical = realpathWithMissingTail(lexicalAbsolute(targetPath, cwd || '/'));
+  } catch (e) {
+    return { decision: 'deny', reason: e && e.message ? e.message : 'invalid path', signals: ['invalid-path'], path: '<invalid>', root: null };
+  }
+  if (!roots.length) {
+    return { decision: 'deny', reason: 'no scoped roots declared', signals: ['no-roots'], path: canonical, root: null };
+  }
+  const matched = roots.find((root) => isWithinRoot(root, canonical)) || null;
+  if (!matched) {
+    return { decision: 'deny', reason: op + ' path is outside declared roots', signals: ['outside-root'], path: canonical, root: null };
+  }
+  return { decision: 'allow', reason: op + ' path is inside declared root', signals: ['inside-root'], path: canonical, root: matched };
+}
+
+function classifyWorkspaceExec(command, cwd, roots) {
+  const safety = classifyCommandSafety(command);
+  const verdict = classifyScopedPath('workspace.exec cwd', cwd, roots, roots[0] || '/');
+  verdict.dangerLevel = safety.level;
+  verdict.command = null;
+  if (safety.level === 'CRITICAL') {
+    return {
+      decision: 'deny',
+      reason: safety.reason,
+      signals: ['critical-command'],
+      path: verdict.path,
+      root: verdict.root,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+  if (verdict.decision !== 'allow') return verdict;
+  const curated = parseCuratedExecCommand(command);
+  if (!curated.ok) {
+    return {
+      decision: 'deny',
+      reason: curated.reason,
+      signals: [curated.signal],
+      path: verdict.path,
+      root: verdict.root,
+      dangerLevel: safety.level,
+      command: null,
+    };
+  }
+  for (const rawPath of curated.command.pathArgs) {
+    const pathVerdict = classifyScopedPath('workspace.exec path argument', rawPath, roots, verdict.path);
+    if (pathVerdict.decision !== 'allow') {
+      return {
+        decision: 'deny',
+        reason: pathVerdict.reason,
+        signals: pathVerdict.signals,
+        path: verdict.path,
+        root: verdict.root,
+        dangerLevel: safety.level,
+        command: null,
+      };
+    }
+  }
+  verdict.reason = safety.reason || 'curated command allowed inside workspace root';
+  verdict.command = curated.command;
+  return verdict;
+}
+
+function splitCuratedCommand(command) {
+  const text = String(command || '').trim();
+  if (!text) return { error: 'command is empty', signal: 'unsupported-command' };
+  if (/[\0\r\n]/.test(text)) return { error: 'multi-line shell commands are not supported by workspace.exec', signal: 'unsafe-shell-syntax' };
+  if (/[|&;()<>`$\\*?\[\]{}!~]/.test(text)) return { error: 'shell expansion and control operators are not supported by workspace.exec', signal: 'unsafe-shell-syntax' };
+  const argv = [];
+  let current = '';
+  let quote = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        argv.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (quote) return { error: 'unterminated quote in workspace.exec command', signal: 'unsafe-shell-syntax' };
+  if (current) argv.push(current);
+  if (!argv.length) return { error: 'command is empty', signal: 'unsupported-command' };
+  return { argv: argv };
+}
+
+function parseCuratedExecCommand(command) {
+  const split = splitCuratedCommand(command);
+  if (split.error) return { ok: false, reason: split.error, signal: split.signal };
+  const argv = split.argv;
+  const name = argv[0];
+  const pathArgs = [];
+
+  if (name === 'env') {
+    if (argv.length !== 1) return { ok: false, reason: 'env template does not accept arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'env', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'printenv') {
+    if (argv.length > 2 || (argv[1] && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(argv[1]))) {
+      return { ok: false, reason: 'printenv template accepts at most one variable name', signal: 'unsupported-command' };
+    }
+    return { ok: true, command: { template: 'printenv', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'pwd' || name === 'true' || name === 'false') {
+    if (argv.length !== 1) return { ok: false, reason: name + ' template does not accept arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: name, argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'printf') {
+    if (argv.length < 2 || argv.length > 8) return { ok: false, reason: 'printf template requires 1-7 literal arguments', signal: 'unsupported-command' };
+    if (argv.slice(1).some((arg) => arg[0] === '-')) return { ok: false, reason: 'printf template only accepts literal arguments', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'printf', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'sleep') {
+    if (argv.length !== 2 || !/^\d+(?:\.\d+)?$/.test(argv[1])) return { ok: false, reason: 'sleep template requires one numeric duration', signal: 'unsupported-command' };
+    return { ok: true, command: { template: 'sleep', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'cat') {
+    const args = argv.slice(1).filter((arg) => arg !== '--');
+    if (!args.length || args.some((arg) => arg[0] === '-')) return { ok: false, reason: 'cat template requires one or more file paths', signal: 'unsupported-command' };
+    pathArgs.push.apply(pathArgs, args);
+    return { ok: true, command: { template: 'cat', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'ls') {
+    for (const arg of argv.slice(1)) {
+      if (arg[0] === '-') {
+        if (['-a', '-l', '-la', '-al'].indexOf(arg) === -1) return { ok: false, reason: 'ls template only supports -a/-l/-la/-al', signal: 'unsupported-command' };
+      } else {
+        pathArgs.push(arg);
+      }
+    }
+    return { ok: true, command: { template: 'ls', argv: argv, pathArgs: pathArgs } };
+  }
+  if (name === 'grep') {
+    const rest = [];
+    for (const arg of argv.slice(1)) {
+      if (arg[0] === '-') {
+        if (['-n', '-i', '-r', '-R'].indexOf(arg) === -1) return { ok: false, reason: 'grep template only supports -n/-i/-r/-R', signal: 'unsupported-command' };
+      } else {
+        rest.push(arg);
+      }
+    }
+    if (rest.length < 2) return { ok: false, reason: 'grep template requires a literal query and at least one path', signal: 'unsupported-command' };
+    pathArgs.push.apply(pathArgs, rest.slice(1));
+    return { ok: true, command: { template: 'grep', argv: argv, pathArgs: pathArgs } };
+  }
+  return { ok: false, reason: 'workspace.exec command is not in the curated template allowlist: ' + name, signal: 'unsupported-command' };
+}
+
+function classifyCommandSafety(command) {
+  const cleaned = String(command || '').replace(/#[^\n]*/g, '').trim();
+  if (!cleaned) return { level: 'SAFE', reason: 'empty command' };
+  const critical = [
+    { re: /rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(\/|~\/?\s*$|\/\*|~\/\*)/i, reason: 'recursive removal of root or home is forbidden' },
+    { re: /rm\s+-rf\s+\/(?:usr|bin|lib|etc|boot|sys|proc|dev|sbin)/i, reason: 'system directory removal is forbidden' },
+    { re: /:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;?\s*:/, reason: 'fork bomb is forbidden' },
+    { re: /dd\s+if=\/dev\/(?:zero|random|urandom)\s+of=\/dev\/(?:sd[a-z]|nvme|mmcblk)/i, reason: 'raw storage overwrite is forbidden' },
+    { re: /mkfs\s+.*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i, reason: 'device formatting is forbidden' },
+    { re: />\s*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i, reason: 'direct device write is forbidden' },
+    { re: /shred\s+.*\/dev\//i, reason: 'device shredding is forbidden' },
+  ];
+  for (const item of critical) {
+    if (item.re.test(cleaned)) return { level: 'CRITICAL', reason: item.reason };
+  }
+  const high = [
+    { re: /curl\s+.*\|\s*(?:bash|sh|zsh|fish|python3?|node|ruby|perl)/i, reason: 'remote script pipe is high risk' },
+    { re: /wget\s+.*-O\s*-\s*\|\s*(?:bash|sh|zsh|fish)/i, reason: 'remote script pipe is high risk' },
+    { re: /rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+/i, reason: 'recursive force removal is high risk' },
+    { re: /git\s+reset\s+--hard/i, reason: 'hard reset is high risk' },
+    { re: /git\s+(?:push\s+.*--force|push\s+-f)\b/i, reason: 'force push is high risk' },
+  ];
+  for (const item of high) {
+    if (item.re.test(cleaned)) return { level: 'HIGH', reason: item.reason };
+  }
+  return { level: 'SAFE', reason: 'No risky command pattern matched.' };
 }
 
 // ---------------------------------------------------------------------------
@@ -275,6 +566,60 @@ function buildAudit(nowIso, method, url, authRef, tainted, verdict, extra) {
   return entry;
 }
 
+function buildFsAudit(nowIso, op, verdict, extra) {
+  const entry = {
+    ts: nowIso,
+    kind: 'scoped.fs',
+    op: op,
+    path: verdict.path || '<invalid>',
+    root: verdict.root || null,
+    decision: verdict.decision,
+    signals: verdict.signals || [],
+    reason: redact(verdict.reason),
+  };
+  if (extra && typeof extra.ok === 'boolean') entry.ok = extra.ok;
+  if (extra && extra.reason) entry.reason = redact(extra.reason);
+  return entry;
+}
+
+function writeFileNoFollowFromFile(srcPath, destPath) {
+  const noFollow = fs.constants.O_NOFOLLOW || 0;
+  const inFd = fs.openSync(srcPath, fs.constants.O_RDONLY);
+  let outFd = null;
+  try {
+    outFd = fs.openSync(destPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | noFollow, 0o600);
+    const buf = Buffer.allocUnsafe(64 * 1024);
+    while (true) {
+      const n = fs.readSync(inFd, buf, 0, buf.length, null);
+      if (n <= 0) break;
+      fs.writeSync(outFd, buf, 0, n);
+    }
+  } finally {
+    try { fs.closeSync(inFd); } catch (_) {}
+    if (outFd !== null) {
+      try { fs.closeSync(outFd); } catch (_) {}
+    }
+  }
+}
+
+function buildExecAudit(nowIso, verdict, timeoutSeconds, extra) {
+  const entry = {
+    ts: nowIso,
+    kind: 'workspace.exec',
+    cwd: verdict.path || '<invalid>',
+    root: verdict.root || null,
+    decision: verdict.decision,
+    signals: verdict.signals || [],
+    dangerLevel: verdict.dangerLevel || 'SAFE',
+    timeoutSeconds: Number(timeoutSeconds || 0),
+    reason: redact(verdict.reason),
+  };
+  if (extra && typeof extra.ok === 'boolean') entry.ok = extra.ok;
+  if (extra && typeof extra.exitCode === 'number') entry.exitCode = extra.exitCode;
+  if (extra && extra.reason) entry.reason = redact(extra.reason);
+  return entry;
+}
+
 // ---------------------------------------------------------------------------
 // HTTP send (mirrors the http_post_json node contract in agent-executor.ts)
 // ---------------------------------------------------------------------------
@@ -338,6 +683,413 @@ function sendRequest(opts, cb) {
 }
 
 // ---------------------------------------------------------------------------
+// FS-001 scoped.fs operations
+// ---------------------------------------------------------------------------
+
+function openOutErr(outFile, errFile) {
+  if (!outFile || !errFile) throw new Error('out and err files are required');
+  return {
+    outFd: fs.openSync(outFile, 'w'),
+    errFd: fs.openSync(errFile, 'w'),
+  };
+}
+
+function runFsOp(args, nowIso) {
+  const op = args.op || '';
+  const targetPath = args.path || '';
+  const auditFile = args['audit-log'] || '';
+  let fds;
+  try {
+    fds = openOutErr(args.out || '', args.err || '');
+  } catch (e) {
+    process.stderr.write('cannot open out/err files\n');
+    process.exit(EXIT.INTERNAL);
+  }
+  const finish = (code, verdict, extra) => {
+    appendAudit(auditFile, buildFsAudit(nowIso, op, verdict, extra));
+    try { fs.closeSync(fds.outFd); } catch (_) {}
+    try { fs.closeSync(fds.errFd); } catch (_) {}
+    process.exit(code);
+  };
+
+  const roots = readRoots(args);
+  const verdict = classifyScopedPath(op, targetPath, roots, args.cwd || '/');
+  if (verdict.decision !== 'allow') {
+    fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(verdict.reason) + '\n');
+    return finish(EXIT.FS_DENY, verdict, { ok: false });
+  }
+
+  try {
+    if (op === 'fs.read') {
+      const data = fs.readFileSync(verdict.path);
+      fs.writeSync(fds.outFd, data);
+      return finish(EXIT.OK, verdict, { ok: true });
+    }
+    if (op === 'fs.write') {
+      const inputFile = args['input-file'] || '';
+      if (!inputFile) {
+        fs.writeSync(fds.errFd, 'scoped.fs: --input-file is required for fs.write\n');
+        return finish(EXIT.USAGE, verdict, { ok: false });
+      }
+      const inputVerdict = classifyScopedPath('fs.write input', inputFile, roots, args.cwd || '/');
+      if (inputVerdict.decision !== 'allow') {
+        const reason = 'fs.write input file is outside declared roots';
+        const denyVerdict = {
+          decision: 'deny',
+          reason: reason,
+          signals: inputVerdict.signals || ['outside-root'],
+          path: verdict.path,
+          root: verdict.root,
+        };
+        fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(reason) + '\n');
+        return finish(EXIT.FS_DENY, denyVerdict, { ok: false });
+      }
+      fs.mkdirSync(path.dirname(verdict.path), { recursive: true });
+      const writeVerdict = classifyScopedPath(op, verdict.path, roots, args.cwd || '/');
+      if (writeVerdict.decision !== 'allow') {
+        fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(writeVerdict.reason) + '\n');
+        return finish(EXIT.FS_DENY, writeVerdict, { ok: false });
+      }
+      writeFileNoFollowFromFile(inputVerdict.path, writeVerdict.path);
+      fs.writeSync(fds.outFd, verdict.path + '\n');
+      return finish(EXIT.OK, writeVerdict, { ok: true });
+    }
+    if (op === 'fs.list') {
+      const entries = fs.readdirSync(verdict.path, { withFileTypes: true }).map((entry) => ({
+        name: entry.name,
+        type: entry.isDirectory() ? 'directory' : entry.isFile() ? 'file' : entry.isSymbolicLink() ? 'symlink' : 'other',
+      }));
+      fs.writeSync(fds.outFd, JSON.stringify(entries) + '\n');
+      return finish(EXIT.OK, verdict, { ok: true });
+    }
+    if (op === 'fs.search') {
+      const query = String(args.query || '');
+      if (!query) {
+        fs.writeSync(fds.errFd, 'scoped.fs: --query is required for fs.search\n');
+        return finish(EXIT.USAGE, verdict, { ok: false });
+      }
+      const results = [];
+      searchFiles(verdict.path, query, verdict.root, results, 200);
+      fs.writeSync(fds.outFd, JSON.stringify(results) + '\n');
+      return finish(EXIT.OK, verdict, { ok: true });
+    }
+    fs.writeSync(fds.errFd, 'scoped.fs: unknown op ' + op + '\n');
+    return finish(EXIT.USAGE, verdict, { ok: false });
+  } catch (e) {
+    const reason = e && e.message ? e.message : String(e);
+    fs.writeSync(fds.errFd, 'scoped.fs: ' + redact(reason) + '\n');
+    return finish(EXIT.FS_DENY, verdict, { ok: false, reason: reason });
+  }
+}
+
+function searchFiles(rootPath, query, allowedRoot, results, maxResults) {
+  if (results.length >= maxResults) return;
+  let stat;
+  try {
+    stat = fs.lstatSync(rootPath);
+  } catch (_) {
+    return;
+  }
+  const real = realpathWithMissingTail(rootPath);
+  if (!isWithinRoot(allowedRoot, real)) return;
+  if (stat.isSymbolicLink()) return;
+  if (stat.isDirectory()) {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(rootPath);
+    } catch (_) {
+      return;
+    }
+    for (const entry of entries) {
+      if (results.length >= maxResults) return;
+      searchFiles(path.join(rootPath, entry), query, allowedRoot, results, maxResults);
+    }
+    return;
+  }
+  if (!stat.isFile() || stat.size > 1024 * 1024) return;
+  try {
+    const text = fs.readFileSync(rootPath, 'utf8');
+    const idx = text.indexOf(query);
+    if (idx !== -1) {
+      results.push({ path: real, index: idx, preview: text.slice(Math.max(0, idx - 80), idx + query.length + 80) });
+    }
+  } catch (_) {
+    /* binary/unreadable */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EXEC-001 workspace.exec
+// ---------------------------------------------------------------------------
+
+function safeExecEnv() {
+  const env = {};
+  for (const key of ['HOME', 'PATH', 'TMPDIR', 'LANG', 'LC_ALL', 'TERM']) {
+    if (process.env[key]) env[key] = process.env[key];
+  }
+  if (!env.PATH) env.PATH = '/system/bin:/bin:/usr/bin';
+  return env;
+}
+
+function writeSafeEnv(outFd, variableName) {
+  const env = safeExecEnv();
+  const keys = Object.keys(env).sort();
+  if (variableName) {
+    if (Object.prototype.hasOwnProperty.call(env, variableName)) {
+      fs.writeSync(outFd, variableName + '=' + env[variableName] + '\n');
+      return 0;
+    }
+    return 1;
+  }
+  for (const key of keys) {
+    fs.writeSync(outFd, key + '=' + env[key] + '\n');
+  }
+  return 0;
+}
+
+function safeReadScopedFile(filePath, roots, cwd) {
+  const verdict = classifyScopedPath('workspace.exec file', filePath, roots, cwd);
+  if (verdict.decision !== 'allow') return { ok: false, verdict: verdict, reason: verdict.reason };
+  let stat;
+  try {
+    stat = fs.statSync(verdict.path);
+  } catch (e) {
+    return { ok: false, verdict: verdict, reason: e && e.message ? e.message : 'cannot stat file' };
+  }
+  if (!stat.isFile()) return { ok: false, verdict: verdict, reason: 'path is not a regular file' };
+  if (stat.size > 1024 * 1024) return { ok: false, verdict: verdict, reason: 'file exceeds workspace.exec 1MiB read limit' };
+  try {
+    return { ok: true, path: verdict.path, data: fs.readFileSync(verdict.path) };
+  } catch (e) {
+    return { ok: false, verdict: verdict, reason: e && e.message ? e.message : 'cannot read file' };
+  }
+}
+
+function renderScopedList(targetPath, roots, cwd, longFormat, allEntries) {
+  const verdict = classifyScopedPath('workspace.exec list', targetPath || '.', roots, cwd);
+  if (verdict.decision !== 'allow') return { ok: false, reason: verdict.reason };
+  let stat;
+  try {
+    stat = fs.lstatSync(verdict.path);
+  } catch (e) {
+    return { ok: false, reason: e && e.message ? e.message : 'cannot stat path' };
+  }
+  if (!stat.isDirectory()) {
+    return { ok: true, text: verdict.path + '\n' };
+  }
+  let entries;
+  try {
+    entries = fs.readdirSync(verdict.path, { withFileTypes: true });
+  } catch (e) {
+    return { ok: false, reason: e && e.message ? e.message : 'cannot list directory' };
+  }
+  const lines = entries
+    .filter((entry) => allEntries || entry.name[0] !== '.')
+    .map((entry) => {
+      const suffix = entry.isDirectory() ? '/' : entry.isSymbolicLink() ? '@' : '';
+      if (!longFormat) return entry.name + suffix;
+      const full = path.join(verdict.path, entry.name);
+      let size = 0;
+      try { size = fs.lstatSync(full).size; } catch (_) {}
+      return String(size).padStart(8, ' ') + ' ' + entry.name + suffix;
+    })
+    .sort();
+  return { ok: true, text: lines.join('\n') + (lines.length ? '\n' : '') };
+}
+
+function renderScopedGrep(argv, roots, cwd) {
+  let ignoreCase = false;
+  const rest = [];
+  for (const arg of argv.slice(1)) {
+    if (arg === '-i') ignoreCase = true;
+    else if (arg === '-n' || arg === '-r' || arg === '-R') {
+      /* accepted for template compatibility; output is path:index:preview */
+    } else {
+      rest.push(arg);
+    }
+  }
+  const query = rest[0];
+  const paths = rest.slice(1);
+  const needle = ignoreCase ? query.toLowerCase() : query;
+  const results = [];
+  for (const rawPath of paths) {
+    const verdict = classifyScopedPath('workspace.exec grep', rawPath, roots, cwd);
+    if (verdict.decision !== 'allow') return { ok: false, reason: verdict.reason };
+    if (ignoreCase) {
+      collectCaseInsensitiveMatches(verdict.path, needle, verdict.root, results, 200);
+    } else {
+      searchFiles(verdict.path, query, verdict.root, results, 200);
+    }
+    if (results.length >= 200) break;
+  }
+  const text = results.slice(0, 200).map((item) => item.path + ':' + item.index + ':' + item.preview.replace(/\n/g, '\\n')).join('\n');
+  return { ok: true, text: text + (text ? '\n' : '') };
+}
+
+function collectCaseInsensitiveMatches(rootPath, needle, allowedRoot, results, maxResults) {
+  if (results.length >= maxResults) return;
+  let stat;
+  try {
+    stat = fs.lstatSync(rootPath);
+  } catch (_) {
+    return;
+  }
+  const real = realpathWithMissingTail(rootPath);
+  if (!isWithinRoot(allowedRoot, real)) return;
+  if (stat.isSymbolicLink()) return;
+  if (stat.isDirectory()) {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(rootPath);
+    } catch (_) {
+      return;
+    }
+    for (const entry of entries) {
+      if (results.length >= maxResults) return;
+      collectCaseInsensitiveMatches(path.join(rootPath, entry), needle, allowedRoot, results, maxResults);
+    }
+    return;
+  }
+  if (!stat.isFile() || stat.size > 1024 * 1024) return;
+  try {
+    const text = fs.readFileSync(rootPath, 'utf8');
+    const idx = text.toLowerCase().indexOf(needle);
+    if (idx !== -1) {
+      results.push({ path: real, index: idx, preview: text.slice(Math.max(0, idx - 80), idx + needle.length + 80) });
+    }
+  } catch (_) {
+    /* binary/unreadable */
+  }
+}
+
+function runWorkspaceExec(args, nowIso) {
+  const auditFile = args['audit-log'] || '';
+  const outFile = args.out || '';
+  const errFile = args.err || '';
+  const commandFile = args['command-file'] || '';
+  const timeoutSeconds = Number(args['timeout-seconds'] || '600');
+  const roots = readRoots(args);
+  const commandFileVerdict = classifyScopedPath('workspace.exec command file', commandFile, roots, roots[0] || '/');
+  if (commandFileVerdict.decision !== 'allow') {
+    process.stderr.write('workspace.exec: command file is outside declared roots\n');
+    appendAudit(auditFile, buildExecAudit(nowIso, {
+      decision: 'deny',
+      reason: commandFileVerdict.reason,
+      signals: commandFileVerdict.signals,
+      path: commandFileVerdict.path,
+      root: commandFileVerdict.root,
+      dangerLevel: 'SAFE',
+      command: null,
+    }, timeoutSeconds, { ok: false }));
+    process.exit(EXIT.EXEC_DENY);
+  }
+  let command = '';
+  try {
+    command = fs.readFileSync(commandFile, 'utf8');
+  } catch (_) {
+    process.stderr.write('workspace.exec: cannot read command file\n');
+    process.exit(EXIT.USAGE);
+  }
+  let fds;
+  try {
+    fds = openOutErr(outFile, errFile);
+  } catch (_) {
+    process.stderr.write('cannot open out/err files\n');
+    process.exit(EXIT.INTERNAL);
+  }
+  const verdict = classifyWorkspaceExec(command, args.cwd || '', roots);
+  const finish = (code, extra) => {
+    appendAudit(auditFile, buildExecAudit(nowIso, verdict, timeoutSeconds, extra));
+    try { fs.closeSync(fds.outFd); } catch (_) {}
+    try { fs.closeSync(fds.errFd); } catch (_) {}
+    process.exit(code);
+  };
+  if (verdict.decision !== 'allow') {
+    fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(verdict.reason) + '\n');
+    return finish(EXIT.EXEC_DENY, { ok: false });
+  }
+
+  const cmd = verdict.command;
+  if (!cmd) {
+    fs.writeSync(fds.errFd, 'workspace.exec: command template missing\n');
+    return finish(EXIT.EXEC_DENY, { ok: false, reason: 'command template missing' });
+  }
+
+  try {
+    if (cmd.template === 'env') {
+      return finish(writeSafeEnv(fds.outFd, null), { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'printenv') {
+      const rc = writeSafeEnv(fds.outFd, cmd.argv[1] || null);
+      return finish(rc, { ok: rc === 0, exitCode: rc });
+    }
+    if (cmd.template === 'pwd') {
+      fs.writeSync(fds.outFd, verdict.path + '\n');
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'true') return finish(0, { ok: true, exitCode: 0 });
+    if (cmd.template === 'false') return finish(1, { ok: false, exitCode: 1 });
+    if (cmd.template === 'printf') {
+      fs.writeSync(fds.outFd, cmd.argv.slice(1).join(''));
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'sleep') {
+      const seconds = Number(cmd.argv[1]);
+      if (Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 && seconds > timeoutSeconds) {
+        setTimeout(() => {
+          fs.writeSync(fds.errFd, 'workspace.exec: timed out\n');
+          finish(124, { ok: false, exitCode: 124, reason: 'timed out' });
+        }, timeoutSeconds * 1000);
+        return;
+      }
+      setTimeout(() => finish(0, { ok: true, exitCode: 0 }), Math.max(0, seconds * 1000));
+      return;
+    }
+    if (cmd.template === 'cat') {
+      for (const rawPath of cmd.pathArgs) {
+        const read = safeReadScopedFile(rawPath, roots, verdict.path);
+        if (!read.ok) {
+          fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(read.reason) + '\n');
+          return finish(EXIT.EXEC_DENY, { ok: false, reason: read.reason });
+        }
+        fs.writeSync(fds.outFd, read.data);
+      }
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'ls') {
+      const longFormat = cmd.argv.indexOf('-l') !== -1 || cmd.argv.indexOf('-la') !== -1 || cmd.argv.indexOf('-al') !== -1;
+      const allEntries = cmd.argv.indexOf('-a') !== -1 || cmd.argv.indexOf('-la') !== -1 || cmd.argv.indexOf('-al') !== -1;
+      const targets = cmd.pathArgs.length ? cmd.pathArgs : ['.'];
+      for (const target of targets) {
+        const listed = renderScopedList(target, roots, verdict.path, longFormat, allEntries);
+        if (!listed.ok) {
+          fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(listed.reason) + '\n');
+          return finish(EXIT.EXEC_DENY, { ok: false, reason: listed.reason });
+        }
+        fs.writeSync(fds.outFd, listed.text);
+      }
+      return finish(0, { ok: true, exitCode: 0 });
+    }
+    if (cmd.template === 'grep') {
+      const rendered = renderScopedGrep(cmd.argv, roots, verdict.path);
+      if (!rendered.ok) {
+        fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(rendered.reason) + '\n');
+        return finish(EXIT.EXEC_DENY, { ok: false, reason: rendered.reason });
+      }
+      fs.writeSync(fds.outFd, rendered.text);
+      return finish(rendered.text ? 0 : 1, { ok: Boolean(rendered.text), exitCode: rendered.text ? 0 : 1 });
+    }
+  } catch (e) {
+    const reason = e && e.message ? e.message : String(e);
+    fs.writeSync(fds.errFd, 'workspace.exec: ' + redact(reason) + '\n');
+    return finish(EXIT.EXEC_DENY, { ok: false, reason: reason });
+  }
+
+  fs.writeSync(fds.errFd, 'workspace.exec: unsupported command template\n');
+  return finish(EXIT.EXEC_DENY, { ok: false, reason: 'unsupported command template' });
+}
+
+// ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
 
@@ -361,6 +1113,21 @@ function parseArgs(argv) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
+  const op = args.op || 'http.request';
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  if (op === 'fs.read' || op === 'fs.write' || op === 'fs.list' || op === 'fs.search') {
+    return runFsOp(args, nowIso);
+  }
+  if (op === 'workspace.exec') {
+    return runWorkspaceExec(args, nowIso);
+  }
+  if (op !== 'http.request') {
+    process.stderr.write('unknown capability op: ' + op + '\n');
+    process.exit(EXIT.USAGE);
+  }
+
   const method = (args.method || 'POST').toUpperCase();
   const url = args.url || '';
   const authRef = args['auth-ref'] || '';
@@ -373,9 +1140,6 @@ function main() {
   const errFile = args.err || '';
   const bodyFile = args['body-file'] || '';
   const timeoutSeconds = args['timeout-seconds'] || '30';
-
-  const nowMs = Date.now();
-  const nowIso = new Date(nowMs).toISOString();
 
   if (!url || !outFile || !errFile) {
     process.stderr.write('usage: --url <u> --out <f> --err <f> [--method] [--body-file] [--auth-ref] [--tainted 0|1] [--approved 0|1] [--secret-env-file] [--audit-log] [--budget-file] [--timeout-seconds]\n');

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -197,16 +197,6 @@ function previewText(text) {
   return String(text || '').replace(/\s+/g, ' ').trim().slice(0, 500);
 }
 
-function lexicalNormalize(p) {
-  return path.resolve('/', String(p || ''));
-}
-
-function isWithin(root, target) {
-  const r = lexicalNormalize(root).replace(/\/$/, '');
-  const t = lexicalNormalize(target);
-  return t === r || t.startsWith(r + '/');
-}
-
 function sanitizeRelPath(value) {
   const cleaned = String(value || '')
     .replace(/[^A-Za-z0-9 _./{}-]+/g, '')
@@ -227,21 +217,16 @@ function uniqueRoots(roots) {
   return out;
 }
 
-function scopedRoots(paths, config, plan) {
+function scopedRoots(paths, config) {
   const obsidianRoot = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
   const customRoot = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
-  const baseRoots = uniqueRoots([
+  return uniqueRoots([
     paths.tmpDir,
     path.join(paths.home, 'agent-output'),
     path.join(paths.home, 'projects/shelly-content-studio'),
     obsidianRoot,
     customRoot,
   ]);
-  const outputDir = plan.output && plan.output.outputDir;
-  if (outputDir && baseRoots.some((root) => isWithin(root, outputDir))) {
-    baseRoots.push(outputDir);
-  }
-  return uniqueRoots(baseRoots);
 }
 
 function writeRootsFile(paths, roots) {
@@ -595,7 +580,7 @@ function dispatchAction(paths, opts, plan, config, roots, resultText) {
   if (actionType !== 'draft' && actionType !== 'notify') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
-  if (!plan.agent.autonomous) requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   if (actionType === 'draft') {
     const dest = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
@@ -628,7 +613,7 @@ function run(args) {
   ensureDir(paths.logDir);
 
   const config = parseConfigEnv(paths.envFile);
-  const roots = scopedRoots(paths, config, plan);
+  const roots = scopedRoots(paths, config);
   const startedAt = Date.now();
   appendJsonl(paths.planAuditFile, {
     ts: new Date().toISOString(),

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -579,6 +579,9 @@ function sha256File(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 }
 
+// Mirrors the .sh save_draft_result destination logic (lib/agent-executor.ts).
+// Returns { dest, rel, useGlobalOutput }: `rel` is the content-studio relative
+// filename reused by the Obsidian mirror; it is empty for the global-output path.
 function resolveDraftDestination(paths, plan, config) {
   const now = new Date();
   const date = now.toISOString().slice(0, 10);
@@ -588,9 +591,10 @@ function resolveDraftDestination(paths, plan, config) {
     const target = config.SHELLY_AGENT_OUTPUT_TARGET || 'local';
     if (target === 'obsidian') base = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
     if (target === 'custom') base = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
-    const topic = sanitizeRelPath(config.SHELLY_AGENT_TOPIC_FOLDER || '');
+    // The .sh appends SHELLY_AGENT_TOPIC_FOLDER only for obsidian/custom, never local.
+    const topic = target === 'obsidian' || target === 'custom' ? sanitizeRelPath(config.SHELLY_AGENT_TOPIC_FOLDER || '') : '';
     const topicPart = topic && topic !== '{date}-{slug}' ? topic : '';
-    return path.join(base, topicPart, date, `${date}_${plan.output.slug}.md`);
+    return { dest: path.join(base, topicPart, date, `${date}_${plan.output.slug}.md`), rel: '', useGlobalOutput: true };
   }
   const template = sanitizeRelPath(plan.output && plan.output.outputNameTemplate);
   let rel = template
@@ -598,7 +602,35 @@ function resolveDraftDestination(paths, plan, config) {
     .replace(/\{slug\}/g, plan.output && plan.output.slug ? plan.output.slug : plan.agent.id)
     .replace(/\{time\}/g, time);
   if (!/\.(md|markdown|txt)$/i.test(rel)) rel += '.md';
-  return path.join(plan.output.outputDir, rel);
+  return { dest: path.join(plan.output.outputDir, rel), rel, useGlobalOutput: false };
+}
+
+// Keyword-routed Obsidian subfolder for content-studio agents. Mirrors the
+// `case "$OUTPUT_DIR"` map in the .sh save_draft_result (order-sensitive: first
+// match wins, matching bash `case`).
+function obsidianTargetFor(outputDir) {
+  const dir = String(outputDir || '');
+  if (dir.includes('drafts/substack')) return '50_Drafts/Substack';
+  if (dir.includes('drafts/x')) return '50_Drafts/X';
+  if (dir.includes('drafts/articles')) return '50_Drafts/Substack';
+  if (dir.includes('sources')) return '20_Literature/Papers';
+  if (dir.includes('images/prompts')) return '60_Experiments/Image_Prompts';
+  if (dir.includes('evals')) return '90_Log/Agent_Evals';
+  return '90_Log/Agent_Output';
+}
+
+// The content-studio Obsidian mirror destination, or null when no vault is
+// configured/present (the .sh guards on `[ -n "$OBSIDIAN_VAULT_PATH" ] && [ -d ]`
+// and silently skips otherwise). The write itself is broker-routed and root-jailed.
+function resolveObsidianMirror(plan, config, rel) {
+  const vault = String(config.OBSIDIAN_VAULT_PATH || '').trim();
+  if (!vault || !rel) return null;
+  try {
+    if (!fs.statSync(vault).isDirectory()) return null;
+  } catch (_) {
+    return null;
+  }
+  return path.join(vault, obsidianTargetFor(plan.output && plan.output.outputDir), rel);
 }
 
 function webhookDestinationHost(urlText) {
@@ -854,8 +886,15 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   }
   if (actionType === 'draft') {
-    const dest = resolveDraftDestination(paths, plan, config);
+    const { dest, rel, useGlobalOutput } = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
+    if (!useGlobalOutput) {
+      // Content-studio agents also mirror the draft into the Obsidian vault.
+      // Fatal on failure when the vault exists (parity with the .sh, which runs
+      // the mirror under `set -euo pipefail` with no `|| true`).
+      const mirror = resolveObsidianMirror(plan, config, rel);
+      if (mirror) brokerFsWrite(paths, opts, roots, mirror, paths.resultFile);
+    }
   }
   if (actionType === 'draft' || actionType === 'notify') {
     writeNotification(paths, plan, 'success', preview);

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -194,7 +194,7 @@ function sleepMs(ms) {
 }
 
 function previewText(text) {
-  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+  return redact(String(text || '')).replace(/\s+/g, ' ').trim().slice(0, 500);
 }
 
 function sanitizeRelPath(value) {
@@ -573,14 +573,54 @@ function resolveDraftDestination(paths, plan, config) {
   return path.join(plan.output.outputDir, rel);
 }
 
-function dispatchAction(paths, opts, plan, config, roots, resultText) {
+function argTruthy(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function trustedNativeLowRiskAction(args, plan, actionType) {
+  const trustedAgentId = String(args['trusted-autonomous-agent-id'] || '').trim();
+  const trustedAction = String(args['trusted-autonomous-action'] || '').trim();
+  const trustedTool = String(args['trusted-tool-type'] || '').trim();
+  if (trustedAgentId !== plan.agent.id) return false;
+  if (trustedAction !== 'draft' && trustedAction !== 'notify') return false;
+  if (trustedAction !== actionType) return false;
+  // Native only emits this for deterministic local autonomous agents. This keeps
+  // a tampered plan from turning a low-risk file/notify action into key spend.
+  return trustedTool === 'local' && plan.tool.type === 'local';
+}
+
+function unattendedPreflightFailure(args, plan) {
+  if (!argTruthy(args.unattended)) return '';
+  const actionType = plan.action.type;
+  if (actionType === '__suppressed__') return '';
+  if (actionType !== 'draft' && actionType !== 'notify') {
+    return `unsupported unattended PlanSpec action: ${actionType}`;
+  }
+  if (!trustedNativeLowRiskAction(args, plan, actionType)) {
+    return `${actionType} action is not trusted for unattended PlanSpec execution`;
+  }
+  return '';
+}
+
+function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args) {
   const actionType = plan.action.type;
   const preview = previewText(resultText);
   if (actionType === '__suppressed__') return { status: 'success', preview };
   if (actionType !== 'draft' && actionType !== 'notify') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
-  requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  if (trustedNativeLowRiskAction(args, plan, actionType)) {
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'action_trusted_allow',
+      agentId: plan.agent.id,
+      actionType,
+      toolType: plan.tool.type,
+    });
+  } else {
+    requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  }
   if (actionType === 'draft') {
     const dest = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
@@ -602,7 +642,14 @@ function mirrorBrokerAudit(paths, plan) {
 
 function run(args) {
   const plan = loadPlan(args['plan-file']);
-  const home = args.home || process.env.HOME || (plan.paths && plan.paths.home);
+  const expectedAgentId = String(args['agent-id'] || '').trim();
+  if (expectedAgentId && expectedAgentId !== plan.agent.id) {
+    throw new PlanFailure(`plan agent id mismatch: expected ${expectedAgentId}`, { exitCode: EXIT.PLAN_DENY });
+  }
+  const home = args.home || process.env.HOME;
+  if (!home || !path.isAbsolute(home)) {
+    throw new PlanFailure('--home or absolute HOME is required', { exitCode: EXIT.PLAN_DENY });
+  }
   const paths = runtimePaths(home, plan.agent.id);
   const opts = {
     libDir: args['lib-dir'] || process.env.SHELLY_LIB_DIR || '',
@@ -623,7 +670,24 @@ function run(args) {
     schemaVersion: plan.schemaVersion,
     toolType: plan.tool.type,
     actionType: plan.action.type,
+    unattended: argTruthy(args.unattended),
   });
+
+  const unattendedFailure = unattendedPreflightFailure(args, plan);
+  if (unattendedFailure) {
+    const message = redact(unattendedFailure);
+    writeNotification(paths, plan, 'skipped', message);
+    writeRunLog(paths, plan, 'skipped', message, Date.now() - startedAt, message);
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status: 'skipped',
+      reason: message,
+      durationMs: Date.now() - startedAt,
+    });
+    return EXIT.OK;
+  }
 
   if (!acquireLock(paths)) {
     const message = 'previous run still active';
@@ -643,7 +707,7 @@ function run(args) {
     const response = brokerHttp(paths, opts, plan, request);
     const resultText = extractModelContent(plan.tool.type, response);
     writeAtomic(paths.resultFile, resultText + (resultText.endsWith('\n') ? '' : '\n'));
-    const action = dispatchAction(paths, opts, plan, config, roots, resultText);
+    const action = dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args);
     const durationMs = Date.now() - startedAt;
     writeRunLog(paths, plan, action.status, action.preview, durationMs, '');
     appendJsonl(paths.planAuditFile, {

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -36,6 +36,7 @@ const CONFIG_ENV_KEYS = new Set([
   'SHELLY_AGENT_CUSTOM_PATH',
   'SHELLY_AGENT_EXEC_CWD',
   'SHELLY_CONTENT_PROJECT',
+  'SOURCE_REGISTRY_FILE',
   'OBSIDIAN_VAULT_PATH',
   'SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS',
   'WEBHOOK_TIMEOUT_SECONDS',
@@ -649,8 +650,85 @@ function writeDraftOutputs(paths, opts, plan, config, roots, bestEffort) {
   // aborts before the mirror). The terminal draft path lets the failure propagate.
   try {
     for (const target of targets) brokerFsWrite(paths, opts, roots, target, paths.resultFile);
+    // save_draft_result appends source URLs to the shared dedup registry AFTER the
+    // write, inside set -e — a failed write aborts before it. Keep it inside the try
+    // so a swallowed bestEffort write failure also skips the registry (parity).
+    registerSourceUrls(paths, config, plan);
   } catch (e) {
     if (!bestEffort) throw e;
+  }
+}
+
+// Mirror of the .sh register_source_urls: append https URLs found in the draft to a
+// shared per-project registry TSV (timestamp, agentId, toolLabel, url), deduped on
+// the url column, under a mkdir mutex. Fixed path (no model-controlled path), best
+// effort — a registry hiccup must never fail the run. No-op when the sources/ dir is
+// absent (parity with the .sh, whose `>>` silently fails without it).
+function registerSourceUrls(paths, config, plan) {
+  try {
+    const contentProject = config.SHELLY_CONTENT_PROJECT || path.join(paths.home, 'projects/shelly-content-studio');
+    const registryFile = config.SOURCE_REGISTRY_FILE || path.join(contentProject, 'sources', 'source-registry.tsv');
+
+    let text = '';
+    try {
+      text = fs.readFileSync(paths.resultFile, 'utf8');
+    } catch (_) {
+      return;
+    }
+    const seen = new Set();
+    // The .sh uses line-oriented `grep -Eo`, so a match never spans a newline; exclude
+    // \t\r\n from the class so adjacent-line URLs don't merge into one bogus entry.
+    const matches = text.match(/https?:\/\/[^\][ )<>"'\t\r\n]+/g) || [];
+    for (const raw of matches) {
+      // Match the .sh: `sed 's/[.,;)]$//'` strips exactly one trailing char.
+      const url = raw.replace(/[.,;)]$/, '');
+      if (url) seen.add(url);
+    }
+    // `sort -u` in the .sh: unique + sorted before appending.
+    const urls = Array.from(seen).sort();
+    if (!urls.length) return;
+
+    // The .sh creates the registry dir/file unconditionally at startup (mkdir -p +
+    // touch, lib/agent-executor.ts), so register_source_urls always has a target.
+    fs.mkdirSync(path.dirname(registryFile), { recursive: true });
+    const lockDir = `${registryFile}.lock`;
+    let locked = false;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      try {
+        fs.mkdirSync(lockDir);
+        locked = true;
+        break;
+      } catch (_) {
+        sleepMs(1000);
+      }
+    }
+    try {
+      let existing = '';
+      try {
+        existing = fs.readFileSync(registryFile, 'utf8');
+      } catch (_) {
+        /* first write */
+      }
+      const known = new Set(existing.split('\n').map((line) => line.split('\t')[3]).filter(Boolean));
+      const toolLabel = (plan.tool && plan.tool.label) || '';
+      const ts = new Date().toISOString();
+      let append = '';
+      for (const url of urls) {
+        if (!known.has(url)) {
+          append += `${ts}\t${plan.agent.id}\t${toolLabel}\t${url}\n`;
+          known.add(url);
+        }
+      }
+      if (append) fs.appendFileSync(registryFile, append);
+    } finally {
+      if (locked) {
+        try {
+          fs.rmdirSync(lockDir);
+        } catch (_) {}
+      }
+    }
+  } catch (_) {
+    /* best-effort registry bookkeeping — never fail the run */
   }
 }
 

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -633,6 +633,27 @@ function resolveObsidianMirror(plan, config, rel) {
   return path.join(vault, obsidianTargetFor(plan.output && plan.output.outputDir), rel);
 }
 
+// Write the draft to its primary destination and (for content-studio) the Obsidian
+// mirror, both through the root-jailed broker fs.write. `bestEffort` mirrors the .sh:
+// the terminal `draft` action runs save_draft_result under `set -e` (fatal), while an
+// orchestration `__suppressed__` step runs it `2>/dev/null || true` (swallow errors).
+function writeDraftOutputs(paths, opts, plan, config, roots, bestEffort) {
+  const { dest, rel, useGlobalOutput } = resolveDraftDestination(paths, plan, config);
+  const targets = [dest];
+  if (!useGlobalOutput) {
+    const mirror = resolveObsidianMirror(plan, config, rel);
+    if (mirror) targets.push(mirror);
+  }
+  // In bestEffort mode the whole sequence is swallowed on the FIRST failure, matching
+  // the .sh `save_draft_result ... || true` under `set -e` (a failed primary write
+  // aborts before the mirror). The terminal draft path lets the failure propagate.
+  try {
+    for (const target of targets) brokerFsWrite(paths, opts, roots, target, paths.resultFile);
+  } catch (e) {
+    if (!bestEffort) throw e;
+  }
+}
+
 function webhookDestinationHost(urlText) {
   try {
     const u = new URL(String(urlText || ''));
@@ -808,7 +829,12 @@ function unattendedPreflightFailure(args, plan) {
 function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args) {
   const actionType = plan.action.type;
   const preview = previewText(resultText);
-  if (actionType === '__suppressed__') return { status: 'success', preview };
+  if (actionType === '__suppressed__') {
+    // Orchestration non-final step: still save the draft (so the next step can read
+    // it) but request no approval and fire no notification. Best-effort, like the .sh.
+    writeDraftOutputs(paths, opts, plan, config, roots, true);
+    return { status: 'success', preview };
+  }
   if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
@@ -886,15 +912,9 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   }
   if (actionType === 'draft') {
-    const { dest, rel, useGlobalOutput } = resolveDraftDestination(paths, plan, config);
-    brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
-    if (!useGlobalOutput) {
-      // Content-studio agents also mirror the draft into the Obsidian vault.
-      // Fatal on failure when the vault exists (parity with the .sh, which runs
-      // the mirror under `set -euo pipefail` with no `|| true`).
-      const mirror = resolveObsidianMirror(plan, config, rel);
-      if (mirror) brokerFsWrite(paths, opts, roots, mirror, paths.resultFile);
-    }
+    // Terminal draft: primary + (content-studio) Obsidian mirror, fatal on failure
+    // (parity with the .sh save_draft_result under `set -euo pipefail`).
+    writeDraftOutputs(paths, opts, plan, config, roots, false);
   }
   if (actionType === 'draft' || actionType === 'notify') {
     writeNotification(paths, plan, 'success', preview);

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -129,6 +129,7 @@ function runtimePaths(home, agentId) {
     logsDir,
     logDir,
     envFile: path.join(agentsDir, '.env'),
+    haltSentinel: path.join(agentsDir, '.halted'),
     resultFile: path.join(tmpDir, `agent-result-${agentId}.md`),
     lockFile: path.join(locksDir, `${agentId}.pid`),
     notifyFile: path.join(logDir, 'native-result-notification.json'),
@@ -873,6 +874,23 @@ function mirrorBrokerAudit(paths, plan) {
   }
 }
 
+// Shared epilogue for the pre-run refuse paths (kill-switch, unattended-not-trusted):
+// notify + run log + a `plan_finish status:skipped` audit line, then exit cleanly.
+function finishSkipped(paths, plan, startedAt, message) {
+  const durationMs = Date.now() - startedAt;
+  writeNotification(paths, plan, 'skipped', message);
+  writeRunLog(paths, plan, 'skipped', message, durationMs, message);
+  appendJsonl(paths.planAuditFile, {
+    ts: new Date().toISOString(),
+    kind: 'plan.executor',
+    event: 'plan_finish',
+    status: 'skipped',
+    reason: message,
+    durationMs,
+  });
+  return EXIT.OK;
+}
+
 function run(args) {
   const plan = loadPlan(args['plan-file']);
   const expectedAgentId = String(args['agent-id'] || '').trim();
@@ -906,20 +924,17 @@ function run(args) {
     unattended: argTruthy(args.unattended),
   });
 
+  // Global kill-switch (STOP ALL). haltAllAgents drops a `.halted` sentinel and
+  // uninstalls schedules; this is the native/executor-side defense in depth so a
+  // still-in-flight alarm or a direct `am` fire is refused before any model IO,
+  // not just JS-initiated runs. Fail-closed: refuse (skip), never run.
+  if (fs.existsSync(paths.haltSentinel)) {
+    return finishSkipped(paths, plan, startedAt, 'All agents are stopped (global kill-switch is on).');
+  }
+
   const unattendedFailure = unattendedPreflightFailure(args, plan);
   if (unattendedFailure) {
-    const message = redact(unattendedFailure);
-    writeNotification(paths, plan, 'skipped', message);
-    writeRunLog(paths, plan, 'skipped', message, Date.now() - startedAt, message);
-    appendJsonl(paths.planAuditFile, {
-      ts: new Date().toISOString(),
-      kind: 'plan.executor',
-      event: 'plan_finish',
-      status: 'skipped',
-      reason: message,
-      durationMs: Date.now() - startedAt,
-    });
-    return EXIT.OK;
+    return finishSkipped(paths, plan, startedAt, redact(unattendedFailure));
   }
 
   if (!acquireLock(paths)) {

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -1,0 +1,729 @@
+#!/usr/bin/env node
+/*
+ * shelly-plan-executor.js - Phase 0 PlanSpec executor canary.
+ *
+ * This intentionally supports a narrow first slice. It runs one PlanSpec without
+ * sourcing run-agent-*.sh, but delegates HTTP and filesystem effects to the
+ * capability broker so the broker remains the final security boundary.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PLAN_SPEC_SCHEMA_VERSION = 1;
+const PLAN_SPEC_KIND = 'shelly.agent.plan';
+
+const EXIT = {
+  OK: 0,
+  PLAN_DENY: 47,
+  TOOL_DENY: 48,
+  INTERNAL: 127,
+};
+
+const CONFIG_ENV_KEYS = new Set([
+  'LOCAL_LLM_URL',
+  'LOCAL_LLM_MODEL',
+  'GEMINI_MODEL',
+  'PERPLEXITY_MODEL',
+  'CEREBRAS_MODEL',
+  'GROQ_MODEL',
+  'SHELLY_AGENT_OUTPUT_TARGET',
+  'SHELLY_AGENT_TOPIC_FOLDER',
+  'SHELLY_AGENT_CUSTOM_PATH',
+  'OBSIDIAN_VAULT_PATH',
+  'SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS',
+]);
+
+const REDACT_PATTERNS = [
+  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-proj-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bAIza[0-9A-Za-z_-]{25,}\b/g,
+  /\bgsk_[A-Za-z0-9_-]{20,}\b/g,
+  /\bcsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi,
+];
+
+class PlanFailure extends Error {
+  constructor(message, options) {
+    super(message);
+    this.name = 'PlanFailure';
+    this.status = options && options.status ? options.status : 'error';
+    this.exitCode = options && typeof options.exitCode === 'number' ? options.exitCode : EXIT.PLAN_DENY;
+    this.handled = options && options.handled === true;
+  }
+}
+
+class ActionSkipped extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ActionSkipped';
+  }
+}
+
+function redact(text) {
+  let out = String(text == null ? '' : text);
+  for (const pattern of REDACT_PATTERNS) out = out.replace(pattern, '<redacted>');
+  return out;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const current = argv[i];
+    if (!current.startsWith('--')) continue;
+    const key = current.slice(2);
+    const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) {
+      args[key] = '1';
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeAtomic(file, text) {
+  ensureDir(path.dirname(file));
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`);
+  fs.writeFileSync(tmp, text);
+  fs.renameSync(tmp, file);
+}
+
+function appendJsonl(file, entry) {
+  if (!file) return;
+  try {
+    ensureDir(path.dirname(file));
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n');
+  } catch (_) {
+    // best-effort audit only
+  }
+}
+
+function runtimePaths(home, agentId) {
+  const shellyDir = path.join(home, '.shelly');
+  const agentsDir = path.join(shellyDir, 'agents');
+  const tmpDir = path.join(shellyDir, 'tmp');
+  const locksDir = path.join(agentsDir, 'locks');
+  const logsDir = path.join(agentsDir, 'logs');
+  const logDir = path.join(logsDir, agentId);
+  return {
+    home,
+    shellyDir,
+    agentsDir,
+    tmpDir,
+    locksDir,
+    logsDir,
+    logDir,
+    envFile: path.join(agentsDir, '.env'),
+    resultFile: path.join(tmpDir, `agent-result-${agentId}.md`),
+    lockFile: path.join(locksDir, `${agentId}.pid`),
+    notifyFile: path.join(logDir, 'native-result-notification.json'),
+    brokerAuditFile: path.join(logDir, 'agent-driver-audit.jsonl'),
+    planAuditFile: path.join(logDir, 'plan-executor-audit.jsonl'),
+    actionApprovalDir: path.join(agentsDir, 'action-approvals'),
+    actionApprovalReplyDir: path.join(agentsDir, 'action-approval-replies'),
+  };
+}
+
+function parseConfigEnv(file) {
+  const out = {};
+  let text = '';
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch (_) {
+    return out;
+  }
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line || line[0] === '#') continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    let key = line.slice(0, eq).trim().replace(/^export\s+/, '');
+    if (!CONFIG_ENV_KEYS.has(key)) continue;
+    let val = line.slice(eq + 1).trim();
+    if (val.length >= 2 && val[0] === "'" && val[val.length - 1] === "'") {
+      val = val.slice(1, -1).replace(/'\\''/g, "'");
+    } else if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
+      val = val.slice(1, -1).replace(/\\(["\\])/g, '$1');
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+function validatePlan(raw) {
+  if (!raw || typeof raw !== 'object') throw new PlanFailure('plan is not an object');
+  if (raw.kind !== PLAN_SPEC_KIND) throw new PlanFailure('plan kind mismatch');
+  if (raw.schemaVersion !== PLAN_SPEC_SCHEMA_VERSION) throw new PlanFailure('plan schema version mismatch');
+  if (!raw.agent || typeof raw.agent.id !== 'string' || !/^[A-Za-z0-9_-]+$/.test(raw.agent.id)) {
+    throw new PlanFailure('plan agent id is invalid');
+  }
+  if (typeof raw.prompt !== 'string') throw new PlanFailure('plan prompt is invalid');
+  if (!raw.tool || typeof raw.tool.type !== 'string') throw new PlanFailure('plan tool is invalid');
+  if (!raw.action || typeof raw.action.type !== 'string') throw new PlanFailure('plan action is invalid');
+  if (raw.tool.type === 'unsupported') throw new PlanFailure(redact(raw.tool.unsupportedReason || 'unsupported tool'), { exitCode: EXIT.TOOL_DENY });
+  if (raw.action.type === 'unsupported') throw new PlanFailure(redact(raw.action.unsupportedReason || 'unsupported action'), { exitCode: EXIT.TOOL_DENY });
+  return raw;
+}
+
+function loadPlan(planFile) {
+  if (!planFile) throw new PlanFailure('--plan-file is required');
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(planFile, 'utf8'));
+  } catch (e) {
+    throw new PlanFailure(`cannot read plan: ${e && e.message ? e.message : e}`);
+  }
+  return validatePlan(parsed);
+}
+
+function sleepMs(ms) {
+  const shared = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(shared), 0, 0, ms);
+}
+
+function previewText(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function lexicalNormalize(p) {
+  return path.resolve('/', String(p || ''));
+}
+
+function isWithin(root, target) {
+  const r = lexicalNormalize(root).replace(/\/$/, '');
+  const t = lexicalNormalize(target);
+  return t === r || t.startsWith(r + '/');
+}
+
+function sanitizeRelPath(value) {
+  const cleaned = String(value || '')
+    .replace(/[^A-Za-z0-9 _./{}-]+/g, '')
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter((segment) => segment && segment !== '.' && segment !== '..')
+    .join('/');
+  return cleaned || '{date}-{slug}';
+}
+
+function uniqueRoots(roots) {
+  const out = [];
+  for (const root of roots) {
+    const value = String(root || '').trim();
+    if (!value || value[0] !== '/') continue;
+    if (!out.includes(value)) out.push(value);
+  }
+  return out;
+}
+
+function scopedRoots(paths, config, plan) {
+  const obsidianRoot = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
+  const customRoot = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
+  const baseRoots = uniqueRoots([
+    paths.tmpDir,
+    path.join(paths.home, 'agent-output'),
+    path.join(paths.home, 'projects/shelly-content-studio'),
+    obsidianRoot,
+    customRoot,
+  ]);
+  const outputDir = plan.output && plan.output.outputDir;
+  if (outputDir && baseRoots.some((root) => isWithin(root, outputDir))) {
+    baseRoots.push(outputDir);
+  }
+  return uniqueRoots(baseRoots);
+}
+
+function writeRootsFile(paths, roots) {
+  const rootsFile = path.join(paths.tmpDir, `plan-roots-${process.pid}-${Date.now()}.txt`);
+  writeAtomic(rootsFile, roots.join('\n') + '\n');
+  return rootsFile;
+}
+
+function childEnv(paths, opts) {
+  const libDir = opts.libDir || process.env.SHELLY_LIB_DIR || process.env.LD_LIBRARY_PATH || '';
+  const env = Object.assign({}, process.env, {
+    HOME: paths.home,
+    SHELLY_LIB_DIR: libDir,
+  });
+  if (libDir) {
+    env.LD_LIBRARY_PATH = libDir;
+    env.PATH = `${libDir}:${libDir}/node_modules/npm/bin:${libDir}/node_modules/.bin:${env.PATH || ''}`;
+    const preload = path.join(libDir, 'libexec_wrapper.so');
+    if (fs.existsSync(preload)) env.LD_PRELOAD = preload;
+  }
+  return env;
+}
+
+function nodeInvocation(script, args, paths, opts) {
+  const libDir = opts.libDir || process.env.SHELLY_LIB_DIR || '';
+  const androidNode = libDir ? path.join(libDir, 'node') : '';
+  if (androidNode && fs.existsSync(androidNode) && fs.existsSync('/system/bin/linker64')) {
+    return { file: '/system/bin/linker64', args: [androidNode, script].concat(args) };
+  }
+  return { file: process.execPath, args: [script].concat(args) };
+}
+
+function runBroker(paths, opts, brokerArgs) {
+  const broker = opts.broker || path.join(paths.home, '.shelly-capability-broker.js');
+  if (!fs.existsSync(broker)) throw new PlanFailure('capability broker is missing', { exitCode: EXIT.TOOL_DENY });
+  const invocation = nodeInvocation(broker, brokerArgs, paths, opts);
+  const result = spawnSync(invocation.file, invocation.args, {
+    env: childEnv(paths, opts),
+    encoding: 'utf8',
+    timeout: 700000,
+  });
+  if (result.error) {
+    throw new PlanFailure(`capability broker spawn failed: ${redact(result.error.message)}`, { exitCode: EXIT.TOOL_DENY });
+  }
+  return result.status == null ? EXIT.INTERNAL : result.status;
+}
+
+function writeJsonRequest(file, payload) {
+  writeAtomic(file, JSON.stringify(payload));
+}
+
+function chatEndpoint(base) {
+  const url = String(base || '').trim().replace(/\/+$/, '');
+  if (!url) return 'http://127.0.0.1:8080/v1/chat/completions';
+  if (/\/v1\/chat\/completions$/.test(url)) return url;
+  return `${url}/v1/chat/completions`;
+}
+
+function isLoopbackUrl(urlText) {
+  try {
+    const u = new URL(urlText);
+    return (u.protocol === 'http:' || u.protocol === 'https:') && (u.hostname === '127.0.0.1' || u.hostname === 'localhost');
+  } catch (_) {
+    return false;
+  }
+}
+
+function modelRequest(plan, config) {
+  const prompt = plan.prompt;
+  switch (plan.tool.type) {
+    case 'local': {
+      const url = chatEndpoint(config.LOCAL_LLM_URL || 'http://127.0.0.1:8080');
+      if (!isLoopbackUrl(url)) throw new PlanFailure('local PlanSpec endpoint must be loopback', { exitCode: EXIT.TOOL_DENY });
+      return {
+        url,
+        authRef: '',
+        body: {
+          model: config.LOCAL_LLM_MODEL || plan.tool.model || 'Qwen3.5-0.8B-Q4_K_M',
+          messages: [{ role: 'user', content: prompt }],
+          max_tokens: 2048,
+          chat_template_kwargs: { enable_thinking: false },
+        },
+      };
+    }
+    case 'gemini-api': {
+      const model = config.GEMINI_MODEL || plan.tool.model || 'gemini-2.5-flash';
+      return {
+        url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
+        authRef: 'gemini',
+        body: { contents: [{ parts: [{ text: prompt }] }] },
+      };
+    }
+    case 'perplexity':
+      return openAiCompatRequest('https://api.perplexity.ai/chat/completions', 'perplexity', config.PERPLEXITY_MODEL || plan.tool.model || 'sonar', prompt);
+    case 'cerebras':
+      return openAiCompatRequest('https://api.cerebras.ai/v1/chat/completions', 'cerebras', config.CEREBRAS_MODEL || plan.tool.model || 'qwen-3-235b-a22b-instruct-2507', prompt);
+    case 'groq':
+      return openAiCompatRequest('https://api.groq.com/openai/v1/chat/completions', 'groq', config.GROQ_MODEL || plan.tool.model || 'llama-3.3-70b-versatile', prompt);
+    default:
+      throw new PlanFailure(`unsupported PlanSpec tool: ${plan.tool.type}`, { exitCode: EXIT.TOOL_DENY });
+  }
+}
+
+function openAiCompatRequest(url, authRef, model, prompt) {
+  return {
+    url,
+    authRef,
+    body: {
+      model,
+      messages: [{ role: 'user', content: prompt }],
+    },
+  };
+}
+
+function brokerHttp(paths, opts, plan, request) {
+  const bodyFile = path.join(paths.tmpDir, `plan-request-${plan.agent.id}-${process.pid}.json`);
+  const outFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.json`);
+  const errFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.err`);
+  writeJsonRequest(bodyFile, request.body);
+  const args = [
+    '--op', 'http.request',
+    '--method', 'POST',
+    '--url', request.url,
+    '--body-file', bodyFile,
+    '--secret-env-file', paths.envFile,
+    '--audit-log', paths.brokerAuditFile,
+    '--budget-file', path.join(paths.tmpDir, `cap-budget-${plan.agent.id}.json`),
+    '--timeout-seconds', String(plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600),
+    '--out', outFile,
+    '--err', errFile,
+  ];
+  if (request.authRef) args.push('--auth-ref', request.authRef);
+  const rc = runBroker(paths, opts, args);
+  const response = readFile(outFile);
+  const errorText = readFile(errFile);
+  try {
+    fs.unlinkSync(bodyFile);
+  } catch (_) {}
+  if (rc !== 0) {
+    const status = rc === 23 ? 'unavailable' : 'error';
+    throw new PlanFailure(`HTTP broker failed rc=${rc}: ${redact(errorText || response).slice(0, 300)}`, {
+      status,
+      exitCode: EXIT.OK,
+      handled: true,
+    });
+  }
+  return response;
+}
+
+function extractModelContent(toolType, raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_) {
+    const text = String(raw || '').trim();
+    if (text) return text;
+    throw new PlanFailure('model response was empty', { handled: true });
+  }
+  if (toolType === 'gemini-api') {
+    const candidates = Array.isArray(parsed.candidates) ? parsed.candidates : [];
+    const parts = candidates.flatMap((candidate) => {
+      const content = candidate && candidate.content;
+      return content && Array.isArray(content.parts) ? content.parts : [];
+    });
+    const text = parts.map((part) => (part && typeof part.text === 'string' ? part.text : '')).join('\n').trim();
+    if (text) return text;
+  } else {
+    const choice = Array.isArray(parsed.choices) ? parsed.choices[0] : null;
+    const content = choice && choice.message && typeof choice.message.content === 'string'
+      ? choice.message.content
+      : choice && typeof choice.text === 'string'
+        ? choice.text
+        : '';
+    if (content.trim()) return content.trim();
+  }
+  throw new PlanFailure('model response did not contain assistant content', { handled: true });
+}
+
+function brokerFsWrite(paths, opts, roots, dest, src) {
+  const rootsFile = writeRootsFile(paths, roots);
+  const outFile = path.join(paths.tmpDir, `plan-fs-${process.pid}.out`);
+  const errFile = path.join(paths.tmpDir, `plan-fs-${process.pid}.err`);
+  const rc = runBroker(paths, opts, [
+    '--op', 'fs.write',
+    '--path', dest,
+    '--input-file', src,
+    '--roots-file', rootsFile,
+    '--audit-log', paths.brokerAuditFile,
+    '--out', outFile,
+    '--err', errFile,
+  ]);
+  const err = readFile(errFile);
+  try {
+    fs.unlinkSync(rootsFile);
+  } catch (_) {}
+  if (rc !== 0) {
+    throw new PlanFailure(`scoped filesystem write denied: ${redact(err).slice(0, 300)}`, {
+      exitCode: EXIT.OK,
+      handled: true,
+    });
+  }
+}
+
+function readFile(file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (_) {
+    return '';
+  }
+}
+
+function acquireLock(paths) {
+  ensureDir(path.dirname(paths.lockFile));
+  if (fs.existsSync(paths.lockFile)) {
+    const pid = Number(readFile(paths.lockFile).trim());
+    if (pid > 0) {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (_) {
+        // stale
+      }
+    }
+    try {
+      fs.unlinkSync(paths.lockFile);
+    } catch (_) {}
+  }
+  writeAtomic(paths.lockFile, `${process.pid}\n`);
+  return true;
+}
+
+function releaseLock(paths) {
+  try {
+    if (readFile(paths.lockFile).trim() === String(process.pid)) fs.unlinkSync(paths.lockFile);
+  } catch (_) {}
+}
+
+function writeNotification(paths, plan, status, preview) {
+  writeAtomic(paths.notifyFile, JSON.stringify({
+    agentId: plan.agent.id,
+    agentName: plan.agent.name,
+    toolLabel: plan.tool.label,
+    status,
+    preview,
+    timestamp: Math.floor(Date.now() / 1000),
+  }) + '\n');
+}
+
+function writeRunLog(paths, plan, status, preview, durationMs, errorMessage) {
+  const ts = Date.now();
+  const log = {
+    agentId: plan.agent.id,
+    timestamp: ts,
+    status,
+    outputPreview: previewText(preview),
+    durationMs,
+    toolUsed: plan.tool.label,
+    errorMessage: errorMessage ? previewText(errorMessage) : '',
+    routeDecision: plan.routeDecision,
+    executor: 'planspec',
+  };
+  writeAtomic(path.join(paths.logDir, `${Math.floor(ts / 1000)}.json`), JSON.stringify(log) + '\n');
+}
+
+function requestActionApproval(paths, plan, actionType, preview, resultFile, config) {
+  ensureDir(paths.actionApprovalDir);
+  ensureDir(paths.actionApprovalReplyDir);
+  const runId = `${plan.agent.id}-${Math.floor(Date.now() / 1000)}-${process.pid}`;
+  const requestFile = path.join(paths.actionApprovalDir, `action-${safeFilePart(runId)}.json`);
+  const replyFile = path.join(paths.actionApprovalReplyDir, `action-${safeFilePart(runId)}.reply.json`);
+  const timeoutSeconds = Number(config.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || process.env.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || 120);
+  const request = {
+    runId,
+    agentId: plan.agent.id,
+    agentName: plan.agent.name,
+    toolLabel: plan.tool.label,
+    actionType,
+    preview,
+    destinationHost: '',
+    command: '',
+    safetyLevel: '',
+    safetyReason: '',
+    payloadPath: '',
+    resultPath: resultFile,
+    ts: new Date().toISOString(),
+    expiresAt: Date.now() + Math.max(1, timeoutSeconds) * 1000,
+  };
+  writeAtomic(requestFile, JSON.stringify(request) + '\n');
+  const requestSha256 = sha256File(requestFile);
+  const deadline = Date.now() + Math.max(1, timeoutSeconds) * 1000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(replyFile)) {
+      let reply = null;
+      try {
+        reply = JSON.parse(readFile(replyFile));
+      } catch (_) {
+        reply = null;
+      }
+      try {
+        fs.unlinkSync(replyFile);
+        fs.unlinkSync(requestFile);
+      } catch (_) {}
+      if (!reply || reply.runId !== runId || reply.requestSha256 !== requestSha256) {
+        continue;
+      }
+      if (reply.decision === 'accept') return;
+      throw new ActionSkipped(`${actionType} action declined`);
+    }
+    sleepMs(500);
+  }
+  try {
+    fs.unlinkSync(requestFile);
+  } catch (_) {}
+  throw new ActionSkipped(`${actionType} action approval timed out`);
+}
+
+function safeFilePart(value) {
+  return String(value || '').slice(0, 160).replace(/[^A-Za-z0-9_.=-]/g, '_') || 'request';
+}
+
+function sha256File(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function resolveDraftDestination(paths, plan, config) {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const time = now.toISOString().slice(11, 19).replace(/:/g, '');
+  if (plan.output && plan.output.useGlobalOutput) {
+    let base = path.join(paths.home, 'agent-output');
+    const target = config.SHELLY_AGENT_OUTPUT_TARGET || 'local';
+    if (target === 'obsidian') base = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
+    if (target === 'custom') base = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
+    const topic = sanitizeRelPath(config.SHELLY_AGENT_TOPIC_FOLDER || '');
+    const topicPart = topic && topic !== '{date}-{slug}' ? topic : '';
+    return path.join(base, topicPart, date, `${date}_${plan.output.slug}.md`);
+  }
+  const template = sanitizeRelPath(plan.output && plan.output.outputNameTemplate);
+  let rel = template
+    .replace(/\{date\}/g, date)
+    .replace(/\{slug\}/g, plan.output && plan.output.slug ? plan.output.slug : plan.agent.id)
+    .replace(/\{time\}/g, time);
+  if (!/\.(md|markdown|txt)$/i.test(rel)) rel += '.md';
+  return path.join(plan.output.outputDir, rel);
+}
+
+function dispatchAction(paths, opts, plan, config, roots, resultText) {
+  const actionType = plan.action.type;
+  const preview = previewText(resultText);
+  if (actionType === '__suppressed__') return { status: 'success', preview };
+  if (actionType !== 'draft' && actionType !== 'notify') {
+    throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
+  }
+  if (!plan.agent.autonomous) requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
+  if (actionType === 'draft') {
+    const dest = resolveDraftDestination(paths, plan, config);
+    brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
+  }
+  writeNotification(paths, plan, 'success', preview);
+  return { status: 'success', preview };
+}
+
+function mirrorBrokerAudit(paths, plan) {
+  if (!fs.existsSync(paths.brokerAuditFile)) return;
+  try {
+    const auditDir = path.join(paths.agentsDir, 'audits');
+    ensureDir(auditDir);
+    fs.copyFileSync(paths.brokerAuditFile, path.join(auditDir, `${plan.agent.id}-agent-driver-audit.jsonl`));
+  } catch (_) {
+    // best-effort parity with the shell path
+  }
+}
+
+function run(args) {
+  const plan = loadPlan(args['plan-file']);
+  const home = args.home || process.env.HOME || (plan.paths && plan.paths.home);
+  const paths = runtimePaths(home, plan.agent.id);
+  const opts = {
+    libDir: args['lib-dir'] || process.env.SHELLY_LIB_DIR || '',
+    broker: args.broker || '',
+  };
+  ensureDir(paths.tmpDir);
+  ensureDir(paths.locksDir);
+  ensureDir(paths.logDir);
+
+  const config = parseConfigEnv(paths.envFile);
+  const roots = scopedRoots(paths, config, plan);
+  const startedAt = Date.now();
+  appendJsonl(paths.planAuditFile, {
+    ts: new Date().toISOString(),
+    kind: 'plan.executor',
+    event: 'plan_start',
+    agentId: plan.agent.id,
+    schemaVersion: plan.schemaVersion,
+    toolType: plan.tool.type,
+    actionType: plan.action.type,
+  });
+
+  if (!acquireLock(paths)) {
+    const message = 'previous run still active';
+    writeRunLog(paths, plan, 'skipped', message, 0, message);
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status: 'skipped',
+      reason: message,
+    });
+    return EXIT.OK;
+  }
+
+  try {
+    const request = modelRequest(plan, config);
+    const response = brokerHttp(paths, opts, plan, request);
+    const resultText = extractModelContent(plan.tool.type, response);
+    writeAtomic(paths.resultFile, resultText + (resultText.endsWith('\n') ? '' : '\n'));
+    const action = dispatchAction(paths, opts, plan, config, roots, resultText);
+    const durationMs = Date.now() - startedAt;
+    writeRunLog(paths, plan, action.status, action.preview, durationMs, '');
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status: action.status,
+      durationMs,
+    });
+    return EXIT.OK;
+  } catch (e) {
+    const durationMs = Date.now() - startedAt;
+    if (e instanceof ActionSkipped) {
+      const message = redact(e.message);
+      writeNotification(paths, plan, 'skipped', message);
+      writeRunLog(paths, plan, 'skipped', message, durationMs, message);
+      appendJsonl(paths.planAuditFile, {
+        ts: new Date().toISOString(),
+        kind: 'plan.executor',
+        event: 'plan_finish',
+        status: 'skipped',
+        reason: message,
+        durationMs,
+      });
+      return EXIT.OK;
+    }
+    const status = e instanceof PlanFailure && e.status ? e.status : 'error';
+    const message = redact(e && e.message ? e.message : String(e));
+    writeAtomic(paths.resultFile, message + '\n');
+    writeNotification(paths, plan, status, message);
+    writeRunLog(paths, plan, status, message, durationMs, message);
+    appendJsonl(paths.planAuditFile, {
+      ts: new Date().toISOString(),
+      kind: 'plan.executor',
+      event: 'plan_finish',
+      status,
+      reason: message,
+      durationMs,
+    });
+    if (e instanceof PlanFailure && e.handled) return EXIT.OK;
+    return e instanceof PlanFailure ? e.exitCode : EXIT.INTERNAL;
+  } finally {
+    mirrorBrokerAudit(paths, plan);
+    releaseLock(paths);
+  }
+}
+
+function main() {
+  try {
+    process.exit(run(parseArgs(process.argv.slice(2))));
+  } catch (e) {
+    process.stderr.write(redact(e && e.stack ? e.stack : e && e.message ? e.message : String(e)) + '\n');
+    process.exit(e instanceof PlanFailure ? e.exitCode : EXIT.INTERNAL);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  PLAN_SPEC_SCHEMA_VERSION,
+  PLAN_SPEC_KIND,
+  validatePlan,
+  runtimePaths,
+  parseConfigEnv,
+  isLoopbackUrl,
+};

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -249,9 +249,16 @@ function childEnv(paths, opts) {
   if (libDir) {
     env.LD_LIBRARY_PATH = libDir;
     env.PATH = `${libDir}:${libDir}/node_modules/npm/bin:${libDir}/node_modules/.bin:${env.PATH || ''}`;
-    const preload = path.join(libDir, 'libexec_wrapper.so');
-    if (fs.existsSync(preload)) env.LD_PRELOAD = preload;
   }
+  // The broker is a leaf bionic-node process: its workspace.exec curates commands
+  // in-node (cat/ls/grep/printf/… implemented in JS) and never execs an app-data
+  // binary, so it does NOT need the Knox exec-wrapper. Inheriting
+  // LD_PRELOAD=libexec_wrapper.so (set globally by shelly-exec.c on the launching
+  // shell) BREAKS node's OpenSSL config load on-device — verified on hardware:
+  // "BIO_new_file:Bad file descriptor" on openssl.cnf → node aborts → every broker
+  // call fails. Drop it here (mirrors the llama-server launcher, which unsets
+  // LD_PRELOAD before its own linker64 launch for the same class of reason).
+  delete env.LD_PRELOAD;
   return env;
 }
 

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -614,6 +614,58 @@ function writeWebhookPayload(file, plan, status, preview, resultText) {
   }) + '\n');
 }
 
+const CRITICAL_COMMAND_PATTERNS = [
+  {
+    pattern: /rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(\/|~\/?\s*$|\/\*|~\/\*)/i,
+    reason: 'Root or home directory recursive removal is critical.',
+  },
+  {
+    pattern: /rm\s+-rf\s+\/(?:usr|bin|lib|etc|boot|sys|proc|dev|sbin)/i,
+    reason: 'System directory removal is critical.',
+  },
+  {
+    pattern: /:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;?\s*:/,
+    reason: 'Fork bomb command is critical.',
+  },
+  {
+    pattern: /dd\s+if=\/dev\/(?:zero|random|urandom)\s+of=\/dev\/(?:sd[a-z]|nvme|mmcblk)/i,
+    reason: 'Direct storage overwrite is critical.',
+  },
+  {
+    pattern: /mkfs\s+.*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i,
+    reason: 'Storage device format is critical.',
+  },
+  {
+    pattern: />\s*\/dev\/(?:sd[a-z]|nvme|mmcblk)/i,
+    reason: 'Direct storage device write is critical.',
+  },
+  {
+    pattern: /shred\s+.*\/dev\//i,
+    reason: 'Device shred command is critical.',
+  },
+];
+
+function recomputeCliSafety(commandText, declaredSafety) {
+  const cleaned = String(commandText || '').replace(/#[^\n]*/g, '').trim();
+  for (const { pattern, reason } of CRITICAL_COMMAND_PATTERNS) {
+    if (pattern.test(cleaned)) {
+      return {
+        level: 'CRITICAL',
+        reason,
+        message: 'Executor-side command safety blocked a critical command.',
+        matchedPattern: pattern.source,
+      };
+    }
+  }
+  const safety = declaredSafety && typeof declaredSafety === 'object' ? declaredSafety : {};
+  return {
+    level: safety.level || 'SAFE',
+    reason: safety.reason || 'No critical command pattern matched.',
+    message: safety.message || '',
+    matchedPattern: safety.matchedPattern || '',
+  };
+}
+
 function resolveCliCwd(paths, plan, config) {
   const wanted =
     config.SHELLY_AGENT_EXEC_CWD ||
@@ -747,7 +799,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
       writeWebhookPayload(payloadFile, plan, 'success', preview, resultText);
       requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
         destinationHost: host,
-        payloadPath: payloadFile,
+        payloadPath: path.basename(payloadFile),
       });
       try {
         brokerHttpBodyFile(paths, opts, plan, {
@@ -765,7 +817,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     }
     if (actionType === 'cli') {
       const commandText = String(plan.action.command || '').trim();
-      const safety = plan.action.safety || {};
+      const safety = recomputeCliSafety(commandText, plan.action.safety || {});
       if (!commandText) {
         const message = 'CLI action is missing a command.';
         writeNotification(paths, plan, 'error', message);

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -34,8 +34,11 @@ const CONFIG_ENV_KEYS = new Set([
   'SHELLY_AGENT_OUTPUT_TARGET',
   'SHELLY_AGENT_TOPIC_FOLDER',
   'SHELLY_AGENT_CUSTOM_PATH',
+  'SHELLY_AGENT_EXEC_CWD',
+  'SHELLY_CONTENT_PROJECT',
   'OBSIDIAN_VAULT_PATH',
   'SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS',
+  'WEBHOOK_TIMEOUT_SECONDS',
 ]);
 
 const REDACT_PATTERNS = [
@@ -220,10 +223,12 @@ function uniqueRoots(roots) {
 function scopedRoots(paths, config) {
   const obsidianRoot = config.OBSIDIAN_VAULT_PATH || '/sdcard/Documents/ObsidianVault';
   const customRoot = config.SHELLY_AGENT_CUSTOM_PATH || path.join(paths.home, 'agent-output');
+  const contentProject = config.SHELLY_CONTENT_PROJECT || path.join(paths.home, 'projects/shelly-content-studio');
   return uniqueRoots([
     paths.tmpDir,
     path.join(paths.home, 'agent-output'),
     path.join(paths.home, 'projects/shelly-content-studio'),
+    contentProject,
     obsidianRoot,
     customRoot,
   ]);
@@ -343,28 +348,42 @@ function openAiCompatRequest(url, authRef, model, prompt) {
 
 function brokerHttp(paths, opts, plan, request) {
   const bodyFile = path.join(paths.tmpDir, `plan-request-${plan.agent.id}-${process.pid}.json`);
+  writeJsonRequest(bodyFile, request.body);
+  try {
+    return brokerHttpBodyFile(paths, opts, plan, {
+      url: request.url,
+      authRef: request.authRef,
+      bodyFile,
+      approved: request.approved,
+      timeoutSeconds: request.timeoutSeconds,
+    });
+  } finally {
+    try {
+      fs.unlinkSync(bodyFile);
+    } catch (_) {}
+  }
+}
+
+function brokerHttpBodyFile(paths, opts, plan, request) {
   const outFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.json`);
   const errFile = path.join(paths.tmpDir, `plan-response-${plan.agent.id}-${process.pid}.err`);
-  writeJsonRequest(bodyFile, request.body);
   const args = [
     '--op', 'http.request',
     '--method', 'POST',
     '--url', request.url,
-    '--body-file', bodyFile,
+    '--body-file', request.bodyFile,
     '--secret-env-file', paths.envFile,
     '--audit-log', paths.brokerAuditFile,
     '--budget-file', path.join(paths.tmpDir, `cap-budget-${plan.agent.id}.json`),
-    '--timeout-seconds', String(plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600),
+    '--timeout-seconds', String(request.timeoutSeconds || (plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600)),
     '--out', outFile,
     '--err', errFile,
   ];
   if (request.authRef) args.push('--auth-ref', request.authRef);
+  if (request.approved) args.push('--approved', '1');
   const rc = runBroker(paths, opts, args);
   const response = readFile(outFile);
   const errorText = readFile(errFile);
-  try {
-    fs.unlinkSync(bodyFile);
-  } catch (_) {}
   if (rc !== 0) {
     const status = rc === 23 ? 'unavailable' : 'error';
     throw new PlanFailure(`HTTP broker failed rc=${rc}: ${redact(errorText || response).slice(0, 300)}`, {
@@ -491,13 +510,14 @@ function writeRunLog(paths, plan, status, preview, durationMs, errorMessage) {
   writeAtomic(path.join(paths.logDir, `${Math.floor(ts / 1000)}.json`), JSON.stringify(log) + '\n');
 }
 
-function requestActionApproval(paths, plan, actionType, preview, resultFile, config) {
+function requestActionApproval(paths, plan, actionType, preview, resultFile, config, details) {
   ensureDir(paths.actionApprovalDir);
   ensureDir(paths.actionApprovalReplyDir);
   const runId = `${plan.agent.id}-${Math.floor(Date.now() / 1000)}-${process.pid}`;
   const requestFile = path.join(paths.actionApprovalDir, `action-${safeFilePart(runId)}.json`);
   const replyFile = path.join(paths.actionApprovalReplyDir, `action-${safeFilePart(runId)}.reply.json`);
   const timeoutSeconds = Number(config.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || process.env.SHELLY_AGENT_ACTION_APPROVAL_TIMEOUT_SECONDS || 120);
+  const extra = details || {};
   const request = {
     runId,
     agentId: plan.agent.id,
@@ -505,11 +525,11 @@ function requestActionApproval(paths, plan, actionType, preview, resultFile, con
     toolLabel: plan.tool.label,
     actionType,
     preview,
-    destinationHost: '',
-    command: '',
-    safetyLevel: '',
-    safetyReason: '',
-    payloadPath: '',
+    destinationHost: extra.destinationHost || '',
+    command: extra.command || '',
+    safetyLevel: extra.safetyLevel || '',
+    safetyReason: extra.safetyReason || '',
+    payloadPath: extra.payloadPath || '',
     resultPath: resultFile,
     ts: new Date().toISOString(),
     expiresAt: Date.now() + Math.max(1, timeoutSeconds) * 1000,
@@ -573,6 +593,97 @@ function resolveDraftDestination(paths, plan, config) {
   return path.join(plan.output.outputDir, rel);
 }
 
+function webhookDestinationHost(urlText) {
+  try {
+    const u = new URL(String(urlText || ''));
+    if (u.protocol !== 'https:') return '';
+    return u.host;
+  } catch (_) {
+    return '';
+  }
+}
+
+function writeWebhookPayload(file, plan, status, preview, resultText) {
+  writeAtomic(file, JSON.stringify({
+    agentId: plan.agent.id,
+    status,
+    preview,
+    toolUsed: plan.tool.label,
+    timestamp: Math.floor(Date.now() / 1000),
+    result: resultText,
+  }) + '\n');
+}
+
+function resolveCliCwd(paths, plan, config) {
+  const wanted =
+    config.SHELLY_AGENT_EXEC_CWD ||
+    config.SHELLY_CONTENT_PROJECT ||
+    path.join(paths.home, 'projects/shelly-content-studio');
+  try {
+    if (wanted && path.isAbsolute(wanted) && fs.existsSync(wanted) && fs.statSync(wanted).isDirectory()) return wanted;
+  } catch (_) {
+    // fall through to the known local output directory
+  }
+  const fallback = path.join(paths.home, 'agent-output');
+  ensureDir(fallback);
+  return fallback;
+}
+
+function brokerWorkspaceExec(paths, opts, roots, plan, commandText, cwd) {
+  const commandFile = path.join(paths.tmpDir, `plan-exec-command-${plan.agent.id}-${process.pid}.txt`);
+  const rootsFile = writeRootsFile(paths, roots);
+  const outFile = path.join(paths.logDir, `cli-action-output-${Date.now()}.txt`);
+  const errFile = path.join(paths.logDir, `cli-action-error-${Date.now()}.txt`);
+  writeAtomic(commandFile, commandText);
+  const rc = runBroker(paths, opts, [
+    '--op', 'workspace.exec',
+    '--command-file', commandFile,
+    '--cwd', cwd,
+    '--roots-file', rootsFile,
+    '--audit-log', paths.brokerAuditFile,
+    '--timeout-seconds', String(plan.limits && plan.limits.timeoutSeconds ? plan.limits.timeoutSeconds : 600),
+    '--out', outFile,
+    '--err', errFile,
+  ]);
+  try {
+    fs.unlinkSync(commandFile);
+  } catch (_) {}
+  try {
+    fs.unlinkSync(rootsFile);
+  } catch (_) {}
+  return { rc, outFile, errFile, out: readFile(outFile), err: readFile(errFile) };
+}
+
+function appendCliActionReport(resultFile, commandText, cwd, safety, execResult) {
+  const errorText = execResult.err ? `\n[stderr]\n${execResult.err}` : '';
+  const combined = `${execResult.out || ''}${errorText}`;
+  const safetyLevel = safety && safety.level ? safety.level : '';
+  const safetyReason = safety && safety.reason ? safety.reason : '';
+  fs.appendFileSync(resultFile, [
+    '',
+    '## CLI action',
+    '',
+    `Safety: ${safetyLevel} - ${safetyReason}`,
+    '',
+    `Cwd: ${cwd}`,
+    '',
+    'Command:',
+    '',
+    '```sh',
+    commandText,
+    '```',
+    '',
+    `Exit code: ${execResult.rc}`,
+    '',
+    'Output:',
+    '',
+    '```text',
+    redact(combined).slice(0, 4000),
+    '```',
+    '',
+  ].join('\n'));
+}
+
 function argTruthy(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
 }
@@ -606,7 +717,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
   const actionType = plan.action.type;
   const preview = previewText(resultText);
   if (actionType === '__suppressed__') return { status: 'success', preview };
-  if (actionType !== 'draft' && actionType !== 'notify') {
+  if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
   if (trustedNativeLowRiskAction(args, plan, actionType)) {
@@ -619,13 +730,76 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
       toolType: plan.tool.type,
     });
   } else {
+    if (actionType === 'webhook') {
+      const webhookUrl = String(plan.action.webhookUrl || '').trim();
+      const host = webhookDestinationHost(webhookUrl);
+      if (!webhookUrl) {
+        const message = 'Webhook action is missing an https URL.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      if (!host) {
+        const message = 'Webhook action requires a valid https URL.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      const payloadFile = path.join(paths.logDir, `webhook-payload-${Date.now()}.json`);
+      writeWebhookPayload(payloadFile, plan, 'success', preview, resultText);
+      requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
+        destinationHost: host,
+        payloadPath: payloadFile,
+      });
+      try {
+        brokerHttpBodyFile(paths, opts, plan, {
+          url: webhookUrl,
+          bodyFile: payloadFile,
+          approved: true,
+          timeoutSeconds: Number(config.WEBHOOK_TIMEOUT_SECONDS || 30),
+        });
+      } catch (e) {
+        const message = e instanceof PlanFailure ? redact(e.message) : redact(String(e));
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      return { status: 'success', preview };
+    }
+    if (actionType === 'cli') {
+      const commandText = String(plan.action.command || '').trim();
+      const safety = plan.action.safety || {};
+      if (!commandText) {
+        const message = 'CLI action is missing a command.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      if (safety.level === 'CRITICAL') {
+        const message = `CLI action was blocked by command safety: ${safety.reason || 'critical command'}`;
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
+        command: commandText,
+        safetyLevel: safety.level || '',
+        safetyReason: safety.reason || '',
+      });
+      const cwd = resolveCliCwd(paths, plan, config);
+      const execResult = brokerWorkspaceExec(paths, opts, roots, plan, commandText, cwd);
+      appendCliActionReport(paths.resultFile, commandText, cwd, safety, execResult);
+      if (execResult.rc !== 0) {
+        const message = `CLI action failed with exit ${execResult.rc}.`;
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      return { status: 'success', preview };
+    }
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);
   }
   if (actionType === 'draft') {
     const dest = resolveDraftDestination(paths, plan, config);
     brokerFsWrite(paths, opts, roots, dest, paths.resultFile);
   }
-  writeNotification(paths, plan, 'success', preview);
+  if (actionType === 'draft' || actionType === 'notify') {
+    writeNotification(paths, plan, 'success', preview);
+  }
   return { status: 'success', preview };
 }
 
@@ -709,7 +883,7 @@ function run(args) {
     writeAtomic(paths.resultFile, resultText + (resultText.endsWith('\n') ? '' : '\n'));
     const action = dispatchActionTrusted(paths, opts, plan, config, roots, resultText, args);
     const durationMs = Date.now() - startedAt;
-    writeRunLog(paths, plan, action.status, action.preview, durationMs, '');
+    writeRunLog(paths, plan, action.status, action.preview, durationMs, action.errorMessage || '');
     appendJsonl(paths.planAuditFile, {
       ts: new Date().toISOString(),
       kind: 'plan.executor',

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -1087,6 +1087,15 @@ function run(args) {
     return EXIT.OK;
   }
 
+  // Each run opens a fresh CAP-001 egress budget envelope. The broker's budget file
+  // (cap-budget-<agentId>.json) is keyed per-agent and persists across runs; without
+  // this reset the wall-time budget is measured from the first-ever run, so every run
+  // spuriously fails rc=42 "wall-time budget exhausted" ~10 min after the first
+  // (found in device-verify). The .sh path already rm's it at run start; mirror it.
+  try {
+    fs.rmSync(path.join(paths.tmpDir, `cap-budget-${plan.agent.id}.json`), { force: true });
+  } catch (_) {}
+
   try {
     const request = modelRequest(plan, config);
     const response = brokerHttp(paths, opts, plan, request);


### PR DESCRIPTION
## Summary

Ports the PlanSpec executor core and hardening as a correctly ordered 14-commit batch.

The first commit is the newly authorized prerequisite `78959cf10` (`feat(capability): add scoped fs and curated exec broker ops`). It supplies FS-001 `fs.write`/scoped filesystem operations and EXEC-001 `workspace.exec` routing required by the PlanSpec executor. It remains dormant by default and adds the intended root/symlink-aware checks, cwd jail, curated commands, CRITICAL denial, timeout, secret-free child environment, and redacted audit. The existing 13 PlanSpec commits were replayed after it so every commit is dependency-correct and bisectable.

The remaining commits add the PlanSpec canary, root and unattended hardening, webhook/CLI actions and approval hardening, STOP-ALL gating, Obsidian/draft/source-registry parity, orchestration coverage, LD_PRELOAD launch fixes, and per-run CAP budget reset.

## Dormancy / scope evidence

- `rg -n "SHELLY_PLAN_EXECUTOR" lib scripts` returns no matches.
- Native execution is gated by `isTruthy(flags["SHELLY_PLAN_EXECUTOR"])` and an exact `SHELLY_PLAN_EXECUTOR_AGENT_ID` match before `runPlanAgent` is called.
- `lib/agent-manager.ts` imports the PlanSpec builder and materializes an inert plan alongside the legacy script; it does not launch the executor.
- Legacy FS/EXEC seams read `${SHELLY_CAP_FS:-0}` and `${SHELLY_CAP_EXEC:-0}`; neither is set true by default. The only `=1` assignment is inside the already-opted-in native PlanSpec launch.
- No default flip, schema v3, Codex escalation, signed approval, INTENT, or DM-reply commits are included.

## Verification

- `pnpm run check`: PASS
- actual `pnpm run lint` (`expo lint`, via temporary `pnpm` shim): PASS, 0 errors; 2 pre-existing `ScouterDetailModal.tsx` warnings
- `git diff --check`: PASS
- focused platform-neutral capability/PlanSpec sweep: PASS, 6 suites / 40 tests
- exact approved CLI `workspace.exec` regression: PASS
- changed-test Windows sweep: 118 PASS; 26 host-only failures caused by the broker's intentional POSIX/Android path model and Windows command-line length (`ENAMETOOLONG`). Linux CI is the authoritative run for the scoped draft-writing integration cases.

This PR must not be merged until CC review.