### PR TITLE
fix(ai): port capability grounding and cosmetic hydration

### DIFF
--- a/__tests__/ai-pane-context.test.ts
+++ b/__tests__/ai-pane-context.test.ts
@@ -92,3 +92,29 @@ describe('AI pane terminal context', () => {
     expect(prompt).toContain('untrusted data');
   });
 });
+
+describe('AI pane capability grounding', () => {
+  it('always includes at least the ambient feature catalog', () => {
+    const noPrompt = buildAIPaneSystemPrompt(null, null, null);
+    const ordinary = buildAIPaneSystemPrompt(null, null, null, 'fix foo.ts');
+
+    expect(noPrompt).toContain('<SHELLY_FEATURES>');
+    expect(ordinary).toContain('<SHELLY_FEATURES>');
+  });
+
+  it('upgrades cloud prompts for recognized capability questions', () => {
+    const ambient = buildAIPaneSystemPrompt(null, null, null, 'fix foo.ts');
+    const upgraded = buildAIPaneSystemPrompt(null, null, null, '何が出来る？');
+
+    expect(upgraded.length).toBeGreaterThan(ambient.length);
+    expect(upgraded).toContain("The user's message looks like a question");
+    expect(ambient).not.toContain("The user's message looks like a question");
+  });
+
+  it('keeps local prompts on the compact ambient catalog', () => {
+    const prompt = buildLocalAIPaneSystemPrompt(null);
+
+    expect(prompt).toContain('<SHELLY_FEATURES>');
+    expect(prompt).not.toContain("The user's message looks like a question");
+  });
+});

