### PR TITLE
fix(agent-nl): explicit draft wording wins over 通知 trigger-condition word

### DIFF
--- a/__tests__/agent-nl-parser.test.ts
+++ b/__tests__/agent-nl-parser.test.ts
@@ -408,6 +408,15 @@ describe('parseAgentNL — action layer (capability boundary)', () => {
   it('a bare "通知" with no draft/下書き mention still resolves to notify (regression guard for the fix above)', () => {
     expect(parseAgentNL('LINEで通知が来たら教えて').action.type).toBe('notify');
   });
+
+  it('the mirror case also resolves correctly: 下書き as the trigger condition, 通知 as the delivery action', () => {
+    // Found during review of the fix above: naively prioritizing draft-keywords
+    // over notify-keywords fixes "通知(条件)+ドラフト(動作)" but breaks the mirror
+    // "下書き(条件)+通知(動作)" case the same way. Scoping both keyword scans to
+    // the clause after "たら" (the delivery clause) resolves both directions.
+    expect(parseAgentNL('下書きができたら通知して').action.type).toBe('notify');
+    expect(parseAgentNL('下書きを保存したらLINEで知らせて').action.type).toBe('notify');
+  });
 });
 
 describe('parseAgentNL — invariants', () => {

--- a/__tests__/agent-nl-parser.test.ts
+++ b/__tests__/agent-nl-parser.test.ts
@@ -394,6 +394,20 @@ describe('parseAgentNL — action layer (capability boundary)', () => {
   it('generic task does NOT escalate to cli', () => {
     expect(parseAgentNL('毎日8時に要約を作って').action.type).toBe('draft');
   });
+
+  it('an explicit "ドラフト" mention wins over "通知" used as a NOTIFY-001 trigger-condition word, not a delivery verb', () => {
+    // Live on-device bug (2026-07-13): "LINEで通知が来たら…ドラフトを作成して" was
+    // misclassified as action=notify because detectAction's notify check matched
+    // the bare "通知" substring, even though it describes the notification-trigger
+    // CONDITION here, not the delivery action -- the user explicitly asked for a
+    // draft. The explicit "ドラフト" signal must take priority.
+    const d = parseAgentNL('LINEで通知が来たら「新着メッセージあり」ってドラフトを作成して');
+    expect(d.action.type).toBe('draft');
+  });
+
+  it('a bare "通知" with no draft/下書き mention still resolves to notify (regression guard for the fix above)', () => {
+    expect(parseAgentNL('LINEで通知が来たら教えて').action.type).toBe('notify');
+  });
 });
 
 describe('parseAgentNL — invariants', () => {

--- a/lib/agent-nl-parser.ts
+++ b/lib/agent-nl-parser.ts
@@ -445,6 +445,15 @@ function detectAction(text: string): AgentAction {
   // -- that's the only part of the sentence that actually names the delivery.
   // No "たら" at all (e.g. "毎日20時30分に通知して") scans the whole text, same
   // as before this fix.
+  //
+  // Known residual limitation (low severity -- always human-gated via the
+  // confirm card's editable action picker before registration): a compound
+  // utterance with a SECOND, trailing "たら" clause after the real delivery
+  // verb truncates that verb out of scope, e.g. "毎朝ニュースが届いたら通知
+  // して、余裕があったら要約も作って" falls to the default draft instead of
+  // notify, because slicing after the LAST "たら" drops "通知して". Rare in
+  // practice (needs two chained conditionals in one utterance); not fixed
+  // here, no known simple fix without deeper clause parsing.
   const talaIndex = text.lastIndexOf('たら');
   const actionScope = talaIndex >= 0 ? text.slice(talaIndex + 2) : text;
 

--- a/lib/agent-nl-parser.ts
+++ b/lib/agent-nl-parser.ts
@@ -436,6 +436,15 @@ function detectAction(text: string): AgentAction {
     return { type: 'cli' };
   }
 
+  // An explicit "draft"/"下書き" mention wins over a bare "通知" keyword hit below.
+  // "通知" is ambiguous: it's also this project's own NOTIFY-001 trigger-condition
+  // word ("LINEで通知が来たら…") -- when the SAME utterance also names the
+  // delivery explicitly ("…ドラフトを作成して"), that's the stronger, more
+  // specific signal and must not be shadowed by the trigger-condition mention.
+  if (/ドラフト|下書き|\bdraft\b/i.test(text)) {
+    return { type: 'draft' };
+  }
+
   // notify — explicit delivery-by-notification verbs.
   if (/通知|知らせ|教えて|リマインド|アラート|notify|alert|\bremind\b|tell me|push notification/i.test(lower)) {
     return { type: 'notify' };

--- a/lib/agent-nl-parser.ts
+++ b/lib/agent-nl-parser.ts
@@ -421,8 +421,6 @@ const URL_RE = /https?:\/\/[^\s、。)）]+/i;
 
 /** Detect the delivery action. Default = draft. Never returns 'publish'. */
 function detectAction(text: string): AgentAction {
-  const lower = text.toLowerCase();
-
   // webhook — an explicit URL is the strongest signal.
   const url = text.match(URL_RE);
   if (url || /webhook|フック/i.test(text)) {
@@ -436,17 +434,26 @@ function detectAction(text: string): AgentAction {
     return { type: 'cli' };
   }
 
-  // An explicit "draft"/"下書き" mention wins over a bare "通知" keyword hit below.
-  // "通知" is ambiguous: it's also this project's own NOTIFY-001 trigger-condition
-  // word ("LINEで通知が来たら…") -- when the SAME utterance also names the
-  // delivery explicitly ("…ドラフトを作成して"), that's the stronger, more
-  // specific signal and must not be shadowed by the trigger-condition mention.
-  if (/ドラフト|下書き|\bdraft\b/i.test(text)) {
+  // A conditional utterance ("Xたら、Y") names its trigger CONDITION before the
+  // "たら" marker and its delivery ACTION after it -- e.g. "通知が来たらドラフトを
+  // 作成して" (条件=通知, 動作=ドラフト) vs "下書きができたら通知して" (条件=下書き,
+  // 動作=通知). "通知" and "下書き/ドラフト" are each both a NOTIFY-001
+  // trigger-condition word AND a delivery-action keyword in this project, so
+  // scanning the WHOLE string for either would misread whichever one happens to
+  // describe the condition as if it were the delivery type. Restrict both
+  // keyword scans below to the clause after the LAST "たら" when one is present
+  // -- that's the only part of the sentence that actually names the delivery.
+  // No "たら" at all (e.g. "毎日20時30分に通知して") scans the whole text, same
+  // as before this fix.
+  const talaIndex = text.lastIndexOf('たら');
+  const actionScope = talaIndex >= 0 ? text.slice(talaIndex + 2) : text;
+
+  if (/ドラフト|下書き|\bdraft\b/i.test(actionScope)) {
     return { type: 'draft' };
   }
 
   // notify — explicit delivery-by-notification verbs.
-  if (/通知|知らせ|教えて|リマインド|アラート|notify|alert|\bremind\b|tell me|push notification/i.test(lower)) {
+  if (/通知|知らせ|教えて|リマインド|アラート|notify|alert|\bremind\b|tell me|push notification/i.test(actionScope.toLowerCase())) {
     return { type: 'notify' };
   }
 


### PR DESCRIPTION
## What

`detectAction()` in `lib/agent-nl-parser.ts` matched a bare `通知` substring anywhere in the utterance as a signal for `action: notify` — but `通知` is ambiguous in this project: it's also NOTIFY-001's own trigger-condition word.

## Why this matters

Caught live tonight testing NOTIFY-001 end-to-end: `LINEで通知が来たら「新着メッセージあり」ってドラフトを作成して` (when a LINE notification arrives, create a draft saying "new message") registered with `action: notify` instead of `action: draft`, even though the user explicitly asked for a draft. The `通知` in `通知が来たら` describes the trigger *condition*, not the delivery action.

## Fix (2 commits)

1. First commit: an explicit `ドラフト`/`下書き`/`draft` mention wins over a bare `通知` keyword hit.
2. **Second commit, after review caught a mirror false-positive**: prioritizing draft-keywords over notify-keywords fixed "通知(条件)+ドラフト(動作)" but broke the inverse "下書き(条件)+通知(動作)" case the same way — e.g. `下書きができたら通知して` (notify me when the draft is ready) now wrongly resolved to draft. Root cause is structural: in a conditional utterance ("Xたら、Y"), the trigger condition is named before "たら" and the delivery action is named after it. Fixed by scoping BOTH the draft-keyword and notify-keyword scans to the clause after the last "たら" when the utterance has one — only that clause actually names the delivery. No "たら" at all falls back to scanning the whole text, unchanged from before.

## Verification

- `__tests__/agent-nl-parser.test.ts`: 80/80 pass (77 existing + 3 new: the original bug, the bare-通知 regression guard, and the mirror-case regression guard).
- `git diff --check` clean.
- `tsc --noEmit` clean for the touched files (an unrelated error surfaces from an untracked in-progress Codex task's leftover directory `worktrees-local/capability-cosmetics/` in the shared repo — not from this PR).

## Scope note

`parseAgentNL` does not currently populate `notificationTrigger` from natural language at all (confirmed via grep — zero matches) — a user still has to manually type a package name into the confirm card's notification-trigger field, regardless of this fix. That's a separate, larger gap and out of scope here; this PR only fixes the draft-vs-notify action misclassification.