### PR TITLE
feat(memory): port dormant MEMORY-001 core

### DIFF
--- a/__tests__/memory/embedding.test.ts
+++ b/__tests__/memory/embedding.test.ts
@@ -1,0 +1,100 @@
+import { MemoryStore } from '@/lib/memory/memory-store';
+import { InMemoryMemoryStorage } from '@/lib/memory/storage-memory';
+import {
+  EmbeddingPort,
+  MEMORY_SCHEMA_VERSION,
+  MemoryRecord,
+  recordsToRecallContext,
+} from '@/lib/memory';
+import { scanForSecrets } from '@/lib/secret-guard';
+import { FakeClock } from '../support/event-queue-harness';
+
+// Fake embedding: maps a text to a fixed vector by lookup, else zeros. Lets the
+// test control cosine ordering deterministically.
+function fakePort(table: Record<string, number[]>): EmbeddingPort {
+  return {
+    async embed(texts: string[]): Promise<number[][]> {
+      return texts.map((t) => table[t] ?? [0, 0, 0]);
+    },
+  };
+}
+
+function recWithEmbedding(key: string, text: string, embedding: number[]): MemoryRecord {
+  return {
+    namespace: 'ns',
+    key,
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    kind: 'fact',
+    text,
+    tags: [],
+    createdAt: 0,
+    updatedAt: 0,
+    embedding,
+  };
+}
+
+describe('MemoryStore embedding (optional, semantic/hybrid)', () => {
+  it('re-ranks by cosine similarity in semantic mode', async () => {
+    const adapter = new InMemoryMemoryStorage();
+    await adapter.put(recWithEmbedding('near', 'about cats', [1, 0, 0]));
+    await adapter.put(recWithEmbedding('far', 'about cars', [0, 1, 0]));
+    const store = new MemoryStore({
+      adapter,
+      clock: new FakeClock(0),
+      embedding: fakePort({ 'feline pets': [0.9, 0.1, 0] }),
+    });
+    const hits = await store.query('ns', { text: 'feline pets', mode: 'semantic' });
+    expect(hits[0].record.key).toBe('near');
+    expect(hits[0].score).toBeGreaterThan(hits[1].score);
+  });
+
+  it('applies the kind/tags filter in semantic mode (same as other modes)', async () => {
+    const adapter = new InMemoryMemoryStorage();
+    await adapter.put({ ...recWithEmbedding('p', 'pref one', [1, 0, 0]), kind: 'preference', tags: ['keep'] });
+    await adapter.put({ ...recWithEmbedding('f', 'fact one', [1, 0, 0]), kind: 'fact', tags: ['keep'] });
+    const store = new MemoryStore({
+      adapter,
+      clock: new FakeClock(0),
+      embedding: fakePort({ q: [1, 0, 0] }),
+    });
+    const byKind = await store.query('ns', { text: 'q', mode: 'semantic', kind: 'preference' });
+    expect(byKind.map((h) => h.record.key)).toEqual(['p']);
+    const byTag = await store.query('ns', { text: 'q', mode: 'semantic', tags: ['keep'] });
+    expect(byTag.map((h) => h.record.key).sort()).toEqual(['f', 'p']);
+  });
+
+  it('breaks ties deterministically by recency for embedding-less records (migrated G2 data)', async () => {
+    const adapter = new InMemoryMemoryStorage();
+    // No embeddings => every cosine score is 0; must fall back to recency, not
+    // unstable insertion/fs order.
+    await adapter.put({ namespace: 'ns', key: 'old', schemaVersion: 1, kind: 'fact', text: 'a', tags: [], createdAt: 100, updatedAt: 100 });
+    await adapter.put({ namespace: 'ns', key: 'new', schemaVersion: 1, kind: 'fact', text: 'b', tags: [], createdAt: 200, updatedAt: 200 });
+    const store = new MemoryStore({
+      adapter,
+      clock: new FakeClock(0),
+      embedding: fakePort({ q: [1, 0, 0] }),
+    });
+    const hits = await store.query('ns', { text: 'q', mode: 'semantic', limit: 10 });
+    expect(hits.map((h) => h.record.key)).toEqual(['new', 'old']); // newest first
+  });
+
+  it('degrades to fulltext when no embedding port is present', async () => {
+    const store = new MemoryStore({ adapter: new InMemoryMemoryStorage(), clock: new FakeClock(0) });
+    await store.put({ namespace: 'ns', text: 'quantum computing notes' });
+    // semantic requested but no port -> must still work as fulltext, not throw.
+    const hits = await store.query('ns', { text: 'quantum', mode: 'semantic' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].record.text).toBe('quantum computing notes');
+  });
+
+  it('surfaces a secret in recalled memory so the secret-guard still fires', async () => {
+    const store = new MemoryStore({ adapter: new InMemoryMemoryStorage(), clock: new FakeClock(0) });
+    await store.put({
+      namespace: 'ns',
+      text: 'the deploy token is api_key=sk-abcdef0123456789ghjklmno',
+    });
+    const hits = await store.query('ns', { text: 'deploy token' });
+    const block = recordsToRecallContext(hits);
+    expect(scanForSecrets(block).hasSecret).toBe(true);
+  });
+});

--- a/__tests__/memory/memory-store.test.ts
+++ b/__tests__/memory/memory-store.test.ts
@@ -1,0 +1,64 @@
+import { MemoryStore } from '@/lib/memory/memory-store';
+import { InMemoryMemoryStorage } from '@/lib/memory/storage-memory';
+import { deriveKey, MEMORY_SCHEMA_VERSION } from '@/lib/memory';
+import { FakeClock } from '../support/event-queue-harness';
+
+function makeStore(start = 1000) {
+  const clock = new FakeClock(start);
+  return { store: new MemoryStore({ adapter: new InMemoryMemoryStorage(), clock }), clock };
+}
+
+describe('MemoryStore put/get', () => {
+  it('round-trips a record with clock timestamps and default kind', async () => {
+    const { store } = makeStore();
+    const rec = await store.put({ namespace: 'a1', text: '  hello world  ', tags: ['X', 'y y'] });
+    expect(rec.kind).toBe('fact');
+    expect(rec.text).toBe('hello world'); // trimmed
+    expect(rec.tags).toEqual(['x', 'y-y']); // normalized
+    expect(rec.createdAt).toBe(1000);
+    expect(rec.updatedAt).toBe(1000);
+    expect(rec.schemaVersion).toBe(MEMORY_SCHEMA_VERSION);
+
+    const got = await store.get('a1', rec.key);
+    expect(got?.text).toBe('hello world');
+  });
+
+  it('derives a deterministic key so re-putting the same content overwrites (idempotent)', async () => {
+    const { store, clock } = makeStore();
+    const first = await store.put({ namespace: 'a1', text: 'the sky is blue' });
+    expect(first.key).toBe(deriveKey('a1', 'fact', 'the sky is blue'));
+
+    clock.advance(500);
+    const second = await store.put({ namespace: 'a1', text: 'the sky is blue' });
+    expect(second.key).toBe(first.key);
+    expect(await store.query('a1')).toHaveLength(1); // one record, not two
+    expect(second.createdAt).toBe(first.createdAt); // preserved
+    expect(second.updatedAt).toBe(1500); // advanced
+  });
+
+  it('overwrites fields on an explicit key while preserving createdAt', async () => {
+    const { store, clock } = makeStore();
+    const a = await store.put({ namespace: 'a1', key: 'k', text: 'v1', tags: ['t1'] });
+    clock.advance(10);
+    const b = await store.put({ namespace: 'a1', key: 'k', text: 'v2', tags: ['t2'] });
+    expect(b.text).toBe('v2');
+    expect(b.tags).toEqual(['t2']);
+    expect(b.createdAt).toBe(a.createdAt);
+    expect(await store.query('a1')).toHaveLength(1);
+  });
+
+  it('isolates records by namespace', async () => {
+    const { store } = makeStore();
+    const rec = await store.put({ namespace: 'A', key: 'K', text: 'secret to A' });
+    expect(await store.get('B', rec.key)).toBeNull();
+    expect(await store.query('B')).toHaveLength(0);
+    expect(await store.query('A')).toHaveLength(1);
+  });
+
+  it('deletes a record', async () => {
+    const { store } = makeStore();
+    const rec = await store.put({ namespace: 'A', text: 'gone soon' });
+    await store.delete('A', rec.key);
+    expect(await store.get('A', rec.key)).toBeNull();
+  });
+});

--- a/__tests__/memory/query-ranking.test.ts
+++ b/__tests__/memory/query-ranking.test.ts
@@ -1,0 +1,92 @@
+jest.mock('@/lib/home-path', () => ({ getHomePath: () => '/home/shelly-test' }));
+jest.mock('expo-file-system/legacy', () => ({}));
+
+import { MemoryStore } from '@/lib/memory/memory-store';
+import { InMemoryMemoryStorage } from '@/lib/memory/storage-memory';
+import { deriveKey, g2NoteToRecord } from '@/lib/memory';
+import { memoryNoteId, recallMemoryNotes, type MemoryNote } from '@/lib/agent-memory';
+import { FakeClock } from '../support/event-queue-harness';
+
+describe('deriveKey byte-identity with G2 memoryNoteId (migration idempotency)', () => {
+  it('produces the exact same key as memoryNoteId for the same (namespace/agentId, kind/type, text)', () => {
+    const cases: Array<[string, 'fact' | 'preference' | 'result', string]> = [
+      ['agent-7', 'fact', 'the sky is blue'],
+      ['agent-7', 'preference', '  trims and matches  '],
+      ['ag', 'result', 'CJK テキスト も 一致'],
+      ['x', 'fact', ''],
+    ];
+    for (const [ns, kind, text] of cases) {
+      expect(deriveKey(ns, kind, text)).toBe(memoryNoteId(ns, kind, text));
+    }
+  });
+});
+
+function makeStore(start = 1000) {
+  const clock = new FakeClock(start);
+  return { store: new MemoryStore({ adapter: new InMemoryMemoryStorage(), clock }), clock };
+}
+
+describe('MemoryStore full-text query', () => {
+  it('ranks a tag+token overlap above a weaker match', async () => {
+    const { store, clock } = makeStore();
+    await store.put({ namespace: 'a', text: 'notes about crypto trading', tags: ['crypto'] });
+    clock.advance(1);
+    await store.put({ namespace: 'a', text: 'gardening tips for spring' });
+    const hits = await store.query('a', { text: 'crypto market update' });
+    expect(hits[0].record.text).toBe('notes about crypto trading');
+    expect(hits[0].score).toBeGreaterThan(0);
+  });
+
+  it('falls back to newest-first when nothing overlaps', async () => {
+    const { store, clock } = makeStore();
+    await store.put({ namespace: 'a', text: 'alpha' });
+    clock.advance(100);
+    await store.put({ namespace: 'a', text: 'beta' });
+    const hits = await store.query('a', { text: 'zzz-no-overlap' });
+    expect(hits.map((h) => h.record.text)).toEqual(['beta', 'alpha']); // recency
+  });
+
+  it('honors limit and returns [] for an empty namespace', async () => {
+    const { store } = makeStore();
+    await store.put({ namespace: 'a', text: 'one' });
+    await store.put({ namespace: 'a', text: 'two' });
+    await store.put({ namespace: 'a', text: 'three' });
+    expect(await store.query('a', { limit: 2 })).toHaveLength(2);
+    expect(await store.query('a', { limit: 0 })).toHaveLength(0);
+    expect(await store.query('empty-ns')).toHaveLength(0);
+  });
+
+  it('filters by tags (AND) and by kind', async () => {
+    const { store } = makeStore();
+    await store.put({ namespace: 'a', text: 'r1', tags: ['red', 'blue'], kind: 'fact' });
+    await store.put({ namespace: 'a', text: 'r2', tags: ['red'], kind: 'preference' });
+    const byTags = await store.query('a', { tags: ['red', 'blue'] });
+    expect(byTags.map((h) => h.record.text)).toEqual(['r1']);
+    const byKind = await store.query('a', { kind: 'preference' });
+    expect(byKind.map((h) => h.record.text)).toEqual(['r2']);
+  });
+
+  it('matches G2 recallMemoryNotes ordering (migration recall parity)', async () => {
+    // Sample notes, newest-first (as readMemoryNotes returns them).
+    const notes: MemoryNote[] = [
+      { id: 'n1', agentId: 'ag', type: 'fact', created: '2026-07-03T00:00:03Z', tags: ['crypto'], text: 'crypto portfolio rebalanced' },
+      { id: 'n2', agentId: 'ag', type: 'fact', created: '2026-07-03T00:00:02Z', tags: ['garden'], text: 'watered the tomatoes' },
+      { id: 'n3', agentId: 'ag', type: 'preference', created: '2026-07-03T00:00:01Z', tags: [], text: 'prefers concise crypto summaries' },
+    ];
+    const taskText = 'give me a crypto update';
+
+    const g2Order = recallMemoryNotes(notes, taskText).map((n) => n.id);
+
+    // Import G2 notes verbatim via g2NoteToRecord (preserving their createdAt so
+    // the recency tiebreak matches), then rank through the new query path.
+    const adapter = new InMemoryMemoryStorage();
+    const store = new MemoryStore({ adapter, clock: new FakeClock(0) });
+    for (const note of notes) {
+      await adapter.put(g2NoteToRecord(note));
+    }
+    const newOrder = (await store.query('ag', { text: taskText, limit: 10 })).map(
+      (h) => h.record.key,
+    );
+    expect(newOrder).toEqual(g2Order);
+  });
+});

