### PR TITLE
test(plan-executor): raise CI-flaky orchestration test timeout to 20s

### DIFF
--- a/__tests__/plan-executor-orchestration.test.ts
+++ b/__tests__/plan-executor-orchestration.test.ts
@@ -125,6 +125,11 @@ describe('shelly-plan-executor orchestration (Option B per-step contract)', () =
   });
 
   it('carries prior-step results into the next step and only the final step notifies', async () => {
+    // Spawns two real child-process executor runs sequentially, each polled via a
+    // 40ms approval interval -- comfortably under Jest's 5000ms default locally, but
+    // observed to intermittently exceed it under GitHub Actions CI's shared CPU
+    // (PR #107 CI run 29224790020, 2026-07-13). Explicit longer timeout, not a
+    // change to executor behavior.
     const home = makeHome();
     autoApprove(home);
     const notifyFile = path.join(home, `.shelly/agents/logs/${AGENT_ID}/native-result-notification.json`);
@@ -159,7 +164,7 @@ describe('shelly-plan-executor orchestration (Option B per-step contract)', () =
     expect(runLogs.length).toBeGreaterThanOrEqual(1);
     const lastLog = JSON.parse(fs.readFileSync(path.join(logDir, runLogs.sort()[runLogs.length - 1]), 'utf8'));
     expect(lastLog).toMatchObject({ status: 'success', executor: 'planspec', toolUsed: 'Local LLM' });
-  });
+  }, 20000);
 });
 
 function listMd(dir: string): string[] {


### PR DESCRIPTION
## What

`__tests__/plan-executor-orchestration.test.ts`'s single test spawns two real child-process executor runs sequentially, each polled via a 40ms approval interval. Bumped its Jest timeout from the 5000ms default to 20000ms.

## Why

Observed CI failure tonight: PR #107's CI run ([29224790020](https://github.com/RYOITABASHI/Shelly/actions/runs/29224790020)) failed this exact test with `Exceeded timeout of 5000 ms for a test`, while the immediately prior CI run (PR #104) and the immediately subsequent one (PR #103) both passed cleanly with the same test file — consistent with CI-load flakiness on GitHub Actions' shared CPU, not a deterministic bug. Two full node child-process spawns plus real I/O and a poll loop comfortably fit under 5s locally but can occasionally cross it under CI load.

No production or executor logic changed — test-only timeout bump.

## Verification

- `tsc --noEmit` clean.
- Could not run this specific test locally: it (and 3 sibling suites) hit a pre-existing, already-documented Windows-only `mkdir 'C:\C:\Users\...'` double-drive-letter path artifact unrelated to this change (confirmed by reproducing the identical error in the unmodified sibling `plan-executor.test.ts` on the same machine). This bug is Windows-local-dev-only; GitHub Actions CI runs on Linux and does not hit it, so CI on this PR is the real verification for this fix.