--- a/__tests__/ask-context.test.ts
+++ b/__tests__/ask-context.test.ts
@@ -1,0 +1,44 @@
+import {
+  buildAmbientCapabilityBlock,
+  buildCapabilityGroundingBlock,
+  isCapabilityQuestion,
+} from '@/lib/ask-context';
+
+describe('isCapabilityQuestion', () => {
+  it('matches common English and Japanese capability phrasing', () => {
+    expect(isCapabilityQuestion('what can you do?')).toBe(true);
+    expect(isCapabilityQuestion('how do I schedule an agent?')).toBe(true);
+    expect(isCapabilityQuestion('Shellyは何ができるの？')).toBe(true);
+    expect(isCapabilityQuestion('SSH接続できますか？')).toBe(true);
+  });
+
+  it('matches kanji 出来る as well as hiragana できる', () => {
+    expect(isCapabilityQuestion('何が出来る？')).toBe(true);
+    expect(isCapabilityQuestion('何が出来るの？')).toBe(true);
+    expect(isCapabilityQuestion('SSH接続出来ますか？')).toBe(true);
+    expect(isCapabilityQuestion('これ出来るの？')).toBe(true);
+  });
+
+  it('does not match ordinary messages', () => {
+    expect(isCapabilityQuestion('fix the null pointer in foo.ts')).toBe(false);
+    expect(isCapabilityQuestion('このエラーを直して')).toBe(false);
+    expect(isCapabilityQuestion(undefined)).toBe(false);
+  });
+});
+
+describe('capability grounding blocks', () => {
+  it('keeps the ambient catalog names-only and shorter than the full catalog', () => {
+    const ambient = buildAmbientCapabilityBlock();
+    const full = buildCapabilityGroundingBlock();
+
+    expect(ambient).toContain('<SHELLY_FEATURES>');
+    expect(ambient.length).toBeLessThan(full.length);
+    expect(ambient).not.toMatch(/- .+: .+/);
+    expect(full).toMatch(/- .+: .+/);
+  });
+
+  it('uses a neutral ambient primer and a question-specific upgrade primer', () => {
+    expect(buildAmbientCapabilityBlock()).not.toContain("The user's message looks like a question");
+    expect(buildCapabilityGroundingBlock()).toContain("The user's message looks like a question");
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ import { t, useI18n } from '@/lib/i18n';
 import { useThemeStore } from '@/lib/theme-engine';
 import { useA11yStore } from '@/lib/accessibility';
 import { usePluginStore } from '@/lib/plugin-api';
+import { useCosmeticStore } from '@/store/cosmetic-store';
 import { useSettingsStore } from '@/store/settings-store';
 import { useDmPairingStore } from '@/store/dm-pairing-store';
 import * as Linking from 'expo-linking';
@@ -232,6 +233,8 @@ export default function RootLayout() {
     logInfo('RootLayout', 'Loaded: a11y');
     usePluginStore.getState().loadPlugins();
     logInfo('RootLayout', 'Loaded: plugins');
+    useCosmeticStore.getState().loadCosmetics();
+    logInfo('RootLayout', 'Loaded: cosmetics');
     useDmPairingStore.getState().loadPairings();
     logInfo('RootLayout', 'Loaded: dm-pairings');
 

--- a/docs/superpowers/DEFERRED.md
+++ b/docs/superpowers/DEFERRED.md
@@ -2182,6 +2182,8 @@ claude() {
 
 - **2026-07-13 (signed-approval レビュー是正: fail-closed バイパス修正)**: PR #115 の独立 Codex レビューで実バグを発見（CC 側の並行レビューは見逃した）: `scripts/shelly-plan-executor.js` の承認 reply ポーリングで、flag-ON 検証分岐が `SIGNED_APPROVAL_ENABLED && reply.sigAlg && reply.signature && reply.keySha256 && reply.nonce` という `&&` 条件でガードされており、flag が true でも reply が署名フィールドを1つでも欠くと条件が false になり、署名検証なしの naive `runId`+`requestSha256` 一致チェックへそのまま fall-through していた — enable した瞬間に signed approval の意味が失われる bypass。修正 (`73e2a07e7`): `SIGNED_APPROVAL_ENABLED` が true の分岐を独立させ、署名フィールド欠落 reply は naive チェックに到達する前に `ActionSkipped` で即座に reject するよう再構成（flag OFF 時は naive チェックのみ到達、挙動不変）。実プロセスを spawn し run-log JSON の `status`/`errorMessage` を検証する回帰テスト2件を追加（`ActionSkipped` は accept/decline とも exit code 0 のため、プロセス終了コードでは判定不可と判明・記録）。Codex 再レビュー + CC 側再レビューの両方で bypass 修正済みを確認後 merge。→ sync: なし（既定 OFF の内部基盤、今回も挙動変化なし）。
 
+- **2026-07-13 (capability grounding + cosmetics catch-up batch)**: dev branch の `097d1cc25` / `a43869cc2` / `ebafb16b2` を current `main` へ手動再構成。AI Chat は全 provider で names-only feature catalog を常時 ambient 注入し、cloud の capability question のみ full catalog へ upgrade、local は context budget 保護のため常時 compact のままとした。日本語 classifier はひらがな `できる` に加えて漢字 `出来る` を回帰テストで固定。RootLayout の既存 store hydration effect から `loadCosmetics()` を呼び、persist 済み wallpaper / CRT / panel 設定を cold start 時に復元する。→ sync: なし（既存機能の grounding / startup restore 修正で README surface 変更なし）。
+
 ---
 
 ## 管理ルール (自分への覚書)

--- a/hooks/use-ai-pane-dispatch.ts
+++ b/hooks/use-ai-pane-dispatch.ts
@@ -542,7 +542,7 @@ export function useAIPaneDispatch(paneId: string) {
         );
         const systemPrompt = (agent === 'local'
           ? buildLocalAIPaneSystemPrompt(promptTerminalCtx)
-          : buildAIPaneSystemPrompt(promptTerminalCtx, agent, stagedFile))
+          : buildAIPaneSystemPrompt(promptTerminalCtx, agent, stagedFile, promptText))
           + detectPostFormatDirective(promptText);
         const conv = store.getOrCreate(paneId);
         // Exclude the streaming placeholder and the current user message;

--- a/lib/ai-pane-context.ts
+++ b/lib/ai-pane-context.ts
@@ -7,6 +7,11 @@
 
 import { useTerminalStore } from '@/store/terminal-store';
 import { useExecutionLogStore } from '@/store/execution-log-store';
+import {
+  buildAmbientCapabilityBlock,
+  buildCapabilityGroundingBlock,
+  isCapabilityQuestion,
+} from './ask-context';
 
 // Match common terminal escape/control sequences, including CSI cursor
 // controls emitted by TUIs such as Codex. AI context should contain the
@@ -197,12 +202,15 @@ export function getTerminalSnapshotForSession(
  * @param terminalContext Output of getTerminalSnapshot(), or null.
  * @param agentName       Agent bound to the current pane (e.g. "codex"), or null.
  * @param stagedFile      File primed for editing (from auto-stage / stageAiEdit).
+ * @param promptText      Current user message, used only to upgrade the ambient
+ *                        feature catalog to the full descriptive catalog.
  * @returns Full system prompt string.
  */
 export function buildAIPaneSystemPrompt(
   terminalContext: string | null,
   agentName: string | null,
   stagedFile?: { path: string; content: string } | null,
+  promptText?: string,
 ): string {
   const parts: string[] = [
     'You are Shelly AI, a terminal assistant. You can see the user\'s terminal output.',
@@ -246,6 +254,12 @@ export function buildAIPaneSystemPrompt(
     );
   }
 
+  parts.push(
+    '\n' + (isCapabilityQuestion(promptText)
+      ? buildCapabilityGroundingBlock()
+      : buildAmbientCapabilityBlock()),
+  );
+
   return parts.join('\n');
 }
 
@@ -259,6 +273,9 @@ export function buildLocalAIPaneSystemPrompt(terminalContext: string | null): st
   if (terminalContext) {
     parts.push('\n[Terminal Output]\n' + terminalContext + '\n[End Terminal Output]');
   }
+
+  // Local models stay on the compact catalog even when the classifier matches.
+  parts.push('\n' + buildAmbientCapabilityBlock());
 
   return parts.join('\n');
 }

--- a/lib/ask-context.ts
+++ b/lib/ask-context.ts
@@ -12,7 +12,7 @@
  * ships in one commit without touching the build pipeline.
  */
 
-import { FEATURE_CATALOG, type Feature } from './feature-catalog';
+import { FEATURE_CATALOG, getCompressedCatalog, type Feature } from './feature-catalog';
 
 const PRIMER = `
 You are the ASK Pane of Shelly — a chat-first terminal IDE for Android
@@ -116,4 +116,48 @@ export function extractStatus(text: string): AskStatus {
  */
 export function stripStatusTag(text: string): string {
   return text.replace(/\s*\[?(AVAILABLE|PLANNED|NOT_AVAILABLE)\]?\s*$/, '').trimEnd();
+}
+
+// ─── Capability-question detection (main AI Chat grounding) ──────────────────
+
+export function isCapabilityQuestion(text: string | null | undefined): boolean {
+  if (!text) return false;
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  const lower = trimmed.toLowerCase();
+
+  // Include both hiragana できる and the common kanji form 出来る.
+  const jaPatterns =
+    /(何が(でき|出来)|なにが(でき|出来)|使い方|使えます?か|使える(の|機能|？|\?)|って機能|機能あります?か|機能ある|(でき|出来)ます?か|(でき|出来)るの|(でき|出来)る[？?]|どうやって|やり方|の仕方|設定方法|方法(を|は)教えて)/;
+  const enPatterns =
+    /\b(what can (you|shelly) do|how do i\b|how to\b|how can i\b|can shelly\b|does shelly\b|is there a way to\b|what features\b|what does shelly\b|how does shelly\b|are you able to\b)/;
+
+  return jaPatterns.test(trimmed) || enPatterns.test(lower);
+}
+
+const CAPABILITY_GROUNDING_PRIMER =
+  "The user's message looks like a question about what Shelly can do or how " +
+  'to use it. Answer grounded in Shelly\'s real feature catalog below — be ' +
+  'concrete, reference actual feature names, and do not invent capabilities ' +
+  "that aren't listed. If nothing below covers what they're asking, say so " +
+  'plainly instead of guessing.';
+
+const AMBIENT_CAPABILITY_PRIMER =
+  "For reference (not necessarily relevant to this message) — Shelly's real " +
+  'feature names. If the user asks what Shelly can do or how to use ' +
+  "something, answer grounded in this list and don't invent capabilities " +
+  "that aren't in it. Otherwise ignore this block and answer normally.";
+
+function getCompactFeatureNames(): string {
+  return FEATURE_CATALOG.map((feature) => feature.name).join(', ');
+}
+
+export function buildCapabilityGroundingBlock(compact = false): string {
+  const catalog = compact ? getCompactFeatureNames() : getCompressedCatalog();
+  return `${CAPABILITY_GROUNDING_PRIMER}\n\n<SHELLY_FEATURES>\n${catalog}\n</SHELLY_FEATURES>`;
+}
+
+/** Always-present names-only catalog for every main AI Chat provider. */
+export function buildAmbientCapabilityBlock(): string {
+  return `${AMBIENT_CAPABILITY_PRIMER}\n\n<SHELLY_FEATURES>\n${getCompactFeatureNames()}\n</SHELLY_FEATURES>`;
 }


### PR DESCRIPTION
## What

Ports 2 small, real, unlanded fixes found during tonight's dev-branch-vs-main audit (308 commits behind, audited into A/B/C/D buckets — these were bucket D "real unlanded gaps").

**Gap 1 (source `097d1cc25` / `a43869cc2`): capability-grounding always-ambient.** AI Chat now always injects a names-only feature catalog into the system context for every provider, and upgrades cloud providers to the full catalog specifically on a recognized capability question ("what can you do?"). Local stays names-only always (context-budget protection). Also fixes a real classifier miss: `isCapabilityQuestion` only matched hiragana でき but missed the kanji form 出来る — a common way Japanese speakers phrase "what can you do." Regression test added for the kanji case.

**Gap 2 (source `ebafb16b2`): cosmetics-store startup rehydration.** `app/_layout.tsx`'s existing root store-hydration effect now also calls `loadCosmetics()`, so persisted wallpaper/CRT/panel settings are restored on cold start instead of showing defaults until the user reopens settings.

## Provenance note

This work was originally dispatched to a sandboxed Codex background task, which completed the implementation and all local verification but could not push or open a PR — its sandbox blocked GitHub HTTPS + `gh` credentials entirely (`git clone`/`git worktree add` to the shared repo were also blocked by ACL, forcing it into an isolated local clone at `worktrees-local/capability-cosmetics/`, owned by a different OS-level sandbox user account). I (CC) recovered that clone, rebased its single commit onto current `main` (clean, no conflicts — the only file overlap with recently-merged PRs, `hooks/use-ai-pane-dispatch.ts`, was untouched by the rebase), ran a real `pnpm install --frozen-lockfile` (node_modules was missing in the sandbox clone), and re-verified everything below myself before pushing.

## Verification

- `tsc --noEmit`: clean.
- `pnpm test -- --runInBand __tests__/ask-context.test.ts __tests__/ai-pane-context.test.ts`: 14/14 pass.
- `expo lint`: 0 errors, 2 pre-existing warnings in an unrelated file (`ScouterDetailModal.tsx`).
- `git diff --check` against `origin/main`: clean.