--- a/__tests__/memory/shadow.test.ts
+++ b/__tests__/memory/shadow.test.ts
@@ -4,13 +4,15 @@ jest.mock('@/lib/home-path', () => ({ getHomePath: () => '/home/shelly-test' }))
 jest.mock('expo-file-system/legacy', () => ({}));
 
 import {
+  activateMemoryRecall,
+  activateMemoryWrite,
   compareShadowRecall,
   runShadowComparison,
   shadowMemoryRecall,
   type ShadowDeps,
 } from '@/lib/memory/shadow';
 import { MEMORY_ENABLED, InMemoryMemoryStorage, MemoryStore, g2NoteToRecord } from '@/lib/memory';
-import { recallMemoryNotes, type MemoryNote } from '@/lib/agent-memory';
+import { buildRecallContext, recallMemoryNotes, type MemoryNote } from '@/lib/agent-memory';
 
 function note(id: string, created: string, text: string, tags: string[] = []): MemoryNote {
   return { id, agentId: 'agent-7', type: 'fact', created, tags, text };
@@ -122,5 +124,113 @@ describe('runShadowComparison (import → query → compare pipeline)', () => {
     expect(cmp.shadowKeys).toEqual([]);
     expect(cmp.orderMatches).toBe(true);
     expect(cmp.contextMatches).toBe(true);
+  });
+});
+
+describe('activateMemoryRecall (MEMORY-001 Step 3)', () => {
+  it('injects the MEMORY-001 store context, not G2, when the store has data', async () => {
+    const deps = makeDeps();
+    const result = await activateMemoryRecall(AGENT, NOTES, deps);
+    // Sanity: MEMORY-001's own render function produced this, and it is
+    // non-null/non-empty because the store actually has matching records.
+    expect(result).not.toBeNull();
+    expect(result).not.toBe('');
+    // Ground truth for "not G2's result": compareShadowRecall already proves
+    // order+content parity between the two paths for this fixture, so instead
+    // we assert the activated result is produced by the MEMORY-001 rendering
+    // path directly (recordsToRecallContext over the store's own query), by
+    // checking it reproduces the query independently of G2's recallMemoryNotes.
+    const g2Context = buildRecallContext(
+      recallMemoryNotes(NOTES, `${AGENT.name}\n${AGENT.prompt}`)
+    );
+    expect(result).toBe(g2Context); // parity fixture: same content, different code path
+  });
+
+  it('returns non-empty content that differs from G2 when the store has EXTRA data G2 does not', async () => {
+    const deps = makeDeps();
+    // Seed the MEMORY-001 store directly (bypassing the G2 import) with a
+    // record G2 has never seen, so a correct activation must reflect it and an
+    // accidental "still calling G2 under the hood" bug would not.
+    await deps.store.put({
+      namespace: 'agent-7',
+      text: 'deploy the app to the device please remember the fold6 rollback plan',
+      kind: 'fact',
+      tags: ['deploy'],
+    });
+    deps.importedAgents.add(AGENT.id); // skip the G2 mirror-import for this call
+    const result = await activateMemoryRecall(AGENT, NOTES, deps);
+    const g2Context = buildRecallContext(
+      recallMemoryNotes(NOTES, `${AGENT.name}\n${AGENT.prompt}`)
+    );
+    expect(result).not.toBeNull();
+    expect(result).not.toBe(g2Context);
+    expect(result).toContain('rollback plan');
+  });
+
+  it('falls back safely (returns null) when the store throws', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const brokenDeps = makeDeps();
+      jest.spyOn(brokenDeps.store, 'query').mockRejectedValue(new Error('disk exploded'));
+      const result = await activateMemoryRecall(AGENT, NOTES, brokenDeps);
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('returns empty string (not null) when the store legitimately has nothing to recall', async () => {
+    const deps = makeDeps();
+    const result = await activateMemoryRecall(AGENT, [], deps);
+    expect(result).toBe('');
+  });
+
+  it('is unreachable while MEMORY_ENABLED=false (agent-manager never calls it)', () => {
+    // Documents the contract enforced at the agent-manager call-site: this
+    // module has no internal flag check of its own (agent-manager gates the
+    // call), so the guarantee lives in agent-manager's `if (MEMORY_ENABLED)`.
+    expect(MEMORY_ENABLED).toBe(false);
+  });
+});
+
+describe('activateMemoryWrite (MEMORY-001 Step 4)', () => {
+  it('writes through store.put (not the G2 shell command) and is queryable back', async () => {
+    const deps = makeDeps();
+    const ok = await activateMemoryWrite(
+      { agentId: 'agent-9', type: 'fact', text: 'remember the API base url', tags: ['Api', 'API'] },
+      deps
+    );
+    expect(ok).toBe(true);
+    const stored = await deps.adapter.list('agent-9');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].text).toBe('remember the API base url');
+    // Tag normalization matches G2's normalizeTags (lowercase, deduped).
+    expect(stored[0].tags).toEqual(['api']);
+  });
+
+  it('reuses makeMemoryNote truncation/id-derivation so the record matches what G2 would have produced', async () => {
+    const deps = makeDeps();
+    const longText = 'x'.repeat(2000);
+    await activateMemoryWrite({ agentId: 'agent-9', type: 'result', text: longText }, deps);
+    const stored = await deps.adapter.list('agent-9');
+    // MAX_NOTE_CHARS = 1200 in agent-memory.ts; activateMemoryWrite must inherit it.
+    expect(stored[0].text.length).toBe(1200);
+  });
+
+  it('falls back safely (returns false) when the store throws', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const brokenDeps = makeDeps();
+      jest.spyOn(brokenDeps.store, 'put').mockRejectedValue(new Error('disk exploded'));
+      const ok = await activateMemoryWrite(
+        { agentId: 'agent-9', type: 'fact', text: 'hello' },
+        brokenDeps
+      );
+      expect(ok).toBe(false);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/memory/shadow.test.ts
+++ b/__tests__/memory/shadow.test.ts
@@ -1,0 +1,126 @@
+jest.mock('@/lib/home-path', () => ({ getHomePath: () => '/home/shelly-test' }));
+// Empty mock: if the MEMORY_ENABLED gate ever leaked, the shadow path would hit
+// this stub, throw, and surface as a console.warn (asserted below).
+jest.mock('expo-file-system/legacy', () => ({}));
+
+import {
+  compareShadowRecall,
+  runShadowComparison,
+  shadowMemoryRecall,
+  type ShadowDeps,
+} from '@/lib/memory/shadow';
+import { MEMORY_ENABLED, InMemoryMemoryStorage, MemoryStore, g2NoteToRecord } from '@/lib/memory';
+import { recallMemoryNotes, type MemoryNote } from '@/lib/agent-memory';
+
+function note(id: string, created: string, text: string, tags: string[] = []): MemoryNote {
+  return { id, agentId: 'agent-7', type: 'fact', created, tags, text };
+}
+
+// Newest-first, like readMemoryNotes returns them.
+const NOTES: MemoryNote[] = [
+  note('fact-c', '2026-07-03T00:00:03Z', 'deploy target is the fold6 device', ['deploy']),
+  note('fact-b', '2026-07-02T00:00:02Z', 'user prefers concise answers'),
+  note('fact-a', '2026-07-01T00:00:01Z', 'api base url is example.com', ['api']),
+];
+
+const AGENT = { id: 'agent-7', name: 'deploy-bot', prompt: 'deploy the app to the device' };
+
+function makeDeps(): ShadowDeps {
+  const adapter = new InMemoryMemoryStorage();
+  return {
+    adapter,
+    store: new MemoryStore({ adapter, clock: { now: () => 1_000 } }),
+    importedAgents: new Set<string>(),
+  };
+}
+
+describe('MEMORY-001 shadow seam — dormancy gate', () => {
+  it('ships flag-OFF', () => {
+    expect(MEMORY_ENABLED).toBe(false);
+  });
+
+  it('shadowMemoryRecall is a silent no-op while MEMORY_ENABLED=false', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // If the gate leaked, the lazy expo port would be constructed over the
+      // empty expo-file-system mock, throw, and be logged via console.warn.
+      await expect(shadowMemoryRecall(AGENT, NOTES)).resolves.toBeUndefined();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('compareShadowRecall (pure comparator)', () => {
+  it('reports parity for identical order + content', () => {
+    const live = recallMemoryNotes(NOTES, `${AGENT.name}\n${AGENT.prompt}`);
+    const hits = live.map((n) => ({ record: g2NoteToRecord(n), score: 0 }));
+    const cmp = compareShadowRecall(live, hits);
+    expect(cmp.orderMatches).toBe(true);
+    expect(cmp.contextMatches).toBe(true);
+    expect(cmp.liveKeys).toEqual(cmp.shadowKeys);
+  });
+
+  it('flags an order divergence', () => {
+    const live = [NOTES[0], NOTES[1]];
+    const hits = [NOTES[1], NOTES[0]].map((n) => ({ record: g2NoteToRecord(n), score: 0 }));
+    const cmp = compareShadowRecall(live, hits);
+    expect(cmp.orderMatches).toBe(false);
+  });
+
+  it('flags a content divergence even when keys line up', () => {
+    const live = [NOTES[0]];
+    const mutated = { ...g2NoteToRecord(NOTES[0]), text: 'different text' };
+    const cmp = compareShadowRecall(live, [{ record: mutated, score: 0 }]);
+    expect(cmp.orderMatches).toBe(true);
+    expect(cmp.contextMatches).toBe(false);
+  });
+
+  it('treats empty-vs-empty as parity (prompt unchanged on both sides)', () => {
+    const cmp = compareShadowRecall([], []);
+    expect(cmp.orderMatches).toBe(true);
+    expect(cmp.contextMatches).toBe(true);
+  });
+});
+
+describe('runShadowComparison (import → query → compare pipeline)', () => {
+  it('imports G2 notes and reproduces the live recall order/content', async () => {
+    const deps = makeDeps();
+    const cmp = await runShadowComparison(AGENT, NOTES, deps);
+    expect(cmp.orderMatches).toBe(true);
+    expect(cmp.contextMatches).toBe(true);
+    // Sanity: something was actually recalled on both sides.
+    expect(cmp.liveKeys.length).toBeGreaterThan(0);
+    expect(cmp.shadowKeys).toEqual(cmp.liveKeys);
+  });
+
+  it('preserves G2 createdAt on import (recency tiebreaks stay in parity)', async () => {
+    const deps = makeDeps();
+    await runShadowComparison(AGENT, NOTES, deps);
+    const imported = await deps.adapter.get('agent-7', 'fact-a');
+    // adapter.put (not store.put): createdAt must be the G2 note's created
+    // timestamp, NOT the injected clock's now (1000).
+    expect(imported?.createdAt).toBe(Date.parse('2026-07-01T00:00:01Z'));
+  });
+
+  it('imports each agent once per session (idempotent upsert either way)', async () => {
+    const deps = makeDeps();
+    const putSpy = jest.spyOn(deps.adapter, 'put');
+    await runShadowComparison(AGENT, NOTES, deps);
+    await runShadowComparison(AGENT, NOTES, deps);
+    expect(putSpy).toHaveBeenCalledTimes(NOTES.length);
+    expect((await deps.adapter.list('agent-7')).length).toBe(NOTES.length);
+  });
+
+  it('shadow recall with zero notes yields empty on both sides', async () => {
+    const cmp = await runShadowComparison(AGENT, [], makeDeps());
+    expect(cmp.liveKeys).toEqual([]);
+    expect(cmp.shadowKeys).toEqual([]);
+    expect(cmp.orderMatches).toBe(true);
+    expect(cmp.contextMatches).toBe(true);
+  });
+});

--- a/__tests__/memory/storage-json.test.ts
+++ b/__tests__/memory/storage-json.test.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { JsonFileMemoryStorage, assertWithinRoot } from '@/lib/memory/storage-json';
+import { MemoryStore } from '@/lib/memory/memory-store';
+import { MEMORY_SCHEMA_VERSION, MemoryRecord } from '@/lib/memory';
+import { FakeClock } from '../support/event-queue-harness';
+import { makeNodeFsPort, makeTmpDir } from '../support/node-fs-port';
+
+function record(namespace: string, key: string, text = key): MemoryRecord {
+  return {
+    namespace,
+    key,
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    kind: 'fact',
+    text,
+    tags: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe('JsonFileMemoryStorage', () => {
+  let root: string;
+  beforeEach(() => {
+    root = path.join(makeTmpDir(), 'memory');
+  });
+  afterEach(() => {
+    fs.rmSync(path.dirname(root), { recursive: true, force: true });
+  });
+
+  it('round-trips put/get/query/delete via a MemoryStore over node fs', async () => {
+    const adapter = new JsonFileMemoryStorage(makeNodeFsPort(), { root });
+    const store = new MemoryStore({ adapter, clock: new FakeClock(1000) });
+    const rec = await store.put({ namespace: 'ns', text: 'durable note', tags: ['keep'] });
+    expect((await store.get('ns', rec.key))?.text).toBe('durable note');
+    expect(await store.query('ns', { text: 'durable' })).toHaveLength(1);
+    await store.delete('ns', rec.key);
+    expect(await store.get('ns', rec.key)).toBeNull();
+  });
+
+  it('skips a corrupt .json on load instead of failing the namespace', async () => {
+    const adapter = new JsonFileMemoryStorage(makeNodeFsPort(), { root });
+    await adapter.put(record('ns', 'good'));
+    const nsDir = path.join(root, encodeURIComponent('ns'));
+    fs.writeFileSync(path.join(nsDir, 'garbage.json'), '{ not json');
+    fs.writeFileSync(path.join(nsDir, 'wrongshape.json'), JSON.stringify({ id: 'x' }));
+    const loaded = await adapter.list('ns');
+    expect(loaded.map((r) => r.key)).toEqual(['good']);
+  });
+
+  it('maps distinct keys/namespaces with special chars to distinct files', async () => {
+    const adapter = new JsonFileMemoryStorage(makeNodeFsPort(), { root });
+    const keys = ['a/b', 'a b', 'a+b'];
+    for (const k of keys) await adapter.put(record('ns', k));
+    expect((await adapter.list('ns')).map((r) => r.key).sort()).toEqual([...keys].sort());
+    await adapter.delete('ns', 'a/b');
+    expect((await adapter.list('ns')).map((r) => r.key).sort()).toEqual(['a b', 'a+b'].sort());
+  });
+
+  it('never writes above the root even for an escaping namespace/key', async () => {
+    const adapter = new JsonFileMemoryStorage(makeNodeFsPort(), { root });
+    // encodeURIComponent neutralizes '/', so an escaping ns/key is just a weird
+    // in-root segment (a miss), never a write above root.
+    expect(await adapter.get('../../etc', 'passwd')).toBeNull();
+    await adapter.put(record('../../etc', 'passwd', 'nope'));
+    expect(fs.existsSync(path.join(path.dirname(root), 'passwd'))).toBe(false);
+    expect(fs.existsSync('/etc/passwd.shelly-test-should-not-exist')).toBe(false);
+  });
+
+  it('throws when a bare ".." namespace escapes the root via the public API', async () => {
+    // encodeURIComponent('..') === '..' (dots unreserved), so <root>/.. escapes
+    // and only assertWithinRoot's canonicalization catches it — proves the JAIL,
+    // not the encoder, through the normal adapter API.
+    const adapter = new JsonFileMemoryStorage(makeNodeFsPort(), { root });
+    await expect(adapter.put(record('..', 'k'))).rejects.toThrow(/scoped\.fs denied/);
+    await expect(adapter.list('..')).rejects.toThrow(/scoped\.fs denied/);
+    await expect(adapter.get('..', 'k')).rejects.toThrow(/scoped\.fs denied/);
+    await expect(adapter.delete('..', 'k')).rejects.toThrow(/scoped\.fs denied/);
+  });
+
+  it('isolates namespaces on disk', async () => {
+    const adapter = new JsonFileMemoryStorage(makeNodeFsPort(), { root });
+    await adapter.put(record('A', 'k', 'in A'));
+    await adapter.put(record('B', 'k', 'in B'));
+    expect((await adapter.list('A')).map((r) => r.text)).toEqual(['in A']);
+    expect((await adapter.list('B')).map((r) => r.text)).toEqual(['in B']);
+  });
+});
+
+describe('assertWithinRoot (scoped.fs root-jail, defense in depth)', () => {
+  const root = '/data/memory-root';
+  it('allows a path inside the root', () => {
+    expect(() => assertWithinRoot(root, 'read', `${root}/ns/key.json`)).not.toThrow();
+  });
+  it('denies an absolute path outside the root', () => {
+    expect(() => assertWithinRoot(root, 'read', '/etc/passwd')).toThrow(/scoped\.fs denied/);
+  });
+  it('denies a traversal that escapes the root', () => {
+    expect(() => assertWithinRoot(root, 'write', `${root}/../secrets/x.json`)).toThrow(
+      /scoped\.fs denied/,
+    );
+  });
+});

--- a/__tests__/memory/wiring.test.ts
+++ b/__tests__/memory/wiring.test.ts
@@ -1,0 +1,67 @@
+jest.mock('@/lib/home-path', () => ({ getHomePath: () => '/home/shelly-test' }));
+jest.mock('expo-file-system/legacy', () => ({}));
+
+import {
+  MEMORY_ENABLED,
+  MEMORY_EMBEDDING_ENABLED,
+  agentNamespace,
+  g2NoteToRecord,
+  recordsToRecallContext,
+  MEMORY_SCHEMA_VERSION,
+} from '@/lib/memory';
+import { buildRecallContext, type MemoryNote } from '@/lib/agent-memory';
+
+describe('MEMORY-001 dormancy + G2 mapping', () => {
+  it('ships disabled (queue + embedding both off)', () => {
+    expect(MEMORY_ENABLED).toBe(false);
+    expect(MEMORY_EMBEDDING_ENABLED).toBe(false);
+  });
+
+  it('agentNamespace is deterministic/stable', () => {
+    expect(agentNamespace('agent-7')).toBe('agent-7');
+    expect(agentNamespace('agent-7')).toBe(agentNamespace('agent-7'));
+  });
+
+  it('g2NoteToRecord maps a G2 note onto a MemoryRecord', () => {
+    const note: MemoryNote = {
+      id: 'fact-abc',
+      agentId: 'agent-7',
+      type: 'preference',
+      created: '2026-07-03T00:00:00.000Z',
+      tags: ['t1', 't2'],
+      text: 'prefers dark mode',
+    };
+    const rec = g2NoteToRecord(note);
+    expect(rec).toEqual({
+      namespace: 'agent-7',
+      key: 'fact-abc',
+      schemaVersion: MEMORY_SCHEMA_VERSION,
+      kind: 'preference',
+      text: 'prefers dark mode',
+      tags: ['t1', 't2'],
+      createdAt: Date.parse('2026-07-03T00:00:00.000Z'),
+      updatedAt: Date.parse('2026-07-03T00:00:00.000Z'),
+    });
+  });
+
+  it('g2NoteToRecord tolerates a bad timestamp (createdAt=0, no throw)', () => {
+    const rec = g2NoteToRecord({
+      id: 'x', agentId: 'a', type: 'fact', created: 'not-a-date', tags: [], text: 't',
+    });
+    expect(rec.createdAt).toBe(0);
+  });
+
+  it('recordsToRecallContext reproduces buildRecallContext format', () => {
+    const notes: MemoryNote[] = [
+      { id: 'n1', agentId: 'a', type: 'fact', created: '2026-07-03T00:00:02Z', tags: [], text: 'the api base url is example.com' },
+      { id: 'n2', agentId: 'a', type: 'preference', created: '2026-07-03T00:00:01Z', tags: [], text: 'concise answers' },
+    ];
+    const g2 = buildRecallContext(notes);
+    const mine = recordsToRecallContext(notes.map((n) => ({ record: g2NoteToRecord(n), score: 0 })));
+    expect(mine).toBe(g2);
+  });
+
+  it('recordsToRecallContext returns empty for no hits (prompt unchanged)', () => {
+    expect(recordsToRecallContext([])).toBe('');
+  });
+});

--- a/docs/superpowers/DEFERRED.md
+++ b/docs/superpowers/DEFERRED.md
@@ -1134,6 +1134,24 @@ coreutils: /sdcard/Download/patch-codex.sh: Permission denied
 
 ## P1 — v0.1.1 で対応推奨
 
+### MEMORY-001 — 保存時暗号化・一般 PII/taint 分類がない
+
+**発見**: 2026-07-13 Batch 11 の MEMORY-001 移植時に、source design の既知制限を再確認。
+
+**状態 / リスク**: MEMORY-001 の実デバイス backend は Expo FS 上の JSON ファイルで、記憶本文を平文で保存する。書き込み時の secret redaction、一般的な PII（氏名、住所、健康・業務上の機微情報など）の分類、taint metadata 付与もない。recall 時には本文が effective `agent.prompt` に挿入され、既存 `scanForSecrets` が認識する secret pattern は再検査されて local-only routing を強制するが、pattern 外の機微な prose は cloud model への送信を止められない。したがって将来 `MEMORY_ENABLED` と MODEL-001/cloud routing を同時に有効化すると、保存済みの機微情報が cloud に渡る可能性がある。
+
+**戻す条件**:
+1. Android Keystore に束縛した at-rest encryption（鍵生成・rotation・backup/restore・既存 JSON migration を含む）を設計し、平文ファイルが残らないことを実機検証する。
+2. write/recall の両境界に一般 PII/taint classification と policy を置き、分類不能・高感度データは local-only または明示承認へ fail-close する。
+3. `scanForSecrets` の既知 pattern だけでなく、非 secret-pattern の機微 prose を含む negative/positive corpus で cloud 非送信をテストする。
+
+**Why not now**: 今回は upstream の dormant parity port であり、`MEMORY_ENABLED = false` かつ production setter なしのため新 backend は fresh install で到達不能。暗号鍵 lifecycle と PII policy は独立した security design・migration・実機検証を要し、source にない仕組みを本移植へ即興で追加すると parity と reviewability を損なうため、flag-ON の前提条件として P1 追跡する。
+
+**優先度**: P1（現在は休眠だが、MEMORY-001 有効化前の privacy gate）
+**→ sync:** MEMORY-001 を公開・有効化する時点で README privacy / data-storage 説明へ反映。
+
+---
+
 ### CC schema-diff watcher を updater に組み込む
 
 **発見**: 2026-05-20 Claude Code 2.1.143+ Bash tool 追従調査中
@@ -2111,6 +2129,8 @@ claude() {
 ---
 
 ## History
+
+- **2026-07-13 (Batch 11)**: **MEMORY-001** を `ac41812a6` → `7ecc7e058` → `fdd5620ab` から現行 `origin/main` へ 3 feature commit の順序を保って独立移植。per-namespace get/put/query、G2 形式・ranking parity、FS-001 `classifyFsAccess` jail、Expo FS JSON device backend、shadow/activated read-write seam を追加した。実稼働 backend は JSON で、`SqliteFtsMemoryStorage` は未配線 skeleton のため roadmap の SQLite/FTS5 は未完。`MEMORY_ENABLED = false` / `MEMORY_EMBEDDING_ENABLED = false` の source 定数と production setter 不在を確認し、fresh install は G2 経路のまま休眠。MODEL-001 / PlanSpec / EVENT-001 / signed approval への新規 import・依存なし。平文保存・write-time redaction / 一般 PII classification 不在は別 P1「MEMORY-001 — 保存時暗号化・一般 PII/taint 分類がない」に追跡し、flag-ON 前の privacy gate とした。旧開発ブランチの companion history commits 5件は移植せず、本記録1件に集約。→ sync: なし（既定OFFの内部 substrate。公開・有効化時の privacy 文書同期は P1 entry 側で追跡）。
 
 - **2026-07-13**: Batch 9 で **MODEL-001（eligibility-first + routing-floor multi-model inference routing）** を `origin/main` へ独立移植。候補を secret/local・web・unattended credential・budget・task-kind の適格性で先に絞り、その後に cost/latency/preference を決定論的に順位付けする pure core、registry、shadow comparator、secret branch の live-flip seam を追加した。`MODEL_ROUTER_ENABLED = false` のソース定数を確認し、既定経路は従来の `onDeviceFallbackTool()` のまま、provider invocation も未配線で fresh install は休眠。MEMORY-001 / FS-001 / PlanSpec への import・依存はなく、MODEL-001 7 suite / 40 tests、`tsc --noEmit`、`expo lint`（既存 warning 2件のみ）、`git diff --check` を PASS。5件の旧開発ブランチ履歴コミットは移植せず、この現行 main 向け記録1件に集約。実機での flag-ON cutover は本バッチのスコープ外。→ sync: なし（既定OFFの内部 substrate のため README 反映不要）。
 

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -21,6 +21,11 @@ import {
   recallMemoryNotes,
   writeMemoryNote,
 } from './agent-memory';
+// MEMORY-001 shadow seam (dormant): flag + shadow entry imported from their own
+// modules (not the '@/lib/memory' index) so host memory tests that import the
+// index never transitively load expo-file-system via fs-expo.
+import { MEMORY_ENABLED } from './memory/wiring';
+import { shadowMemoryRecall } from './memory/shadow';
 import {
   buildSkillInjectionContext,
   bumpSkillUsage,
@@ -363,6 +368,13 @@ async function applyMemoryAndSkills(agent: Agent): Promise<Agent> {
   // Phase 1 memory recall.
   try {
     const notes = await readMemoryNotes(agent.id);
+    // MEMORY-001 shadow read (strangler, flag-OFF today): when enabled, mirror
+    // the notes into the new store and log recall divergence WITHOUT changing
+    // what gets injected — the G2 result below stays authoritative. Guarded
+    // twice (flag + catch) so a shadow failure can never break the live run.
+    if (MEMORY_ENABLED) {
+      await shadowMemoryRecall(agent, notes).catch(() => {});
+    }
     if (notes.length > 0) {
       const relevant = recallMemoryNotes(notes, `${agent.name}\n${agent.prompt}`);
       const recallContext = buildRecallContext(relevant);

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -21,11 +21,11 @@ import {
   recallMemoryNotes,
   writeMemoryNote,
 } from './agent-memory';
-// MEMORY-001 shadow seam (dormant): flag + shadow entry imported from their own
-// modules (not the '@/lib/memory' index) so host memory tests that import the
-// index never transitively load expo-file-system via fs-expo.
+// MEMORY-001 shadow/activation seam (dormant): flag + entry points imported
+// from their own modules (not the '@/lib/memory' index) so host memory tests
+// that import the index never transitively load expo-file-system via fs-expo.
 import { MEMORY_ENABLED } from './memory/wiring';
-import { shadowMemoryRecall } from './memory/shadow';
+import { shadowMemoryRecall, activateMemoryRecall, activateMemoryWrite } from './memory/shadow';
 import {
   buildSkillInjectionContext,
   bumpSkillUsage,
@@ -368,18 +368,28 @@ async function applyMemoryAndSkills(agent: Agent): Promise<Agent> {
   // Phase 1 memory recall.
   try {
     const notes = await readMemoryNotes(agent.id);
-    // MEMORY-001 shadow read (strangler, flag-OFF today): when enabled, mirror
-    // the notes into the new store and log recall divergence WITHOUT changing
-    // what gets injected — the G2 result below stays authoritative. Guarded
-    // twice (flag + catch) so a shadow failure can never break the live run.
+    // MEMORY-001 Step 3 (strangler, flag-OFF today): while MEMORY_ENABLED is
+    // false this whole branch is dead code and the G2 recall below is the ONLY
+    // thing that ever runs — byte-identical to pre-Step-3 behavior. When the
+    // flag is eventually flipped, activateMemoryRecall's rendered context is
+    // injected INSTEAD OF G2's, but a `null` return (any internal MEMORY-001
+    // failure) falls back to the G2 result computed below rather than to no
+    // recall at all — G2 is the on-device-verified path, so falling back to IT
+    // is safer than silently dropping the agent's memory.
+    let recallContext: string | null = null;
     if (MEMORY_ENABLED) {
       await shadowMemoryRecall(agent, notes).catch(() => {});
+      recallContext = await activateMemoryRecall(agent, notes);
     }
-    if (notes.length > 0) {
-      const relevant = recallMemoryNotes(notes, `${agent.name}\n${agent.prompt}`);
-      const recallContext = buildRecallContext(relevant);
-      if (recallContext) prompt = `${recallContext}\n\n---\n\n${prompt}`;
+    if (recallContext === null) {
+      if (notes.length > 0) {
+        const relevant = recallMemoryNotes(notes, `${agent.name}\n${agent.prompt}`);
+        recallContext = buildRecallContext(relevant);
+      } else {
+        recallContext = '';
+      }
     }
+    if (recallContext) prompt = `${recallContext}\n\n---\n\n${prompt}`;
   } catch {
     // best-effort
   }
@@ -393,6 +403,22 @@ async function persistRememberFact(
 ): Promise<void> {
   const fact = agent.memory?.rememberFact?.trim();
   if (!fact) return;
+  // MEMORY-001 Step 4 (strangler, flag-OFF today): while MEMORY_ENABLED is
+  // false this branch never runs and G2's writeMemoryNote below is the ONLY
+  // write path — byte-identical to pre-Step-4 behavior. When the flag is
+  // flipped, activateMemoryWrite (which reuses G2's own makeMemoryNote for
+  // normalization) replaces the G2 write; a `false` return (any internal
+  // MEMORY-001 failure) falls back to G2's write rather than silently losing
+  // the fact.
+  if (MEMORY_ENABLED) {
+    const ok = await activateMemoryWrite({
+      agentId: agent.id,
+      type: 'fact',
+      text: fact,
+      tags: agent.memory?.tags,
+    });
+    if (ok) return;
+  }
   try {
     await writeMemoryNote(
       runCommand,
@@ -748,6 +774,17 @@ async function captureRunMemory(
   if (!latest || latest.status !== 'success') return;
   const digest = extractRunDigest(latest.outputPreview || '');
   if (!digest) return;
+  // MEMORY-001 Step 4 (strangler, flag-OFF today): see persistRememberFact for
+  // the fallback rationale — same G2-fallback-on-failure contract applies here.
+  if (MEMORY_ENABLED) {
+    const ok = await activateMemoryWrite({
+      agentId,
+      type: 'result',
+      text: digest,
+      tags: agent.memory?.tags,
+    });
+    if (ok) return;
+  }
   try {
     await writeMemoryNote(
       runCommand,

--- a/lib/memory/embedding-llama.ts
+++ b/lib/memory/embedding-llama.ts
@@ -1,0 +1,33 @@
+// MEMORY-001 memory layer — llama-server embedding port (DEFERRED).
+//
+// Interface-conformant skeleton only. Semantic/hybrid recall is optional; the
+// core and all host tests pass with NO embedding port. When wired (behind
+// MEMORY_EMBEDDING_ENABLED), embeddings come ONLY from the localhost
+// llama-server (127.0.0.1:8080 /embedding) via the HTTP-001 capability broker —
+// never a cloud embedder, no unmediated egress. Memory text is local-sensitive,
+// so it must never leave the device for a third-party embedder.
+//
+// This file pulls NO network dependency at module load and is NOT re-exported
+// from index.ts until the flag-ON cutover.
+
+import { EmbeddingPort } from './types';
+
+const NOT_WIRED =
+  'LlamaEmbeddingPort is deferred until the MEMORY-001 embedding flag-ON cutover';
+
+export interface LlamaEmbeddingPortOptions {
+  // Localhost llama-server embedding endpoint, reached through the HTTP broker.
+  endpoint: string; // e.g. 'http://127.0.0.1:8080/embedding'
+}
+
+export class LlamaEmbeddingPort implements EmbeddingPort {
+  private readonly endpoint: string;
+
+  constructor(opts: LlamaEmbeddingPortOptions) {
+    this.endpoint = opts.endpoint;
+  }
+
+  async embed(_texts: string[]): Promise<number[][]> {
+    throw new Error(NOT_WIRED);
+  }
+}

--- a/lib/memory/fs-expo.ts
+++ b/lib/memory/fs-expo.ts
@@ -1,0 +1,77 @@
+// MEMORY-001 memory layer — expo-file-system FsPort adapter (device side).
+//
+// Fulfils the FsPort contract from ./types over expo-file-system/legacy — the
+// SAME import surface lib/agent-memory.ts (readMemoryNotes) already uses on
+// device, so the shadow store reads through the identical, known-good Expo path
+// as the live G2 memory. Host tests never load this file (they inject
+// __tests__/support/node-fs-port.ts instead); it only runs on device, and only
+// when a MEMORY_ENABLED path (shadow.ts today) asks for a port. Dormant:
+// "実装されるが有効化はされない."
+
+import * as FileSystem from 'expo-file-system/legacy';
+import { Clock, FsPort } from './types';
+
+// Injected wall clock for MemoryStore on device — the pure core never reads
+// Date.now directly (see types.ts Clock), so the device wiring supplies it.
+export const systemClock: Clock = { now: () => Date.now() };
+
+// Expo FileSystem wants file:// URIs; the storage adapter passes plain paths
+// (same normalization agent-memory's toFileUri does).
+function toFileUri(path: string): string {
+  return path.startsWith('file://') ? path : `file://${path}`;
+}
+
+export function createExpoFsPort(): FsPort {
+  return {
+    async readFile(path: string): Promise<string | null> {
+      try {
+        return await FileSystem.readAsStringAsync(toFileUri(path));
+      } catch {
+        // The legacy API throws a generic error for a missing file with no
+        // ENOENT-style code to discriminate on, so ANY read failure maps to
+        // null ("not there"). The JSON adapter already tolerates missing/
+        // corrupt records, so this degrades to a skipped record, never a crash.
+        return null;
+      }
+    },
+    async writeFileAtomic(path: string, data: string): Promise<void> {
+      // Atomic-ish on Android: write the full payload to a .tmp sibling first,
+      // then move it over the target. moveAsync maps to a rename which is not
+      // guaranteed to REPLACE an existing destination across Android storage
+      // providers, so we delete-then-move. Documented crash window: a crash
+      // between delete and move loses the OLD record, but the NEW content is
+      // complete in the .tmp sibling and the target is never half-written —
+      // acceptable for the shadow store whose ground truth stays G2's .md
+      // files. (.tmp lacks the .json suffix, so loadNamespace never reads a
+      // leftover temp file as a record.)
+      const uri = toFileUri(path);
+      const tmpUri = `${uri}.tmp`;
+      await FileSystem.writeAsStringAsync(tmpUri, data);
+      await FileSystem.deleteAsync(uri, { idempotent: true });
+      await FileSystem.moveAsync({ from: tmpUri, to: uri });
+    },
+    async deleteFile(path: string): Promise<void> {
+      // idempotent: deleting a missing file is a no-op, mirroring node-fs-port's
+      // ENOENT swallow so both ports satisfy the same contract.
+      await FileSystem.deleteAsync(toFileUri(path), { idempotent: true });
+    },
+    async listFiles(dir: string): Promise<string[]> {
+      try {
+        return await FileSystem.readDirectoryAsync(toFileUri(dir));
+      } catch {
+        // Missing dir => empty listing (node-fs-port parity).
+        return [];
+      }
+    },
+    async ensureDir(dir: string): Promise<void> {
+      // Check-then-make instead of relying on makeDirectoryAsync tolerating an
+      // existing dir: legacy Android builds have thrown "directory exists" even
+      // with intermediates:true, and mkdir -p semantics are the contract.
+      const uri = toFileUri(dir);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (!info.exists) {
+        await FileSystem.makeDirectoryAsync(uri, { intermediates: true });
+      }
+    },
+  };
+}

--- a/lib/memory/index.ts
+++ b/lib/memory/index.ts
@@ -1,0 +1,22 @@
+// MEMORY-001 memory layer — public surface.
+//
+// Dormant Phase 1 primitive: a thin namespaced get/put/query memory store over
+// FS-001 scoped.fs, reproducing G2's recall ranking. Flag-OFF (see wiring.ts);
+// no production path imports it yet. The deferred sqlite-FTS5 and llama
+// embedding adapters are intentionally NOT re-exported until the flag-ON cutover.
+
+export * from './types';
+export { deriveKey, tokenize, scoreRecord, rankHits } from './ranking';
+export { cosineSimilarity } from './ranking-semantic';
+export { MemoryStore } from './memory-store';
+export type { MemoryStoreOptions, PutInput } from './memory-store';
+export { InMemoryMemoryStorage } from './storage-memory';
+export { JsonFileMemoryStorage, assertWithinRoot } from './storage-json';
+export type { JsonFileMemoryStorageOptions } from './storage-json';
+export {
+  MEMORY_ENABLED,
+  MEMORY_EMBEDDING_ENABLED,
+  agentNamespace,
+  g2NoteToRecord,
+  recordsToRecallContext,
+} from './wiring';

--- a/lib/memory/memory-store.ts
+++ b/lib/memory/memory-store.ts
@@ -1,0 +1,151 @@
+// MEMORY-001 memory layer — the pure get/put/query core.
+//
+// Depends only on ./types, ./ranking, and injected ports (adapter/clock/
+// optional embedding). No FS, no Date.now, no expo. Namespace routing,
+// deterministic keys, injected-clock timestamps, and optional embedding re-rank
+// live here; all persistence goes through the MemoryStorageAdapter boundary.
+
+import { cosineSimilarity } from './ranking-semantic';
+import { compareHits, deriveKey, matchesFilter } from './ranking';
+import {
+  Clock,
+  DEFAULT_RECALL_LIMIT,
+  EmbeddingPort,
+  MemoryHit,
+  MemoryKind,
+  MemoryQuery,
+  MemoryRecord,
+  MemoryStorageAdapter,
+  MEMORY_SCHEMA_VERSION,
+  ResolvedQuery,
+} from './types';
+
+export interface MemoryStoreOptions {
+  adapter: MemoryStorageAdapter;
+  clock: Clock;
+  // Absent => 'fulltext' only; 'semantic'/'hybrid' degrade to 'fulltext'.
+  embedding?: EmbeddingPort;
+}
+
+export interface PutInput {
+  namespace: string;
+  text: string;
+  // Default deriveKey(namespace, kind, text) — idempotent overwrite.
+  key?: string;
+  kind?: MemoryKind;
+  tags?: string[];
+  metadata?: Record<string, string>;
+}
+
+function normalizeTags(tags: string[] | undefined): string[] {
+  if (!tags) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of tags) {
+    const tag = raw
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (tag && !seen.has(tag)) {
+      seen.add(tag);
+      out.push(tag);
+    }
+  }
+  return out;
+}
+
+export class MemoryStore {
+  private readonly adapter: MemoryStorageAdapter;
+  private readonly clock: Clock;
+  private readonly embedding?: EmbeddingPort;
+
+  constructor(opts: MemoryStoreOptions) {
+    this.adapter = opts.adapter;
+    this.clock = opts.clock;
+    this.embedding = opts.embedding;
+  }
+
+  // Upsert. On overwrite, createdAt is preserved and updatedAt advances.
+  async put(input: PutInput): Promise<MemoryRecord> {
+    const now = this.clock.now();
+    const kind: MemoryKind = input.kind ?? 'fact';
+    const text = input.text.trim();
+    const key = input.key ?? deriveKey(input.namespace, kind, text);
+    const existing = await this.adapter.get(input.namespace, key);
+
+    const record: MemoryRecord = {
+      namespace: input.namespace,
+      key,
+      schemaVersion: MEMORY_SCHEMA_VERSION,
+      kind,
+      text,
+      tags: normalizeTags(input.tags),
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      metadata: input.metadata,
+    };
+    await this.adapter.put(record);
+    return record;
+  }
+
+  async get(namespace: string, key: string): Promise<MemoryRecord | null> {
+    return this.adapter.get(namespace, key);
+  }
+
+  async delete(namespace: string, key: string): Promise<void> {
+    return this.adapter.delete(namespace, key);
+  }
+
+  private resolve(q: MemoryQuery | undefined): ResolvedQuery {
+    const requested = q?.mode ?? 'fulltext';
+    // Degrade to fulltext when no embedding port is available.
+    const mode = requested === 'fulltext' || this.embedding ? requested : 'fulltext';
+    return {
+      text: q?.text ?? '',
+      tags: q?.tags ?? [],
+      kind: q?.kind,
+      limit: q?.limit ?? DEFAULT_RECALL_LIMIT,
+      mode,
+    };
+  }
+
+  async query(namespace: string, q?: MemoryQuery): Promise<MemoryHit[]> {
+    const resolved = this.resolve(q);
+
+    // Full-text (default): the adapter ranks (FTS5 emulation / MATCH+bm25).
+    if (resolved.mode === 'fulltext' || !this.embedding || !resolved.text) {
+      return this.adapter.query(namespace, { ...resolved, mode: 'fulltext' });
+    }
+
+    // Semantic / hybrid: embed the query, re-rank by cosine similarity. Hybrid
+    // prefilters with the full-text ranking (a wider candidate window) before
+    // the embedding re-rank; semantic scores the whole namespace.
+    const [queryEmbedding] = await this.embedding.embed([resolved.text]);
+    const candidates =
+      resolved.mode === 'hybrid'
+        ? // hybrid: full-text prefilter (already kind/tag-filtered) then re-rank.
+          (
+            await this.adapter.query(namespace, {
+              ...resolved,
+              mode: 'fulltext',
+              limit: Math.max(resolved.limit * 4, resolved.limit),
+            })
+          ).map((h) => h.record)
+        : // semantic: whole namespace, but apply the SAME kind/tag filter so the
+          // filters behave identically across modes (list() is unfiltered).
+          (await this.adapter.list(namespace)).filter((r) => matchesFilter(r, resolved));
+
+    const reranked: MemoryHit[] = candidates.map((record) => ({
+      record,
+      score: record.embedding
+        ? cosineSimilarity(queryEmbedding, record.embedding)
+        : 0,
+    }));
+    // compareHits gives a deterministic (score desc, createdAt desc, key asc)
+    // order, so embedding-less records (e.g. migrated G2 records, all score 0)
+    // fall back to recency instead of unstable adapter/fs order.
+    reranked.sort(compareHits);
+    return reranked.slice(0, resolved.limit);
+  }
+}

--- a/lib/memory/ranking-semantic.ts
+++ b/lib/memory/ranking-semantic.ts
@@ -1,0 +1,20 @@
+// MEMORY-001 memory layer — semantic similarity (optional embedding re-rank).
+//
+// Pure. Used only when an EmbeddingPort is injected (semantic/hybrid mode). Kept
+// separate from the full-text ranking so the default path pulls in no vector math.
+
+// Cosine similarity in [-1, 1]; 0 when either vector is empty/zero-norm or the
+// dimensions differ (defensive — a mismatched embedding never throws here).
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length === 0 || a.length !== b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/lib/memory/ranking.ts
+++ b/lib/memory/ranking.ts
@@ -1,0 +1,84 @@
+// MEMORY-001 memory layer — full-text ranking (the FTS5 emulation contract).
+//
+// This is the exact G2 recall scoring (lib/agent-memory.ts recallMemoryNotes):
+// tag overlap ×2 + token overlap ×1, recency (createdAt desc) tiebreak, using
+// the shared offline tokenizer. The bundled-sqlite FTS5 adapter (deferred) must
+// reproduce this ordering (MATCH + bm25); host tests prove the contract on this
+// pure ranking so the two stay in parity across the eventual cutover.
+
+import { tokenizeForMatch } from '@/lib/agent-text-match';
+import { MemoryHit, MemoryRecord, ResolvedQuery } from './types';
+
+export const tokenize = tokenizeForMatch;
+
+// Stable, collision-resistant-enough short id (djb2 → base36), byte-identical to
+// G2's shortHash. Deterministic key = idempotent overwrite of the same content.
+function shortHash(input: string): string {
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5) + h + input.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(36);
+}
+
+// NUL field delimiter, byte-identical to G2 memoryNoteId: it hashes
+// `agentId \0 type \0 text.trim()`. NUL can't appear in normal text, so it keeps
+// the field boundaries injective (no "ab|c" vs "a|bc" collision).
+const KEY_FIELD_SEP = '\u0000';
+
+// Mirrors G2 memoryNoteId(agentId,type,text) exactly (same djb2 shortHash, same
+// NUL-delimited field order, same `${kind}-` prefix) with namespace in the
+// agentId slot, so a per-agent namespace reproduces the SAME key across the G2
+// migration — a re-remembered fact collapses onto its migrated record.
+export function deriveKey(namespace: string, kind: string, text: string): string {
+  return `${kind}-${shortHash(`${namespace}${KEY_FIELD_SEP}${kind}${KEY_FIELD_SEP}${text.trim()}`)}`;
+}
+
+// G2-identical overlap score: +2 per matching tag, +1 per matching text/tag
+// token. taskTokens = tokenize(query text).
+export function scoreRecord(record: MemoryRecord, taskTokens: Set<string>): number {
+  const noteTokens = tokenize(`${record.text} ${record.tags.join(' ')}`);
+  let overlap = 0;
+  for (const tag of record.tags) if (taskTokens.has(tag)) overlap += 2;
+  for (const tok of noteTokens) if (taskTokens.has(tok)) overlap += 1;
+  return overlap;
+}
+
+// Shared kind/tag filter, applied by every query mode (fulltext ranking AND the
+// semantic candidate set) so filters behave identically across modes.
+export function matchesFilter(record: MemoryRecord, q: ResolvedQuery): boolean {
+  if (q.kind !== undefined && record.kind !== q.kind) return false;
+  if (q.tags.length > 0 && !q.tags.every((t) => record.tags.includes(t))) return false;
+  return true;
+}
+
+// Deterministic ordering shared by fulltext and the semantic re-rank: score desc,
+// then recency (createdAt desc), then key asc as a final stable tiebreak.
+// NOTE: for records with an identical (score, createdAt), G2 recallMemoryNotes
+// breaks ties by directory-read order; that order is not reproducible from the
+// adapter's unordered set, so we use key asc — deterministic on both sides, and
+// only observably different when two notes share the exact same ms timestamp.
+export function compareHits(a: MemoryHit, b: MemoryHit): number {
+  if (b.score !== a.score) return b.score - a.score;
+  if (b.record.createdAt !== a.record.createdAt) {
+    return b.record.createdAt - a.record.createdAt;
+  }
+  return a.record.key < b.record.key ? -1 : a.record.key > b.record.key ? 1 : 0;
+}
+
+// Rank records for a resolved query. Applies kind/tag filters, scores full-text
+// overlap, and orders by compareHits.
+export function rankHits(records: MemoryRecord[], q: ResolvedQuery): MemoryHit[] {
+  const filtered = records.filter((r) => matchesFilter(r, q));
+
+  const taskTokens = q.text ? tokenize(q.text) : new Set<string>();
+  const scored = filtered.map((record) => ({
+    record,
+    // Empty query => pure recency listing (score 0 for all).
+    score: q.text ? scoreRecord(record, taskTokens) : 0,
+  }));
+
+  scored.sort(compareHits);
+
+  return scored.slice(0, q.limit);
+}

--- a/lib/memory/shadow.ts
+++ b/lib/memory/shadow.ts
@@ -1,0 +1,170 @@
+// MEMORY-001 memory layer — Step 2 shadow-read seam (dormant, flag-OFF).
+//
+// Called from agent-manager's applyMemoryAndSkills behind MEMORY_ENABLED. While
+// the flag is false (today, always) shadowMemoryRecall returns before touching
+// any state, so live behavior stays byte-identical to G2-only. When the flag is
+// eventually flipped, this module: (a) mirrors the agent's G2 notes into the
+// NEW memory-v2 store (a sibling dir — G2's .md files are never read or
+// written by the store, so deleting memory-v2/ reverts everything), (b) replays
+// the exact recall query G2 ran, and (c) logs order/content divergence between
+// the two results. G2's recall remains the ONLY thing injected into the prompt;
+// the shadow result is observability, not behavior. Strangler convention:
+// additive, reversible, "実装されるが有効化はされない."
+
+import { logInfo, logWarn } from '@/lib/debug-logger';
+import { getHomePath } from '@/lib/home-path';
+import {
+  buildRecallContext,
+  recallMemoryNotes,
+  type MemoryNote,
+} from '@/lib/agent-memory';
+import { MemoryStore } from './memory-store';
+import { JsonFileMemoryStorage } from './storage-json';
+import { createExpoFsPort, systemClock } from './fs-expo';
+import {
+  DEFAULT_RECALL_LIMIT,
+  MemoryHit,
+  MemoryStorageAdapter,
+} from './types';
+import {
+  MEMORY_ENABLED,
+  agentNamespace,
+  g2NoteToRecord,
+  recordsToRecallContext,
+} from './wiring';
+
+const LOG_MODULE = 'MemoryShadow';
+
+// NEW dir, sibling of G2's `.shelly/agents/memory/` — the shadow store must
+// never touch G2's on-disk notes (they stay authoritative and byte-preserved).
+function shadowRootDir(): string {
+  return `${getHomePath()}/.shelly/agents/memory-v2`;
+}
+
+export interface ShadowDeps {
+  adapter: MemoryStorageAdapter;
+  store: MemoryStore;
+  // Session-scoped "already mirrored" set: the import is idempotent anyway
+  // (upsert by key), this just avoids re-writing every note on every run.
+  importedAgents: Set<string>;
+}
+
+// Lazy singleton: the expo FsPort + store are only constructed the first time a
+// flag-ON shadow pass actually runs, so the dormant (flag-OFF) app pays zero
+// cost and host tests never construct the expo port.
+let sharedDeps: ShadowDeps | null = null;
+
+function getShadowDeps(): ShadowDeps {
+  if (!sharedDeps) {
+    const adapter = new JsonFileMemoryStorage(createExpoFsPort(), {
+      root: shadowRootDir(),
+    });
+    sharedDeps = {
+      adapter,
+      store: new MemoryStore({ adapter, clock: systemClock }),
+      importedAgents: new Set<string>(),
+    };
+  }
+  return sharedDeps;
+}
+
+export interface ShadowComparison {
+  liveKeys: string[];
+  shadowKeys: string[];
+  // Same records in the same order (G2 note id === shadow record key).
+  orderMatches: boolean;
+  // The rendered recall block is identical (what WOULD reach the prompt).
+  contextMatches: boolean;
+}
+
+// Pure comparator — exported so the divergence logic is host-testable without
+// any store or fs. Live G2 recall vs shadow hits: order by id/key, content by
+// the exact recall-context string each side would inject.
+export function compareShadowRecall(
+  liveRecalled: MemoryNote[],
+  shadowHits: MemoryHit[]
+): ShadowComparison {
+  const liveKeys = liveRecalled.map((n) => n.id);
+  const shadowKeys = shadowHits.map((h) => h.record.key);
+  const orderMatches =
+    liveKeys.length === shadowKeys.length &&
+    liveKeys.every((key, i) => key === shadowKeys[i]);
+  const contextMatches =
+    buildRecallContext(liveRecalled) === recordsToRecallContext(shadowHits);
+  return { liveKeys, shadowKeys, orderMatches, contextMatches };
+}
+
+// The unconditional import→query→compare pipeline, separated from the flag
+// gate so host tests can exercise it with an injected in-memory store while
+// MEMORY_ENABLED stays false. `notes` is the same newest-first list
+// applyMemoryAndSkills already read via readMemoryNotes (no double disk read).
+export async function runShadowComparison(
+  agent: { id: string; name: string; prompt: string },
+  notes: MemoryNote[],
+  deps: ShadowDeps
+): Promise<ShadowComparison> {
+  const namespace = agentNamespace(agent.id);
+
+  // (b) One-time-per-agent mirror import. adapter.put (NOT store.put) on
+  // purpose: store.put would stamp createdAt=now for new records, and the
+  // ranking's recency tiebreak would then reflect import time instead of the
+  // G2 note's created timestamp — a guaranteed false divergence. The full
+  // g2NoteToRecord record preserves createdAt, and adapter.put is the same
+  // upsert-by-(namespace,key) so re-imports are idempotent.
+  if (!deps.importedAgents.has(agent.id)) {
+    for (const note of notes) {
+      await deps.adapter.put(g2NoteToRecord(note));
+    }
+    deps.importedAgents.add(agent.id);
+  }
+
+  // (c) Replay the exact query G2 runs in applyMemoryAndSkills: same task text,
+  // same limit (DEFAULT_RECALL_LIMIT on both sides).
+  const taskText = `${agent.name}\n${agent.prompt}`;
+  const shadowHits = await deps.store.query(namespace, {
+    text: taskText,
+    limit: DEFAULT_RECALL_LIMIT,
+  });
+
+  // (d) Compare against the live G2 recall (recomputed with the same pure
+  // function agent-manager uses — identical input, identical result).
+  const liveRecalled = recallMemoryNotes(notes, taskText);
+  return compareShadowRecall(liveRecalled, shadowHits);
+}
+
+/**
+ * Shadow a G2 memory recall. No-op while MEMORY_ENABLED is false. Never throws
+ * and never changes what gets injected into the prompt — a shadow failure is
+ * logged and swallowed so it cannot break the live run.
+ */
+export async function shadowMemoryRecall(
+  agent: { id: string; name: string; prompt: string },
+  notes: MemoryNote[]
+): Promise<void> {
+  // Master dormancy gate (wiring.ts). Everything below is dead code until the
+  // separate, device-verified "enable" decision flips the flag.
+  if (!MEMORY_ENABLED) return;
+  try {
+    const cmp = await runShadowComparison(agent, notes, getShadowDeps());
+    if (cmp.orderMatches && cmp.contextMatches) {
+      logInfo(
+        LOG_MODULE,
+        `shadow recall parity for agent ${agent.id}: ${cmp.shadowKeys.length} hits match G2`
+      );
+    } else {
+      // Divergence is a finding, not a failure: G2 stays authoritative either way.
+      logWarn(LOG_MODULE, `shadow recall DIVERGED for agent ${agent.id}`, {
+        liveKeys: cmp.liveKeys,
+        shadowKeys: cmp.shadowKeys,
+        orderMatches: cmp.orderMatches,
+        contextMatches: cmp.contextMatches,
+      });
+    }
+  } catch (error) {
+    logWarn(
+      LOG_MODULE,
+      'shadow recall failed (live run unaffected)',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}

--- a/lib/memory/shadow.ts
+++ b/lib/memory/shadow.ts
@@ -1,22 +1,29 @@
-// MEMORY-001 memory layer — Step 2 shadow-read seam (dormant, flag-OFF).
+// MEMORY-001 memory layer — Step 2 shadow-read seam + Step 3 activated recall
+// + Step 4 activated write (dormant, flag-OFF).
 //
-// Called from agent-manager's applyMemoryAndSkills behind MEMORY_ENABLED. While
-// the flag is false (today, always) shadowMemoryRecall returns before touching
-// any state, so live behavior stays byte-identical to G2-only. When the flag is
-// eventually flipped, this module: (a) mirrors the agent's G2 notes into the
-// NEW memory-v2 store (a sibling dir — G2's .md files are never read or
-// written by the store, so deleting memory-v2/ reverts everything), (b) replays
-// the exact recall query G2 ran, and (c) logs order/content divergence between
-// the two results. G2's recall remains the ONLY thing injected into the prompt;
-// the shadow result is observability, not behavior. Strangler convention:
-// additive, reversible, "実装されるが有効化はされない."
+// Called from agent-manager's applyMemoryAndSkills / persistRememberFact /
+// captureRunMemory, all behind MEMORY_ENABLED. While the flag is false (today,
+// always) shadowMemoryRecall, activateMemoryRecall, and activateMemoryWrite are
+// all unreachable (agent-manager only calls the latter two inside
+// `if (MEMORY_ENABLED)`), so live behavior stays byte-identical to G2-only.
+// When the flag is eventually flipped, this module: (a) mirrors the agent's G2
+// notes into the NEW memory-v2 store (a sibling dir — G2's .md files are never
+// read or written by the store, so deleting memory-v2/ reverts everything),
+// (b) replays the exact recall query G2 ran, and (c) either logs order/content
+// divergence (shadowMemoryRecall, observability-only), actually renders the
+// MEMORY-001 result into the recall context that reaches the prompt
+// (activateMemoryRecall, Step 3), or writes a new fact/result straight into the
+// MEMORY-001 store instead of a G2 .md file (activateMemoryWrite, Step 4).
+// Strangler convention: additive, reversible, "実装されるが有効化はされない."
 
 import { logInfo, logWarn } from '@/lib/debug-logger';
 import { getHomePath } from '@/lib/home-path';
 import {
   buildRecallContext,
+  makeMemoryNote,
   recallMemoryNotes,
   type MemoryNote,
+  type MemoryNoteType,
 } from '@/lib/agent-memory';
 import { MemoryStore } from './memory-store';
 import { JsonFileMemoryStorage } from './storage-json';
@@ -24,6 +31,7 @@ import { createExpoFsPort, systemClock } from './fs-expo';
 import {
   DEFAULT_RECALL_LIMIT,
   MemoryHit,
+  MemoryRecord,
   MemoryStorageAdapter,
 } from './types';
 import {
@@ -94,15 +102,16 @@ export function compareShadowRecall(
   return { liveKeys, shadowKeys, orderMatches, contextMatches };
 }
 
-// The unconditional import→query→compare pipeline, separated from the flag
-// gate so host tests can exercise it with an injected in-memory store while
-// MEMORY_ENABLED stays false. `notes` is the same newest-first list
-// applyMemoryAndSkills already read via readMemoryNotes (no double disk read).
-export async function runShadowComparison(
+// Shared import→query step used by both the Step 2 shadow comparator and the
+// Step 3 activated recall path below: one-time-per-agent mirror import of the
+// G2 notes, then the exact query G2's recallMemoryNotes would run. Kept in one
+// place so activation can never drift from what the shadow comparator has
+// already verified byte-for-byte against G2.
+async function importAndQuery(
   agent: { id: string; name: string; prompt: string },
   notes: MemoryNote[],
   deps: ShadowDeps
-): Promise<ShadowComparison> {
+): Promise<{ namespace: string; taskText: string; hits: MemoryHit[] }> {
   const namespace = agentNamespace(agent.id);
 
   // (b) One-time-per-agent mirror import. adapter.put (NOT store.put) on
@@ -121,10 +130,23 @@ export async function runShadowComparison(
   // (c) Replay the exact query G2 runs in applyMemoryAndSkills: same task text,
   // same limit (DEFAULT_RECALL_LIMIT on both sides).
   const taskText = `${agent.name}\n${agent.prompt}`;
-  const shadowHits = await deps.store.query(namespace, {
+  const hits = await deps.store.query(namespace, {
     text: taskText,
     limit: DEFAULT_RECALL_LIMIT,
   });
+  return { namespace, taskText, hits };
+}
+
+// The unconditional import→query→compare pipeline, separated from the flag
+// gate so host tests can exercise it with an injected in-memory store while
+// MEMORY_ENABLED stays false. `notes` is the same newest-first list
+// applyMemoryAndSkills already read via readMemoryNotes (no double disk read).
+export async function runShadowComparison(
+  agent: { id: string; name: string; prompt: string },
+  notes: MemoryNote[],
+  deps: ShadowDeps
+): Promise<ShadowComparison> {
+  const { taskText, hits: shadowHits } = await importAndQuery(agent, notes, deps);
 
   // (d) Compare against the live G2 recall (recomputed with the same pure
   // function agent-manager uses — identical input, identical result).
@@ -166,5 +188,103 @@ export async function shadowMemoryRecall(
       'shadow recall failed (live run unaffected)',
       error instanceof Error ? error.message : String(error)
     );
+  }
+}
+
+/**
+ * MEMORY-001 Step 3 — activated recall. Only ever called from agent-manager
+ * inside `if (MEMORY_ENABLED)`, so it is unreachable dead code while the flag
+ * stays false; nothing here changes today's byte-identical G2 behavior.
+ *
+ * Runs the same import→query pipeline as shadowMemoryRecall but returns the
+ * MEMORY-001 store's rendered recall context instead of only comparing it.
+ * Returns `null` (not `''`) on ANY internal failure so the caller can tell
+ * "activation broke" apart from "activation succeeded, nothing to recall" and
+ * fall back to the G2 result — G2 is the proven, on-device-verified path, so
+ * falling back to ITS result is strictly safer than falling back to no recall
+ * at all (a fresh MEMORY-001 bug should degrade to "today's behavior", not to
+ * "the agent silently loses its memory"). Never throws.
+ *
+ * `deps` defaults to the lazy device singleton; agent-manager always omits it.
+ * Host tests pass an injected in-memory ShadowDeps so the success path is
+ * exercisable without expo-file-system.
+ */
+export async function activateMemoryRecall(
+  agent: { id: string; name: string; prompt: string },
+  notes: MemoryNote[],
+  deps: ShadowDeps = getShadowDeps()
+): Promise<string | null> {
+  try {
+    const { hits } = await importAndQuery(agent, notes, deps);
+    return recordsToRecallContext(hits);
+  } catch (error) {
+    logWarn(
+      LOG_MODULE,
+      'activated recall failed, caller should fall back to G2 (live run unaffected)',
+      error instanceof Error ? error.message : String(error)
+    );
+    return null;
+  }
+}
+
+/**
+ * MEMORY-001 Step 4 — activated write. Only ever called from agent-manager's
+ * persistRememberFact / captureRunMemory inside `if (MEMORY_ENABLED)`, so it is
+ * unreachable dead code while the flag stays false.
+ *
+ * Builds the record through G2's OWN makeMemoryNote (same trim, MAX_NOTE_CHARS
+ * truncation, tag normalization, and deterministic id derivation G2 applies to
+ * every write) and converts it with g2NoteToRecord, so the MEMORY-001 write
+ * path is bound to reuse G2's normalization rather than re-implement (and
+ * risk drifting from) it. store.put (NOT adapter.put) is deliberate here,
+ * unlike the migration importer: this is a brand-new fact being recorded now,
+ * so it should get a fresh createdAt from the injected clock, exactly like a
+ * new G2 note gets `new Date().toISOString()` at write time.
+ *
+ * NOTE (gap, not fixed here): G2's write path has no secret-redaction step of
+ * its own — writeMemoryNote persists whatever text makeMemoryNote produces,
+ * and the ONLY secret-guard scan happens later, at recall-injection time, when
+ * resolveAgentRoute scans the EFFECTIVE agent.prompt (which by then includes
+ * any recalled note). Because activateMemoryWrite reuses makeMemoryNote
+ * verbatim, it inherits exactly this behavior — no better, no worse than G2.
+ * Returns false (not throw) on any internal failure so the caller can fall
+ * back to G2's writeMemoryNote; never throws.
+ *
+ * `deps` defaults to the lazy device singleton; agent-manager always omits it.
+ * Host tests pass an injected in-memory ShadowDeps so the success path is
+ * exercisable without expo-file-system.
+ */
+export async function activateMemoryWrite(
+  params: {
+    agentId: string;
+    type: MemoryNoteType;
+    text: string;
+    tags?: string[];
+  },
+  deps: ShadowDeps = getShadowDeps()
+): Promise<boolean> {
+  try {
+    const note = makeMemoryNote({
+      agentId: params.agentId,
+      type: params.type,
+      text: params.text,
+      tags: params.tags,
+    });
+    const record: MemoryRecord = g2NoteToRecord(note);
+    await deps.store.put({
+      namespace: record.namespace,
+      key: record.key,
+      kind: record.kind,
+      text: record.text,
+      tags: record.tags,
+    });
+    return true;
+  } catch (error) {
+    logWarn(
+      LOG_MODULE,
+      'activated write failed, caller should fall back to G2 (live run unaffected)',
+      error instanceof Error ? error.message : String(error)
+    );
+    return false;
   }
 }

--- a/lib/memory/storage-json.ts
+++ b/lib/memory/storage-json.ts
@@ -1,0 +1,144 @@
+// MEMORY-001 memory layer — JSON file storage adapter (FS-001 scoped.fs jailed).
+//
+// Durable backend: one JSON file per record under <root>/<namespace>/<key>.json,
+// written atomically through an injected FsPort (node-fs in host tests,
+// expo-file-system on device via a deferred fs-expo). Imports no fs/expo directly.
+//
+// Every read/write/delete/list path is checked through classifyFsAccess (the
+// FS-001 lexical root-jail) BEFORE any I/O: a namespace or key that resolves
+// outside the declared root is denied and nothing is touched. Device symlink
+// hardening (realpath) is the broker's job, exactly as capability-fs.ts documents.
+
+import { classifyFsAccess, FsOperation } from '@/lib/capability-fs';
+import {
+  FsPort,
+  MemoryHit,
+  MemoryRecord,
+  MemoryStorageAdapter,
+  ResolvedQuery,
+} from './types';
+import { rankHits } from './ranking';
+
+const FILE_SUFFIX = '.json';
+
+function joinPath(dir: string, name: string): string {
+  return dir.endsWith('/') ? `${dir}${name}` : `${dir}/${name}`;
+}
+
+// encodeURIComponent is injective and emits no path separator, so distinct
+// namespaces/keys never collide and a crafted key cannot inject a '/'. Note it
+// does NOT neutralize a bare '..' segment (dots are unreserved), so a namespace
+// like '..' becomes <root>/.. — that escape is caught by assertWithinRoot's
+// canonicalization, not the encoder. Both defenses run; the guard is authoritative.
+function segment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+// FS-001 root-jail: canonicalize `path` against `root` and throw if it escapes.
+// The segment encoder above is the primary escape defense; this is defense in
+// depth that also catches any future code path that builds an unencoded path.
+// Exported so the jail is unit-testable without reaching into the adapter.
+export function assertWithinRoot(root: string, op: FsOperation, path: string): void {
+  const verdict = classifyFsAccess({ op, path, roots: [root], cwd: root });
+  if (verdict.decision !== 'allow') {
+    throw new Error(`scoped.fs denied ${op}: ${verdict.reason}`);
+  }
+}
+
+function isWellFormed(value: unknown): value is MemoryRecord {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.namespace === 'string' &&
+    typeof r.key === 'string' &&
+    typeof r.kind === 'string' &&
+    typeof r.text === 'string' &&
+    Array.isArray(r.tags) &&
+    typeof r.createdAt === 'number' &&
+    typeof r.updatedAt === 'number'
+    // kind is an open union — presence of the string fields above is enough.
+  );
+}
+
+export interface JsonFileMemoryStorageOptions {
+  root: string;
+}
+
+export class JsonFileMemoryStorage implements MemoryStorageAdapter {
+  private readonly fs: FsPort;
+  private readonly root: string;
+
+  constructor(fs: FsPort, opts: JsonFileMemoryStorageOptions) {
+    this.fs = fs;
+    this.root = opts.root;
+  }
+
+  // Root-jail gate: deny anything that escapes the declared root before I/O.
+  private guard(op: FsOperation, path: string): void {
+    assertWithinRoot(this.root, op, path);
+  }
+
+  private nsDir(namespace: string): string {
+    return joinPath(this.root, segment(namespace));
+  }
+
+  private fileFor(namespace: string, key: string): string {
+    return joinPath(this.nsDir(namespace), `${segment(key)}${FILE_SUFFIX}`);
+  }
+
+  async put(record: MemoryRecord): Promise<void> {
+    const dir = this.nsDir(record.namespace);
+    const file = this.fileFor(record.namespace, record.key);
+    this.guard('write', file);
+    await this.fs.ensureDir(dir);
+    await this.fs.writeFileAtomic(file, JSON.stringify(record));
+  }
+
+  async get(namespace: string, key: string): Promise<MemoryRecord | null> {
+    const file = this.fileFor(namespace, key);
+    this.guard('read', file);
+    const raw = await this.fs.readFile(file);
+    if (raw === null) return null;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isWellFormed(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadNamespace(namespace: string): Promise<MemoryRecord[]> {
+    const dir = this.nsDir(namespace);
+    this.guard('list', dir);
+    await this.fs.ensureDir(dir);
+    const names = await this.fs.listFiles(dir);
+    const out: MemoryRecord[] = [];
+    for (const name of names) {
+      if (!name.endsWith(FILE_SUFFIX)) continue;
+      const raw = await this.fs.readFile(joinPath(dir, name));
+      if (raw === null) continue;
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        // Tolerate one corrupt/foreign file instead of bricking the namespace.
+        if (isWellFormed(parsed)) out.push(parsed);
+      } catch {
+        continue;
+      }
+    }
+    return out;
+  }
+
+  async query(namespace: string, q: ResolvedQuery): Promise<MemoryHit[]> {
+    return rankHits(await this.loadNamespace(namespace), q);
+  }
+
+  async delete(namespace: string, key: string): Promise<void> {
+    const file = this.fileFor(namespace, key);
+    this.guard('write', file);
+    await this.fs.deleteFile(file);
+  }
+
+  async list(namespace: string): Promise<MemoryRecord[]> {
+    return this.loadNamespace(namespace);
+  }
+}

--- a/lib/memory/storage-memory.ts
+++ b/lib/memory/storage-memory.ts
@@ -1,0 +1,52 @@
+// MEMORY-001 memory layer — in-memory storage adapter.
+//
+// Default backend for host tests. Pure: a nested Map (namespace -> key ->
+// record) with a defensive copy on every boundary. query() ranks via the shared
+// rankHits so it matches the file/sqlite adapters.
+
+import { rankHits } from './ranking';
+import {
+  MemoryHit,
+  MemoryRecord,
+  MemoryStorageAdapter,
+  ResolvedQuery,
+} from './types';
+
+function clone(record: MemoryRecord): MemoryRecord {
+  return JSON.parse(JSON.stringify(record)) as MemoryRecord;
+}
+
+export class InMemoryMemoryStorage implements MemoryStorageAdapter {
+  private store = new Map<string, Map<string, MemoryRecord>>();
+
+  private ns(namespace: string): Map<string, MemoryRecord> {
+    let m = this.store.get(namespace);
+    if (!m) {
+      m = new Map();
+      this.store.set(namespace, m);
+    }
+    return m;
+  }
+
+  async put(record: MemoryRecord): Promise<void> {
+    this.ns(record.namespace).set(record.key, clone(record));
+  }
+
+  async get(namespace: string, key: string): Promise<MemoryRecord | null> {
+    const r = this.store.get(namespace)?.get(key);
+    return r ? clone(r) : null;
+  }
+
+  async query(namespace: string, q: ResolvedQuery): Promise<MemoryHit[]> {
+    const records = [...(this.store.get(namespace)?.values() ?? [])].map(clone);
+    return rankHits(records, q);
+  }
+
+  async delete(namespace: string, key: string): Promise<void> {
+    this.store.get(namespace)?.delete(key);
+  }
+
+  async list(namespace: string): Promise<MemoryRecord[]> {
+    return [...(this.store.get(namespace)?.values() ?? [])].map(clone);
+  }
+}

--- a/lib/memory/storage-sqlite.ts
+++ b/lib/memory/storage-sqlite.ts
@@ -1,0 +1,60 @@
+// MEMORY-001 memory layer — bundled-sqlite FTS5 storage adapter (DEFERRED).
+//
+// Interface-conformant skeleton only. The bundled-sqlite native binding is not
+// loadable in the jest node env, so this adapter is host-UNtestable; the memory
+// contract is proven on the pure in-memory + JSON-file path (which reproduces
+// FTS ordering via the shared rankHits). This file pulls NO native dependency at
+// module load — the sqlite handle is opened lazily inside methods, only on
+// device and only behind MEMORY_ENABLED. It is intentionally NOT re-exported
+// from index.ts until the flag-ON cutover.
+//
+// FTS5 mapping (to implement at cutover): one row per record in an
+// `fts5(text, tags, content=...)` virtual table; query() = `... MATCH ?
+// ORDER BY bm25(...)`, whose ordering MUST match lib/memory/ranking.ts rankHits
+// (tag-weighted overlap, recency tiebreak) so recall parity holds across the
+// JSON<->sqlite choice. put() = upsert by (namespace, key); delete()/list()
+// scoped by namespace column.
+
+import {
+  MemoryHit,
+  MemoryRecord,
+  MemoryStorageAdapter,
+  ResolvedQuery,
+} from './types';
+
+const NOT_WIRED =
+  'SqliteFtsMemoryStorage is deferred until the MEMORY-001 flag-ON cutover';
+
+export interface SqliteFtsMemoryStorageOptions {
+  // Path to the bundled-sqlite database file (device-only, scoped.fs jailed).
+  dbPath: string;
+}
+
+export class SqliteFtsMemoryStorage implements MemoryStorageAdapter {
+  private readonly dbPath: string;
+
+  constructor(opts: SqliteFtsMemoryStorageOptions) {
+    // No native binding opened here — construction is cheap and dep-free.
+    this.dbPath = opts.dbPath;
+  }
+
+  async put(_record: MemoryRecord): Promise<void> {
+    throw new Error(NOT_WIRED);
+  }
+
+  async get(_namespace: string, _key: string): Promise<MemoryRecord | null> {
+    throw new Error(NOT_WIRED);
+  }
+
+  async query(_namespace: string, _q: ResolvedQuery): Promise<MemoryHit[]> {
+    throw new Error(NOT_WIRED);
+  }
+
+  async delete(_namespace: string, _key: string): Promise<void> {
+    throw new Error(NOT_WIRED);
+  }
+
+  async list(_namespace: string): Promise<MemoryRecord[]> {
+    throw new Error(NOT_WIRED);
+  }
+}

--- a/lib/memory/types.ts
+++ b/lib/memory/types.ts
@@ -1,0 +1,102 @@
+// MEMORY-001 memory layer — shared types and ports.
+//
+// Pure, dependency-free contract for the Phase 1 memory primitive: a thin
+// get/put/query store, namespaced per skill/agent, over an injected storage
+// adapter. Imports nothing at runtime — the core (memory-store.ts) and every
+// adapter depend only on these types plus injected ports, so the whole
+// primitive is host-testable and free of Date.now / fs / expo.
+//
+// Dormant: nothing here is wired into a production path yet (see wiring.ts,
+// MEMORY_ENABLED). The live memory path is still G2 (lib/agent-memory.ts),
+// which is byte-preserved. "実装されるが有効化はされない."
+
+// Bump only alongside a persisted-record shape change. FUTURE LOCKSTEP POINT:
+// once the bundled-sqlite adapter or a native/script consumer reads persisted
+// records, mirror this exactly like PLAN_SPEC_SCHEMA_VERSION (TS constant +
+// script asset + AgentRuntime.CURRENT_* + a parity test). No mirror is required
+// while memory is a dormant TS-only library. See wiring.ts §migration.
+export const MEMORY_SCHEMA_VERSION = 1;
+
+// Open string union: 'fact' | 'preference' | 'result' mirror G2's MemoryNoteType
+// (byte-preserved), but callers may namespace other kinds. Default is 'fact'.
+export type MemoryKind = 'fact' | 'preference' | 'result' | (string & {});
+
+export interface MemoryRecord {
+  // Per-skill (per-agent today — see wiring.ts §migration) isolation boundary.
+  namespace: string;
+  // Stable id within the namespace (deterministic from content, or caller-supplied).
+  key: string;
+  schemaVersion: typeof MEMORY_SCHEMA_VERSION;
+  kind: MemoryKind;
+  // Searchable body.
+  text: string;
+  tags: string[];
+  // Epoch ms (injected Clock — no Date.now in the core).
+  createdAt: number;
+  updatedAt: number;
+  // Small opaque kv; never interpreted by the query.
+  metadata?: Record<string, string>;
+  // Present only when an EmbeddingPort produced it (semantic/hybrid mode).
+  embedding?: number[];
+}
+
+export type MemoryMode = 'fulltext' | 'semantic' | 'hybrid';
+
+export interface MemoryQuery {
+  // Full-text query. Empty/undefined => recency listing.
+  text?: string;
+  // Optional AND filter on tags.
+  tags?: string[];
+  // Optional filter on kind.
+  kind?: MemoryKind;
+  limit?: number;
+  // Default 'fulltext'. 'semantic'/'hybrid' require an EmbeddingPort; without
+  // one they silently degrade to 'fulltext'.
+  mode?: MemoryMode;
+}
+
+export interface ResolvedQuery {
+  text: string;
+  tags: string[];
+  kind?: MemoryKind;
+  limit: number;
+  mode: MemoryMode;
+}
+
+export interface MemoryHit {
+  record: MemoryRecord;
+  score: number;
+}
+
+// The single storage boundary. One JSON file per record (host/device) or one
+// FTS5 row (deferred, flag-gated). Scoped to a namespace on every call.
+export interface MemoryStorageAdapter {
+  put(record: MemoryRecord): Promise<void>; // upsert by (namespace, key)
+  get(namespace: string, key: string): Promise<MemoryRecord | null>;
+  query(namespace: string, q: ResolvedQuery): Promise<MemoryHit[]>; // ranked, ns-scoped
+  delete(namespace: string, key: string): Promise<void>;
+  list(namespace: string): Promise<MemoryRecord[]>; // inspection / migration
+}
+
+// Injected, OPTIONAL. Never required by the core or host tests. Implementations
+// must stay local (llama-server) and broker-mediated — never a cloud embedder.
+export interface EmbeddingPort {
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+// Injected clock — the core never reads wall-clock time directly.
+export interface Clock {
+  now(): number;
+}
+
+// Adapter boundary port for file-backed storage. Mirrors EVENT-001's FsPort so
+// the same node-fs / expo-file-system implementations satisfy both by shape.
+export interface FsPort {
+  readFile(path: string): Promise<string | null>;
+  writeFileAtomic(path: string, data: string): Promise<void>;
+  deleteFile(path: string): Promise<void>;
+  listFiles(dir: string): Promise<string[]>;
+  ensureDir(dir: string): Promise<void>;
+}
+
+export const DEFAULT_RECALL_LIMIT = 5;

--- a/lib/memory/wiring.ts
+++ b/lib/memory/wiring.ts
@@ -1,0 +1,69 @@
+// MEMORY-001 memory layer — dormant wiring seam + G2 migration helpers.
+//
+// Documents the future cutover from G2 (lib/agent-memory.ts) WITHOUT enabling
+// it. Memory is implemented (pure core + adapters + tests) but wired into no
+// production path: MEMORY_ENABLED stays false, G2 remains the live memory path
+// and its on-disk .md notes stay authoritative and byte-preserved.
+// "実装されるが有効化はされない."
+//
+// MIGRATION (deferred, flag-ON step, out of scope until the floor is verified):
+//   1. Flip MEMORY_ENABLED. One-time importer: readMemoryNotes(agentId) ->
+//      g2NoteToRecord -> MemoryStore.put; G2 .md files left untouched (reversible
+//      dual-copy).
+//   2. agent-manager swaps readMemoryNotes/recallMemoryNotes/writeMemoryNote for
+//      MemoryStore.query/put + recordsToRecallContext; Sidebar count -> list().length.
+//   3. Choose device backend (JSON vs sqlite-FTS5) and per-agent vs per-skill
+//      namespace granularity at cutover.
+//   Ranking parity is the safety net: MemoryStore's full-text ranking reuses the
+//   exact G2 scoring, so recall ordering is preserved across the cutover.
+
+import type { MemoryNote } from '@/lib/agent-memory';
+import { MemoryHit, MemoryRecord, MEMORY_SCHEMA_VERSION } from './types';
+
+// Master dormancy switch. Never flipped by this work — flipping it is the
+// separate "enable" decision, gated on a device-verified floor.
+export const MEMORY_ENABLED = false;
+
+// Optional semantic re-rank via localhost llama-server, broker-mediated only.
+// Off by default and independent of MEMORY_ENABLED.
+export const MEMORY_EMBEDDING_ENABLED = false;
+
+// Per-agent namespace today (documents the per-agent-now / per-skill-later
+// generalization noted in the spec). Deterministic and stable.
+export function agentNamespace(agentId: string): string {
+  return agentId;
+}
+
+// Map a live G2 note onto a MemoryRecord. id->key, agentId->namespace,
+// type->kind, ISO created -> epoch ms (createdAt==updatedAt at import), tags/text
+// preserved. A bad ISO timestamp falls back to 0 so the import never throws.
+export function g2NoteToRecord(note: MemoryNote): MemoryRecord {
+  const parsed = Date.parse(note.created);
+  const createdAt = Number.isNaN(parsed) ? 0 : parsed;
+  return {
+    namespace: agentNamespace(note.agentId),
+    key: note.id,
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    kind: note.type,
+    text: note.text,
+    tags: note.tags,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+// Reproduce G2 buildRecallContext's format from ranked records, so a recalled
+// block still flows through the same secret-guard scan as the G2 path.
+export function recordsToRecallContext(hits: MemoryHit[]): string {
+  if (hits.length === 0) return '';
+  const MAX_RECALL_NOTE_CHARS = 400;
+  const lines = hits.map((h) => {
+    const text = h.record.text.replace(/\s+/g, ' ').slice(0, MAX_RECALL_NOTE_CHARS);
+    return `- [${h.record.kind}] ${text}`;
+  });
+  return [
+    '# Remembered context (on-device memory)',
+    'These facts were saved from earlier runs or by the user. Use them if relevant.',
+    ...lines,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

Ports MEMORY-001 (persistent per-skill-namespaced memory: get/put/query) from `claude/work-handoff-2qb1xd` to `main`, following the Phase 1 roadmap in `docs/superpowers/specs/2026-07-01-l1-l2-capability-catalog.md`.

- 3 feature commits ported with identical patch IDs.
- Backend is JSON files over Expo FS (not yet bundled SQLite/FTS5 -- the roadmap's "FS-001 + SQLite FTS5" target is only partially implemented; real SQLite/FTS5 is tracked as follow-up scope).
- Depends on FS-001 (`lib/capability-fs.ts`, merged via PR #107) and the already-landed G2 memory format (PR #86) for migration/ranking parity.
- Does NOT depend on MODEL-001, PlanSpec, EVENT-001, or signed approval (verified, no imports).

## Dormancy

`MEMORY_ENABLED = false` by default, no production setter. Fresh-install behavior unchanged.

## Disclosed privacy gap (tracked separately in DEFERRED.md)

Memory is stored **plaintext at rest**, with no write-time redaction or general PII/taint classification. Recalled content is inserted into the effective prompt. Known secret patterns are rescanned via the existing `scanForSecrets` mechanism and force local-only execution, but sensitive prose not recognized as a secret pattern could still reach a cloud model later if MODEL-001's cloud routing is ever flag-enabled alongside this. This is a limitation of the source design, not something newly introduced by this port -- ported as-is (dormant), disclosed here and tracked as a P1 DEFERRED.md entry for follow-up before either flag is ever enabled together.

## Verification

- `pnpm run check`: PASS
- `pnpm run lint` (`expo lint`): PASS, 0 errors, 2 pre-existing unrelated warnings
- Memory tests: 49/49 PASS
- `git diff --check`: PASS

## Not in scope

Do not merge without CC review, per this session's standing process.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>