### PR TITLE
feat(agent): cloud-key preflight in escalation ladder + instant consent re-bake

### DIFF
--- a/__tests__/agent-escalation-ladder.test.ts
+++ b/__tests__/agent-escalation-ladder.test.ts
@@ -149,6 +149,80 @@ describe('resolveEscalationLadder — web-mandatory tasks exclude non-web backen
   });
 });
 
+describe('resolveEscalationLadder — key preflight (G4 P1: keyless cloud degrades upfront)', () => {
+  const NO_CLOUD_KEYS: LadderEnv = {
+    hasCerebrasKey: false,
+    hasGroqKey: false,
+    hasPerplexityKey: false,
+    hasGeminiKey: false,
+  };
+
+  it('auto-scorer research task with no Perplexity key → degrades to local first (no wasted hop)', () => {
+    const l = resolveEscalationLadder(
+      mk({ prompt: 'find the latest research paper with citations' }),
+      NO_CLOUD_KEYS,
+    );
+    expect(types(l)[0]).toBe('local');
+    expect(types(l)).not.toContain('perplexity');
+    expect(types(l).at(-1)).toBe('cli:codex');
+    expect(l.why).toContain('key not configured');
+  });
+
+  it('unknown key state (fields absent) keeps the scorer primary — never wrongly skipped', () => {
+    const l = resolveEscalationLadder(
+      mk({ prompt: 'find the latest research paper with citations' }),
+      NO_KEYS, // hasPerplexityKey/hasGeminiKey absent → unknown → assumed present
+    );
+    expect(types(l)[0]).toBe('perplexity');
+  });
+
+  it('EXPLICITLY configured keyless tool is kept (its missing-key error is the signal)', () => {
+    const l = resolveEscalationLadder(
+      mk({ tool: { type: 'perplexity', model: 'sonar-deep-research' } }),
+      NO_CLOUD_KEYS,
+    );
+    expect(types(l)[0]).toBe('perplexity');
+  });
+
+  it('web-mandatory general task with no Gemini key → Codex directly, local still excluded', () => {
+    const l = resolveEscalationLadder(mk({ prompt: 'ニュースを集めて' }), NO_CLOUD_KEYS);
+    expect(types(l)).toEqual(['cli:codex']);
+    expect(types(l)).not.toContain('local');
+  });
+
+  it('web-mandatory academic task with no Perplexity key → Codex directly', () => {
+    const l = resolveEscalationLadder(mk({ prompt: '最新の論文を集めて' }), NO_CLOUD_KEYS);
+    expect(types(l)).toEqual(['cli:codex']);
+  });
+
+  it('N1: autonomous cloud consent with a keyless backend falls to the fail-closed Codex path', () => {
+    const consentNoKeys: LadderEnv = { ...NO_CLOUD_KEYS, autonomousCloudConsent: true };
+    const l = resolveEscalationLadder(mk({ prompt: 'ニュースを集めて', autonomous: true }), consentNoKeys);
+    expect(types(l)).toEqual(['cli:codex']);
+    // The why must diagnose the missing key, not suggest enabling the (already
+    // enabled) cloud opt-in.
+    expect(l.why).toContain('key is not configured');
+  });
+
+  it('N1: stop policy does not keep a keyless consented backend (missing key ≠ 429)', () => {
+    const consentStopNoKeys: LadderEnv = {
+      ...NO_CLOUD_KEYS,
+      autonomousCloudConsent: true,
+      autonomousCloudStop: true,
+    };
+    const l = resolveEscalationLadder(mk({ prompt: 'ニュースを集めて', autonomous: true }), consentStopNoKeys);
+    expect(types(l)).toEqual(['cli:codex']);
+  });
+
+  it('keyed web primary is unchanged by the preflight', () => {
+    const l = resolveEscalationLadder(
+      mk({ prompt: 'ニュースを集めて' }),
+      { ...NO_CLOUD_KEYS, hasGeminiKey: true },
+    );
+    expect(types(l)).toEqual(['gemini-api', 'cli:codex']);
+  });
+});
+
 describe('failure detection', () => {
   it('isLocalFallbackDigest matches the shell digest marker', () => {
     expect(isLocalFallbackDigest('# Local Context Fallback\n\nLocal LLM was unavailable...')).toBe(true);

--- a/__tests__/agent-manager-consent-race-round2.test.ts
+++ b/__tests__/agent-manager-consent-race-round2.test.ts
@@ -1,0 +1,291 @@
+/* eslint-disable import/first -- Jest mocks must be registered before imports. */
+// Round 2 of the autonomous-agent cloud-consent revocation race.
+//
+// Round 1 (commit 6ff094f1e, this branch) serialized rematerializeAutonomousAgents
+// against ITSELF via a FIFO queue and is covered by
+// __tests__/agent-manager-rematerialize-race.test.ts (kept as regression
+// coverage — scenario (a) below). Two independent reviews (Codex + CC) found
+// that fix insufficient: materializeAgent (the actual write chokepoint) has
+// several OTHER call sites — installAgent, runEscalatingAttempts's post-ladder
+// restore, runLadderAttempts's per-attempt materialize, runAgentOrchestrated's
+// post-chain restore, and scheduleAgentStartupRepair (fired on every app boot)
+// — that bypassed rematerializeAutonomousAgents's queue entirely and could
+// reproduce the identical fail-closed violation (a stale ON-consent write
+// landing after a newer OFF-consent write) via a different path.
+//
+// This file adds the two NEW scenarios round 2 must cover per the task brief:
+//   (b) rematerializeAutonomousAgents racing scheduleAgentStartupRepair (driven
+//       through the public loadAgentsFromDisk entry point) — proves the fix is
+//       a single chokepoint that serializes DIFFERENT callers, not just
+//       rematerializeAutonomousAgents against itself.
+//   (c) the escalation-ladder TOCTOU inside runLadderAttempts — consent is read
+//       once before the attempt loop, then an await (readAgentRunLogs / the
+//       agent run itself) is a real window for a revoke to land; the fix must
+//       make the WRITE re-read consent fresh rather than bake the stale
+//       pre-loop snapshot.
+//
+// Both tests use the same "hold the ON write open, observe that the OFF write
+// cannot even START (let alone complete) until the ON write's queued turn
+// fully settles, only THEN release ON" shape as the round-1 test — this is
+// what distinguishes "properly serialized, OFF always lands last" from "raced,
+// ON silently wins": if OFF's write completed while ON was still gated (or if
+// ON's write landed AFTER OFF without being the one that started first per
+// enqueue order), the assertions below would catch it.
+//
+// Self-review note: both tests below were run against a revert of round 2's
+// lib/agent-manager.ts diff (keeping round 1's fix) and FAIL without it —
+// see the round-2 handoff notes in the PR description / final report for the
+// revert transcript. This directly resolves the CC/Codex disagreement about
+// whether the regression coverage actually exercises the fix.
+
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+jest.mock('@/modules/terminal-emulator/src/TerminalEmulatorModule', () => ({
+  __esModule: true,
+  default: {
+    cancelAgent: jest.fn(async () => undefined),
+    execCommand: jest.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+    runAgent: jest.fn(async () => undefined),
+  },
+}));
+jest.mock('expo-notifications', () => ({}));
+jest.mock('expo-file-system/legacy', () => ({}));
+
+import {
+  rematerializeAutonomousAgents,
+  loadAgentsFromDisk,
+  runAgentNow,
+} from '@/lib/agent-manager';
+import { useAgentStore } from '@/store/agent-store';
+import type { Agent } from '@/store/types';
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const AGENT_LIST_MARKER = '---SEPARATOR---';
+
+describe('materializeAgent shared queue — cross-caller races (round 2)', () => {
+  afterEach(() => {
+    useAgentStore.getState().setAgents([]);
+    jest.clearAllMocks();
+  });
+
+  it('(b) an in-flight scheduleAgentStartupRepair pass cannot outlive a later consent revocation', async () => {
+    const agent: Agent = {
+      id: 'repair-race-agent',
+      name: 'Repair race agent',
+      description: '',
+      prompt: '最新ニュースを集めて',
+      schedule: '0 8 * * *',
+      tool: { type: 'gemini-api' },
+      autonomous: true,
+      outputPath: '~/out',
+      outputTemplate: null,
+      enabled: true,
+      lastRun: null,
+      lastResult: null,
+      createdAt: 0,
+      version: 1,
+    };
+    useAgentStore.getState().setAgents([agent]);
+
+    let consentEnabled = true;
+    let envReads = 0;
+    let writes = 0;
+    const writeCommands: string[] = [];
+    let finalOnDiskCommand = '';
+    const firstWriteGate = deferred<void>();
+    const firstWriteStarted = deferred<void>();
+
+    const runCommand = jest.fn(async (command: string): Promise<string> => {
+      // Halt-sentinel check (loadAgentsFromDisk).
+      if (command.startsWith('[ -f ')) return 'HALTED_NO';
+      // Agent metadata listing (readAgentMetadataViaShell).
+      if (command.startsWith('d=')) {
+        return `${JSON.stringify(agent)}\n${AGENT_LIST_MARKER}\n`;
+      }
+      // Run-log reads (readAgentRunLogs) — no history either way.
+      if (command.includes('SHELLY_AGENT_LOG') || command.startsWith('for d in')) return '';
+      // Orphan-file sweep (cleanupOrphanAgentFiles).
+      if (command.startsWith('cd ')) return '';
+      // Consent / key preflight read (ladderEnvFromDisk).
+      if (command.startsWith('for k in CEREBRAS_API_KEY')) {
+        envReads += 1;
+        return [
+          'CEREBRAS_API_KEY=0',
+          'GROQ_API_KEY=0',
+          'PERPLEXITY_API_KEY=1',
+          'GEMINI_API_KEY=1',
+          `SHELLY_AUTONOMOUS_CLOUD='${consentEnabled ? '1' : '0'}'`,
+          "SHELLY_AUTONOMOUS_CLOUD_STOP='0'",
+        ].join('\n');
+      }
+      // The materialize write itself (writeFileCommand block, `set -e\n...`).
+      writes += 1;
+      writeCommands.push(command);
+      if (writes === 1) {
+        firstWriteStarted.resolve();
+        await firstWriteGate.promise;
+      }
+      finalOnDiskCommand = command;
+      return '';
+    });
+
+    // Boot: startup repair fires almost immediately (repairDelayMs: 0) and will
+    // materialize `agent` while consent is still ON.
+    await loadAgentsFromDisk(runCommand, {
+      repairSchedules: true,
+      repairDelayMs: 0,
+      shouldRepair: () => true,
+    });
+
+    // Wait for the repair pass's materialize write to actually start (not just
+    // for the setTimeout to fire) — this is the ON write, now gated open.
+    await firstWriteStarted.promise;
+    expect(envReads).toBe(1);
+    expect(writes).toBe(1);
+
+    // The user revokes consent while the repair pass's write is still in
+    // flight, and the Settings toggle fires the normal rematerialize path.
+    consentEnabled = false;
+    const revokePass = rematerializeAutonomousAgents(runCommand);
+
+    // Structural check (NOT a fixed microtask-tick count, which would be
+    // timing-fragile — materializeAgent's real body hops through several
+    // genuinely-async, unmocked steps like readMemoryNotes before it ever
+    // reaches a write, so "hasn't written yet after N ticks" proves nothing on
+    // its own). Instead race revokePass's own settlement against a real
+    // timeout: with the fix, revokePass's per-agent materialize call is
+    // chained onto the SAME queue turn the repair pass's write is still
+    // holding open, so it is promise-structurally impossible for it to settle
+    // before that turn resolves — no timeout is "long enough" to let it slip
+    // through. Without the fix, rematerializeAutonomousAgents has nothing to
+    // wait on (its own pass-level queue is untouched by the repair path) and
+    // settles at ordinary microtask speed, comfortably inside this window.
+    const raced = await Promise.race([
+      revokePass.then(() => 'revoke-settled' as const),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 150)),
+    ]);
+    expect(raced).toBe('timeout');
+    // Still exactly the repair pass's single (gated, unfinished) write.
+    expect(writes).toBe(1);
+    expect(envReads).toBe(1);
+
+    // Release the repair pass's (ON) write. Only now can revoke's queued turn
+    // begin (and it must re-read consent fresh, seeing the revoke).
+    firstWriteGate.resolve();
+    await revokePass;
+
+    // The revoke's write must be the LAST one on disk, not the repair pass's.
+    expect(writes).toBe(2);
+    expect(envReads).toBe(2);
+    expect(writeCommands[0]).toContain('https://generativelanguage.googleapis.com');
+    expect(finalOnDiskCommand).toContain('[REFUSED] autonomous mode does not allow the');
+    expect(finalOnDiskCommand).not.toContain('https://generativelanguage.googleapis.com');
+  });
+});
+
+describe('escalation-ladder TOCTOU — per-attempt consent must be re-read fresh (round 2)', () => {
+  afterEach(() => {
+    useAgentStore.getState().setAgents([]);
+    useAgentStore.getState().setRunHistory({});
+    jest.clearAllMocks();
+  });
+
+  it('a revoke that lands between ladder-resolve and the first attempt write is honoured, not the stale pre-loop snapshot', async () => {
+    const agent: Agent = {
+      id: 'ladder-toctou-agent',
+      name: 'Ladder TOCTOU agent',
+      description: '',
+      prompt: 'ニュースを集めて', // needsWeb, general domain -> gemini-api primary
+      schedule: null,
+      tool: { type: 'auto' },
+      autonomous: true,
+      outputPath: '~/out',
+      outputTemplate: null,
+      enabled: true,
+      lastRun: null,
+      lastResult: null,
+      createdAt: 0,
+      version: 1,
+    };
+    useAgentStore.getState().setAgents([agent]);
+
+    // Consent is ON when the ladder is resolved (line ~675, before the attempt
+    // loop) — resolveEscalationLadder therefore picks [gemini-api, cli:codex].
+    let consentEnabled = true;
+    let envReads = 0;
+    let writeCount = 0;
+    let firstAttemptWriteCommand = '';
+    const runLogGate = deferred<void>();
+    const runLogGateStarted = deferred<void>();
+    let runLogGateConsumed = false;
+
+    const runCommand = jest.fn(async (command: string): Promise<string> => {
+      if (command.startsWith('for k in CEREBRAS_API_KEY')) {
+        envReads += 1;
+        return [
+          'CEREBRAS_API_KEY=0',
+          'GROQ_API_KEY=0',
+          'PERPLEXITY_API_KEY=1',
+          'GEMINI_API_KEY=1',
+          `SHELLY_AUTONOMOUS_CLOUD='${consentEnabled ? '1' : '0'}'`,
+          "SHELLY_AUTONOMOUS_CLOUD_STOP='0'",
+        ].join('\n');
+      }
+      if (command.includes('SHELLY_AGENT_LOG') || command.startsWith('for d in')) {
+        // readAgentRunLogs — used both for the ladder's "before" snapshot AND
+        // by waitForAgentRunCompletion's poll. Gate the VERY FIRST call only
+        // (the "before" read inside runLadderAttempts, which happens after the
+        // ladder is resolved but before the first attempt's materialize write
+        // — the real TOCTOU window this test targets) so the revoke can land
+        // in that exact gap.
+        if (!runLogGateConsumed) {
+          runLogGateConsumed = true;
+          runLogGateStarted.resolve();
+          await runLogGate.promise;
+        }
+        return '';
+      }
+      if (command.startsWith('set -e')) {
+        writeCount += 1;
+        if (writeCount === 1) firstAttemptWriteCommand = command;
+        return '';
+      }
+      return '';
+    });
+
+    const runPromise = runAgentNow('ladder-toctou-agent', runCommand, { waitTimeoutMs: 2_000, pollMs: 5 });
+
+    // Wait until runLadderAttempts is blocked in the gap between ladder-resolve
+    // (env read #1, consent=true) and the first attempt's materialize write.
+    await runLogGateStarted.promise;
+    expect(envReads).toBe(1);
+    expect(writeCount).toBe(0);
+
+    // Revoke lands in that exact window.
+    consentEnabled = false;
+    runLogGate.resolve();
+
+    // The run will time out waiting for a completion log (TerminalEmulator is
+    // mocked to a no-op and no run log ever appears) — that's fine, we only
+    // care about what got WRITTEN for the first attempt before the timeout.
+    await expect(runPromise).rejects.toThrow(/Timed out waiting for agent/);
+
+    expect(writeCount).toBeGreaterThanOrEqual(1);
+    // The fix: materializeAgent's own queued turn re-reads consent fresh
+    // (envReads becomes 2) rather than reusing the stale ladder-start value —
+    // so the FIRST attempt's script must reflect the REVOKED consent and
+    // refuse the keyed Gemini backend, even though the ladder picked
+    // gemini-api as tools[0] while consent was still true.
+    expect(envReads).toBeGreaterThanOrEqual(2);
+    expect(firstAttemptWriteCommand).not.toContain('https://generativelanguage.googleapis.com');
+  }, 10_000);
+});

--- a/__tests__/agent-manager-rematerialize-race.test.ts
+++ b/__tests__/agent-manager-rematerialize-race.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable import/first -- Jest mocks must be registered before imports. */
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+jest.mock('@/modules/terminal-emulator/src/TerminalEmulatorModule', () => ({
+  __esModule: true,
+  default: {
+    cancelAgent: jest.fn(async () => undefined),
+    execCommand: jest.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+    runAgent: jest.fn(async () => undefined),
+  },
+}));
+jest.mock('expo-notifications', () => ({}));
+jest.mock('expo-file-system/legacy', () => ({}));
+
+import { rematerializeAutonomousAgents } from '@/lib/agent-manager';
+import { useAgentStore } from '@/store/agent-store';
+import type { Agent } from '@/store/types';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('rematerializeAutonomousAgents serialization', () => {
+  it('leaves the later consent revocation on disk when the older write is delayed', async () => {
+    const agent: Agent = {
+      id: 'race-agent',
+      name: 'Race agent',
+      description: '',
+      prompt: '最新ニュースを集めて',
+      schedule: '0 8 * * *',
+      tool: { type: 'gemini-api' },
+      autonomous: true,
+      outputPath: '~/out',
+      outputTemplate: null,
+      enabled: true,
+      lastRun: null,
+      lastResult: null,
+      createdAt: 0,
+      version: 1,
+    };
+    useAgentStore.getState().setAgents([agent]);
+
+    let consentEnabled = true;
+    let envReads = 0;
+    let writes = 0;
+    let finalOnDiskCommand = '';
+    const writeCommands: string[] = [];
+    const firstWriteGate = deferred();
+    const firstWriteStarted = deferred();
+
+    const runCommand = jest.fn(async (command: string): Promise<string> => {
+      if (command.startsWith('for k in CEREBRAS_API_KEY')) {
+        envReads += 1;
+        return [
+          'CEREBRAS_API_KEY=0',
+          'GROQ_API_KEY=0',
+          'PERPLEXITY_API_KEY=1',
+          'GEMINI_API_KEY=1',
+          `SHELLY_AUTONOMOUS_CLOUD='${consentEnabled ? '1' : '0'}'`,
+          "SHELLY_AUTONOMOUS_CLOUD_STOP='0'",
+        ].join('\n');
+      }
+
+      writes += 1;
+      writeCommands.push(command);
+      if (writes === 1) {
+        firstWriteStarted.resolve();
+        await firstWriteGate.promise;
+      }
+      finalOnDiskCommand = command;
+      return '';
+    });
+
+    const enablePass = rematerializeAutonomousAgents(runCommand);
+    await firstWriteStarted.promise;
+
+    // Revoke while the ON-based write is still in flight. Without the queue,
+    // this OFF pass writes first and the delayed ON pass overwrites it later.
+    consentEnabled = false;
+    const revokePass = rematerializeAutonomousAgents(runCommand);
+    await Promise.resolve();
+
+    expect(envReads).toBe(1);
+    expect(writes).toBe(1);
+
+    firstWriteGate.resolve();
+    await Promise.all([enablePass, revokePass]);
+
+    expect(envReads).toBe(2);
+    expect(writes).toBe(2);
+    expect(writeCommands[0]).toContain('https://generativelanguage.googleapis.com');
+    expect(finalOnDiskCommand).toContain('[REFUSED] autonomous mode does not allow the');
+    expect(finalOnDiskCommand).toContain('gemini-api');
+    expect(finalOnDiskCommand).not.toContain('https://generativelanguage.googleapis.com');
+  });
+});

--- a/components/config/ConfigTUI.tsx
+++ b/components/config/ConfigTUI.tsx
@@ -7,7 +7,7 @@
  * picker sheet for enums.
  */
 
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { colors as C } from '@/theme.config';
 import {
   View,
@@ -301,9 +301,10 @@ interface SettingRowProps {
   onStringEdit: (v: string) => void;
   onEnumOpen: () => void;
   onAction?: () => void;
+  disabled?: boolean;
 }
 
-function SettingRow({ def, value, onToggle, onStringEdit, onEnumOpen, onAction }: SettingRowProps) {
+function SettingRow({ def, value, onToggle, onStringEdit, onEnumOpen, onAction, disabled = false }: SettingRowProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
 
@@ -339,6 +340,7 @@ function SettingRow({ def, value, onToggle, onStringEdit, onEnumOpen, onAction }
         <Switch
           value={Boolean(value)}
           onValueChange={onToggle}
+          disabled={disabled}
           trackColor={{ false: BORDER, true: C.accent + '66' }}
           thumbColor={value ? C.accent : MUTED}
         />
@@ -348,7 +350,7 @@ function SettingRow({ def, value, onToggle, onStringEdit, onEnumOpen, onAction }
 
   if (def.type === 'enum') {
     return (
-      <TouchableOpacity style={styles.row} onPress={onEnumOpen} activeOpacity={0.7}>
+      <TouchableOpacity style={[styles.row, disabled && { opacity: 0.5 }]} onPress={onEnumOpen} activeOpacity={0.7} disabled={disabled}>
         <View style={styles.rowLeft}>
           <Text style={styles.rowKey}>{def.label}</Text>
           {def.description && <Text style={styles.rowDesc}>{def.description}</Text>}
@@ -473,6 +475,8 @@ export function ConfigTUI({ visible, onClose }: ConfigTUIProps) {
   const [customContextText, setCustomContextText] = useState('');
   const [scouterEnabled, setScouterEnabled] = useState(false);
   const [notificationTriggerEnabled, setNotificationTriggerEnabled] = useState(false);
+  const [cloudSyncBusy, setCloudSyncBusy] = useState(false);
+  const cloudSyncBusyRef = useRef(false);
   useEffect(() => {
     if (visible) {
       logLifecycle('ConfigTUI', 'opened');
@@ -529,6 +533,15 @@ export function ConfigTUI({ visible, onClose }: ConfigTUIProps) {
 
   const applyValue = useCallback(
     async (def: SettingDef, rawValue: unknown) => {
+      const isCloudSyncSetting =
+        def.key === 'autonomousCloudConsent' ||
+        def.key === 'autonomousCloudOnExhaustion';
+      if (isCloudSyncSetting && cloudSyncBusyRef.current) return;
+      if (isCloudSyncSetting) {
+        cloudSyncBusyRef.current = true;
+        setCloudSyncBusy(true);
+      }
+      try {
       const displayValue = def.type === 'secret' ? (rawValue ? 'set' : 'empty') : String(rawValue);
       logInfo('ConfigTUI', 'Setting ' + def.key + ' = ' + displayValue);
       // N1: enabling autonomous cloud needs informed consent — an unattended
@@ -634,6 +647,12 @@ export function ConfigTUI({ visible, onClose }: ConfigTUIProps) {
       }
       } catch (e) {
         logError('ConfigTUI', 'Failed to apply ' + def.key, e);
+      }
+      } finally {
+        if (isCloudSyncSetting) {
+          cloudSyncBusyRef.current = false;
+          setCloudSyncBusy(false);
+        }
       }
     },
     [updateSettings, cosmetics, settings, themeStore, i18n, dotfiles],
@@ -831,6 +850,10 @@ export function ConfigTUI({ visible, onClose }: ConfigTUIProps) {
                         onStringEdit={(v) => handleStringEdit(def, v)}
                         onEnumOpen={() => handleEnumOpen(def)}
                         onAction={() => handleAction(def)}
+                        disabled={cloudSyncBusy && (
+                          def.key === 'autonomousCloudConsent' ||
+                          def.key === 'autonomousCloudOnExhaustion'
+                        )}
                       />
                     </View>
                   ))}

--- a/components/config/ConfigTUI.tsx
+++ b/components/config/ConfigTUI.tsx
@@ -37,7 +37,7 @@ import { saveCustomContext, loadCustomContext } from '@/lib/shelly-system-prompt
 import { useTerminalStore } from '@/store/terminal-store';
 import { buildRecentTerminalLogsText } from '@/lib/terminal-logs';
 import { logInfo, logError, logLifecycle } from '@/lib/debug-logger';
-import { flushPendingAgentEnvSync } from '@/lib/agent-env-sync';
+import { flushAutonomousCloudEnvSync, flushPendingAgentEnvSync } from '@/lib/agent-env-sync';
 import TerminalEmulator from '@/modules/terminal-emulator/src/TerminalEmulatorModule';
 import { resetSetup, runFirstLaunchSetup } from '@/lib/first-launch-setup';
 
@@ -611,11 +611,13 @@ export function ConfigTUI({ visible, onClose }: ConfigTUIProps) {
         } else {
           updateSettings({ [def.key]: rawValue } as any);
           if (
-            def.type === 'secret' ||
-            def.key === 'geminiModel' ||
             def.key === 'autonomousCloudConsent' ||
             def.key === 'autonomousCloudOnExhaustion'
           ) {
+            // Consent flush also re-bakes autonomous agents' on-disk scripts so
+            // a scheduled fire picks up the toggle immediately (N1 follow-up).
+            await flushAutonomousCloudEnvSync(def.label);
+          } else if (def.type === 'secret' || def.key === 'geminiModel') {
             await flushPendingAgentEnvSync(def.label);
           }
         }

--- a/components/layout/SettingsDropdown.tsx
+++ b/components/layout/SettingsDropdown.tsx
@@ -775,6 +775,8 @@ function AgentsSection({ visible }: { visible: boolean }) {
   const [vaultDraft, setVaultDraft] = React.useState(vaultPath);
   const [topicDraft, setTopicDraft] = React.useState(topicFolder);
   const [customDraft, setCustomDraft] = React.useState(customPath);
+  const [cloudSyncBusy, setCloudSyncBusy] = React.useState(false);
+  const cloudSyncBusyRef = React.useRef(false);
   React.useEffect(() => setVaultDraft(vaultPath), [vaultPath]);
   React.useEffect(() => setTopicDraft(topicFolder), [topicFolder]);
   React.useEffect(() => setCustomDraft(customPath), [customPath]);
@@ -799,29 +801,45 @@ function AgentsSection({ visible }: { visible: boolean }) {
   // N1: enabling autonomous cloud needs informed consent — an unattended agent
   // will spend your cloud quota/cost without asking each time.
   const toggleCloudConsent = async () => {
-    if (!cloudConsent) {
-      const ok = await new Promise<boolean>((resolve) => {
-        Alert.alert(
-          t('agents.cloud_consent_title'),
-          t('agents.cloud_consent_body'),
-          [
-            { text: t('common.cancel'), style: 'cancel', onPress: () => resolve(false) },
-            { text: t('agents.cloud_consent_enable'), style: 'destructive', onPress: () => resolve(true) },
-          ],
-          { cancelable: true, onDismiss: () => resolve(false) },
-        );
-      });
-      if (!ok) return;
+    if (cloudSyncBusyRef.current) return;
+    cloudSyncBusyRef.current = true;
+    setCloudSyncBusy(true);
+    try {
+      if (!cloudConsent) {
+        const ok = await new Promise<boolean>((resolve) => {
+          Alert.alert(
+            t('agents.cloud_consent_title'),
+            t('agents.cloud_consent_body'),
+            [
+              { text: t('common.cancel'), style: 'cancel', onPress: () => resolve(false) },
+              { text: t('agents.cloud_consent_enable'), style: 'destructive', onPress: () => resolve(true) },
+            ],
+            { cancelable: true, onDismiss: () => resolve(false) },
+          );
+        });
+        if (!ok) return;
+      }
+      updateSettings({ autonomousCloudConsent: !cloudConsent });
+      // Consent flush also re-bakes autonomous agents' on-disk scripts so a
+      // scheduled fire picks up the toggle immediately (N1 follow-up).
+      await flushAutonomousCloudEnvSync('Autonomous Cloud');
+    } finally {
+      cloudSyncBusyRef.current = false;
+      setCloudSyncBusy(false);
     }
-    updateSettings({ autonomousCloudConsent: !cloudConsent });
-    // Consent flush also re-bakes autonomous agents' on-disk scripts so a
-    // scheduled fire picks up the toggle immediately (N1 follow-up).
-    await flushAutonomousCloudEnvSync('Autonomous Cloud');
   };
 
   const toggleExhaustion = async () => {
-    updateSettings({ autonomousCloudOnExhaustion: cloudExhaustion === 'stop' ? 'escalate' : 'stop' });
-    await flushAutonomousCloudEnvSync('Autonomous Cloud');
+    if (cloudSyncBusyRef.current) return;
+    cloudSyncBusyRef.current = true;
+    setCloudSyncBusy(true);
+    try {
+      updateSettings({ autonomousCloudOnExhaustion: cloudExhaustion === 'stop' ? 'escalate' : 'stop' });
+      await flushAutonomousCloudEnvSync('Autonomous Cloud');
+    } finally {
+      cloudSyncBusyRef.current = false;
+      setCloudSyncBusy(false);
+    }
   };
 
   const [notificationTriggerEnabled, setNotificationTriggerEnabled] = React.useState(false);
@@ -943,8 +961,10 @@ function AgentsSection({ visible }: { visible: boolean }) {
           style={[
             styles.switchTrack,
             { backgroundColor: cloudConsent ? withAlpha(C.accent, 0.36) : C.border },
+            cloudSyncBusy && { opacity: 0.5 },
           ]}
           onPress={toggleCloudConsent}
+          disabled={cloudSyncBusy}
           hitSlop={4}
         >
           <View
@@ -959,8 +979,9 @@ function AgentsSection({ visible }: { visible: boolean }) {
       {cloudConsent && (
         <Row label={t('agents.cloud_on_exhaustion')}>
           <Pressable
-            style={[styles.defaultAgentBtn, { borderColor: withAlpha(C.accent, 0.38), backgroundColor: withAlpha(C.accent, 0.08) }]}
+            style={[styles.defaultAgentBtn, { borderColor: withAlpha(C.accent, 0.38), backgroundColor: withAlpha(C.accent, 0.08) }, cloudSyncBusy && { opacity: 0.5 }]}
             onPress={toggleExhaustion}
+            disabled={cloudSyncBusy}
             hitSlop={4}
           >
             <Text style={[styles.defaultAgentLabel, { color: C.text1 }]}>

--- a/components/layout/SettingsDropdown.tsx
+++ b/components/layout/SettingsDropdown.tsx
@@ -34,7 +34,7 @@ import { applyThemePreset, themePresets } from '@/lib/theme-presets';
 import { logInfo, logError } from '@/lib/debug-logger';
 import { useAddPane } from '@/hooks/use-add-pane';
 import { useTerminalStore } from '@/store/terminal-store';
-import { flushPendingAgentEnvSync } from '@/lib/agent-env-sync';
+import { flushAutonomousCloudEnvSync, flushPendingAgentEnvSync } from '@/lib/agent-env-sync';
 import TerminalEmulator from '@/modules/terminal-emulator/src/TerminalEmulatorModule';
 import { usePanelBackground } from '@/hooks/use-panel-background';
 import { DmPairingSection } from '@/components/layout/DmPairingSection';
@@ -814,12 +814,14 @@ function AgentsSection({ visible }: { visible: boolean }) {
       if (!ok) return;
     }
     updateSettings({ autonomousCloudConsent: !cloudConsent });
-    await flushPendingAgentEnvSync('Autonomous Cloud');
+    // Consent flush also re-bakes autonomous agents' on-disk scripts so a
+    // scheduled fire picks up the toggle immediately (N1 follow-up).
+    await flushAutonomousCloudEnvSync('Autonomous Cloud');
   };
 
   const toggleExhaustion = async () => {
     updateSettings({ autonomousCloudOnExhaustion: cloudExhaustion === 'stop' ? 'escalate' : 'stop' });
-    await flushPendingAgentEnvSync('Autonomous Cloud');
+    await flushAutonomousCloudEnvSync('Autonomous Cloud');
   };
 
   const [notificationTriggerEnabled, setNotificationTriggerEnabled] = React.useState(false);

--- a/docs/superpowers/DEFERRED.md
+++ b/docs/superpowers/DEFERRED.md
@@ -2184,6 +2184,8 @@ claude() {
 
 - **2026-07-13 (capability grounding + cosmetics catch-up batch)**: dev branch の `097d1cc25` / `a43869cc2` / `ebafb16b2` を current `main` へ手動再構成。AI Chat は全 provider で names-only feature catalog を常時 ambient 注入し、cloud の capability question のみ full catalog へ upgrade、local は context budget 保護のため常時 compact のままとした。日本語 classifier はひらがな `できる` に加えて漢字 `出来る` を回帰テストで固定。RootLayout の既存 store hydration effect から `loadCosmetics()` を呼び、persist 済み wallpaper / CRT / panel 設定を cold start 時に復元する。→ sync: なし（既存機能の grounding / startup restore 修正で README surface 変更なし）。
 
+- **2026-07-13 (cloud-key preflight + atomic live-script port)**: reviewed commits `43d282b1a` → `9af50965d` を current main へ移植。live agent script / metadata / PlanSpec の書き込みを same-directory unique tmp + `mv -f` にして読み取り競合時の truncate を防ぎ、既存の実行 bit も rename 前に継承。auto route はキー欠如が確定した cloud 候補だけを事前除外し、autonomous cloud consent の変更は `.env` flush 成功後に disabled を含む全 autonomous agent へ即時 re-bake（alarm は不変）。consent は引き続き exact `1` のみ有効・欠落/読取失敗は false、preflight は候補を追加せず削除のみのため、unattended capability は fresh な明示 opt-in なしに拡大しない。→ sync: なし（既存 P1 follow-up の移植完了記録）。
+
 ---
 
 ## 管理ルール (自分への覚書)

--- a/lib/agent-env-sync.ts
+++ b/lib/agent-env-sync.ts
@@ -1,6 +1,7 @@
 import { Alert, ToastAndroid } from 'react-native';
 import { execCommand } from '@/hooks/use-native-exec';
-import { logError } from '@/lib/debug-logger';
+import { logError, logWarn } from '@/lib/debug-logger';
+import { rematerializeAutonomousAgents } from '@/lib/agent-manager';
 import { useAgentStore } from '@/store/agent-store';
 
 export async function flushPendingAgentEnvSync(label: string): Promise<boolean> {
@@ -21,4 +22,30 @@ export async function flushPendingAgentEnvSync(label: string): Promise<boolean> 
     logError('AgentEnvSync', `${label} env sync threw`, e);
     return false;
   }
+}
+
+/**
+ * N1 follow-up: flush for the autonomous-cloud consent flags. The consent is
+ * BAKED into each autonomous agent's on-disk run script, so after the .env
+ * write lands, re-materialize those scripts immediately — otherwise a
+ * scheduled (alarm-fired) run keeps the pre-toggle consent until the next
+ * app-launch startup repair. Re-bake only on a successful flush: the .env is
+ * the source materializeAgent reads consent from, so re-baking after a failed
+ * write would just re-bake the stale value.
+ */
+export async function flushAutonomousCloudEnvSync(label: string): Promise<boolean> {
+  const flushed = await flushPendingAgentEnvSync(label);
+  if (!flushed) return false;
+  try {
+    await rematerializeAutonomousAgents((cmd) =>
+      execCommand(cmd, 30_000).then((r) => {
+        if (r.exitCode !== 0) throw new Error((r.stderr || r.stdout || `exit ${r.exitCode}`).trim());
+        return r.stdout;
+      })
+    );
+  } catch (e) {
+    // Best-effort: the startup repair / next foreground run re-bakes anyway.
+    logWarn('AgentEnvSync', `${label} consent re-bake failed`, e);
+  }
+  return true;
 }

--- a/lib/agent-escalation-ladder.ts
+++ b/lib/agent-escalation-ladder.ts
@@ -31,6 +31,15 @@ export interface LadderEnv {
   /** Groq free-tier key present. */
   hasGroqKey: boolean;
   /**
+   * Perplexity / Gemini key present. Optional: absent means UNKNOWN and is
+   * treated as present (conservative — a usable backend is never wrongly
+   * skipped; a keyless one just fails-and-escalates as before). When known
+   * false, the ladder preflight drops the keyless candidate so the run never
+   * wastes an attempt on a backend that cannot authenticate.
+   */
+  hasPerplexityKey?: boolean;
+  hasGeminiKey?: boolean;
+  /**
    * N1: the user gave informed consent for autonomous agents to use cloud API
    * keys (Gemini/Perplexity) UNATTENDED on web-mandatory tasks. Default OFF →
    * fail-closed (autonomous web stays Codex-only). secret-guard still wins.
@@ -63,6 +72,18 @@ function toolKey(t: ToolChoice): string {
   if (t.type === 'cli') return `cli:${t.cli}`;
   if (t.type === 'local') return 'local';
   return t.type;
+}
+
+/**
+ * Key preflight (G4 P1): is this tool's API key known to be MISSING? Unknown
+ * (env field absent) counts as present so we only skip when certain.
+ */
+function keyKnownMissing(tool: ToolChoice, env: LadderEnv): boolean {
+  if (tool.type === 'perplexity') return env.hasPerplexityKey === false;
+  if (tool.type === 'gemini-api') return env.hasGeminiKey === false;
+  if (tool.type === 'cerebras') return !env.hasCerebrasKey;
+  if (tool.type === 'groq') return !env.hasGroqKey;
+  return false;
 }
 
 function dedupe(tools: ToolChoice[]): ToolChoice[] {
@@ -104,19 +125,41 @@ export function resolveEscalationLadder(agent: Agent, env: LadderEnv): Escalatio
       // halts at the free tier rather than burning Codex/paid quota.
       if (env.autonomousCloudConsent) {
         const consented = web.webDomain === 'academic' ? PERPLEXITY : GEMINI;
-        const tools = env.autonomousCloudStop ? [consented] : [consented, CODEX];
-        return {
-          tools,
-          noEscalation: false,
-          guard: decision.guard,
-          why: `Web-mandatory ${web.webDomain} task; autonomous cloud opt-in → ${web.webDomain === 'academic' ? 'Perplexity' : 'Gemini (grounded)'}${env.autonomousCloudStop ? ' (stop at free tier on 429)' : ' → Codex on 429'}.`,
-        };
+        // Key preflight: consent without the backend's key cannot work — fall
+        // through to the fail-closed no-consent path (Codex/OAuth only) instead
+        // of wasting the run on an unauthenticated request. 'stop' only governs
+        // 429 quota exhaustion, not a missing key, so it doesn't keep a dead
+        // keyless backend in the ladder.
+        if (!keyKnownMissing(consented, env)) {
+          const tools = env.autonomousCloudStop ? [consented] : [consented, CODEX];
+          return {
+            tools,
+            noEscalation: false,
+            guard: decision.guard,
+            why: `Web-mandatory ${web.webDomain} task; autonomous cloud opt-in → ${web.webDomain === 'academic' ? 'Perplexity' : 'Gemini (grounded)'}${env.autonomousCloudStop ? ' (stop at free tier on 429)' : ' → Codex on 429'}.`,
+          };
+        }
       }
       // No consent (fail-closed): api-key web backends are excluded, so the only
-      // web-capable option is Codex (OAuth shell).
-      return { tools: [CODEX], noEscalation: false, guard: decision.guard, why: 'Web-mandatory task; autonomous policy → Codex only (enable cloud opt-in for Gemini/Perplexity).' };
+      // web-capable option is Codex (OAuth shell). Distinguish the keyless
+      // consented case in the why — "enable cloud opt-in" would misdiagnose it.
+      const why = env.autonomousCloudConsent
+        ? `Web-mandatory task; cloud opt-in is on but the ${web.webDomain === 'academic' ? 'Perplexity' : 'Gemini'} key is not configured → Codex only.`
+        : 'Web-mandatory task; autonomous policy → Codex only (enable cloud opt-in for Gemini/Perplexity).';
+      return { tools: [CODEX], noEscalation: false, guard: decision.guard, why };
     }
     const webPrimary = web.webDomain === 'academic' ? PERPLEXITY : GEMINI;
+    // Key preflight: a keyless web primary can't authenticate — go straight to
+    // Codex (web-capable via its shell) instead of burning an attempt. Local /
+    // Cerebras / Groq stay excluded (they would hallucinate a template).
+    if (keyKnownMissing(webPrimary, env)) {
+      return {
+        tools: [CODEX],
+        noEscalation: false,
+        guard: decision.guard,
+        why: `Web-mandatory ${web.webDomain} task; ${web.webDomain === 'academic' ? 'Perplexity' : 'Gemini'} key not configured → Codex directly; non-web backends excluded.`,
+      };
+    }
     return {
       tools: dedupe([webPrimary, CODEX]),
       noEscalation: false,
@@ -144,11 +187,22 @@ export function resolveEscalationLadder(agent: Agent, env: LadderEnv): Escalatio
 
   // Attended: domain/scorer primary first, then on-device, then the free cloud
   // tier (only when keyed), then Codex last to preserve its quota.
-  const ladder: ToolChoice[] = [primary, LOCAL];
+  //
+  // Key preflight (G4 P1): when the AUTO scorer picked an api-key backend whose
+  // key is known missing, drop it so the run degrades to local upfront instead
+  // of failing an attempt on an unauthenticated request. An EXPLICITLY
+  // configured tool (guard 'configured-tool') is kept even keyless — its
+  // "add <KEY> to .env" error is the legible signal of the misconfiguration,
+  // and the ladder still climbs past it.
+  const dropKeylessPrimary = agent.tool.type === 'auto' && keyKnownMissing(primary, env);
+  const ladder: ToolChoice[] = dropKeylessPrimary ? [LOCAL] : [primary, LOCAL];
   if (env.hasCerebrasKey) ladder.push({ type: 'cerebras' });
   if (env.hasGroqKey) ladder.push({ type: 'groq' });
   ladder.push(CODEX);
-  return { tools: dedupe(ladder), noEscalation: false, guard: decision.guard, why: decision.why };
+  const why = dropKeylessPrimary
+    ? `${decision.why} (${primary.type} key not configured → degraded to on-device first.)`
+    : decision.why;
+  return { tools: dedupe(ladder), noEscalation: false, guard: decision.guard, why };
 }
 
 /** First line written by the shell's local_context_fallback (agent-executor.ts). */

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -288,7 +288,67 @@ export async function installAgent(
   await materializeAgent(agent, runCommand, true);
 }
 
-async function materializeAgent(
+type MaterializeRunOpts = {
+  suppressAction?: boolean;
+  suppressErrorNotification?: boolean;
+  autonomousCloudConsent?: boolean;
+  autonomousCloudStop?: boolean;
+  suppressWebCodexBake?: boolean;
+};
+
+/**
+ * round 2 (consent-revocation race, comprehensive fix): EVERY on-disk write for
+ * an autonomous agent's script is security-sensitive — an unattended AlarmManager
+ * fire reads whatever consent value was last baked in, with no foreground gate.
+ * Round 1 only serialized rematerializeAutonomousAgents against ITSELF via
+ * autonomousRematerializeQueue (below); an independent Codex review and an
+ * independent CC review both found that insufficient, because materializeAgent
+ * (this function) has FIVE other call sites that bypass that queue entirely:
+ * installAgent (agent create/edit — installAgent/Sidebar persistAgentUpdate/
+ * TerminalPane @agent create), runEscalatingAttempts's post-ladder restore,
+ * runLadderAttempts's per-attempt materialize (also the site of a separate
+ * TOCTOU — see the comment at its call below), runAgentOrchestrated's
+ * post-chain restore, and scheduleAgentStartupRepair (fired on every app boot,
+ * fully independent of any rematerialize pass). Any two of these racing for the
+ * SAME autonomous agent could let an older ON-consent write land after a newer
+ * OFF-consent write, silently re-enabling a keyed cloud backend the user just
+ * revoked for an agent that can fire unattended.
+ *
+ * Fix: make materializeAgent ITSELF the single unavoidable choke point. Every
+ * call for an autonomous agent — regardless of caller — is routed through this
+ * module-level FIFO queue before it does anything, so writes from different
+ * callers can never interleave; the queue is a property of the write path, not
+ * of any one caller, so a future caller cannot accidentally bypass it (there is
+ * only one way to reach the write). Each queued turn re-reads consent from disk
+ * only once ITS OWN turn begins (materializeAgentBody's existing "read from
+ * disk when runOpts.autonomousCloudConsent is undefined" fallback), so the read
+ * and the write it feeds happen back-to-back inside the SAME turn — no other
+ * queued turn's write can land in the gap between them. Non-autonomous agents
+ * skip the queue (there is no consent to race).
+ */
+let autonomousMaterializeQueue: Promise<void> = Promise.resolve();
+
+function materializeAgent(
+  agent: Agent,
+  runCommand: (cmd: string) => Promise<string>,
+  installAlarm: boolean,
+  persistFacts = true,
+  runOpts: MaterializeRunOpts = {}
+): Promise<void> {
+  if (!agent.autonomous) {
+    return materializeAgentBody(agent, runCommand, installAlarm, persistFacts, runOpts);
+  }
+  const turn = autonomousMaterializeQueue.then(() =>
+    materializeAgentBody(agent, runCommand, installAlarm, persistFacts, runOpts)
+  );
+  // A rejected turn must not poison the queue and block later (possibly
+  // security-critical, e.g. a revoke's) turns from ever running. Callers still
+  // observe their own turn's rejection via the returned/awaited `turn`.
+  autonomousMaterializeQueue = turn.catch(() => undefined);
+  return turn;
+}
+
+async function materializeAgentBody(
   agent: Agent,
   runCommand: (cmd: string) => Promise<string>,
   installAlarm: boolean,
@@ -296,7 +356,7 @@ async function materializeAgent(
   // passes false so we don't re-issue an (idempotent but redundant) fact write
   // for each one. Recall is always re-applied so the baked prompt stays fresh.
   persistFacts = true,
-  runOpts: { suppressAction?: boolean; suppressErrorNotification?: boolean; autonomousCloudConsent?: boolean; autonomousCloudStop?: boolean; suppressWebCodexBake?: boolean } = {}
+  runOpts: MaterializeRunOpts = {}
 ): Promise<void> {
   // Phase 1 memory: persist the "remember that …" fact (idempotent) BEFORE recall
   // so it is immediately recallable, then bake recalled notes + a reused skill
@@ -360,6 +420,16 @@ async function materializeAgent(
  * unattended fire after re-enable would still use the keyed web backend. With
  * installAlarm=false a disabled agent's re-bake writes files only (no schedule),
  * and the metadata keeps enabled:false.
+ *
+ * round 2: this pass-level queue is now a SECOND, coarser layer on top of
+ * materializeAgent's own per-call queue (see its comment above). This one still
+ * matters on its own: it makes a whole PASS (every autonomous agent's write)
+ * atomic relative to another pass, so two rapid toggles can't interleave their
+ * writes agent-by-agent (e.g. pass1=ON writes agent A, pass2=OFF writes agent
+ * A, pass1=ON writes agent B — the per-call queue alone only orders individual
+ * writes, it doesn't guarantee a whole pass finishes before the next starts).
+ * materializeAgent's queue additionally covers every OTHER caller this pass
+ * doesn't touch (ladder attempts, startup repair, install/edit).
  */
 let autonomousRematerializeQueue: Promise<void> = Promise.resolve();
 
@@ -626,12 +696,26 @@ async function runLadderAttempts(
     await materializeAgent(attemptAgent, runCommand, false, true, {
       suppressErrorNotification: !isLast,
       suppressAction: materializeOpts.suppressAction,
-      // N1: lets generateRunScript keep a keyed web tool (Gemini/Perplexity) for
-      // an autonomous run instead of refusing it — the ladder only put one here
-      // when consent + needsWeb held, and secret-guard still re-forces local.
-      autonomousCloudConsent: env.autonomousCloudConsent,
-      // This loop pins ONE tool per attempt and owns escalation; don't also bake
-      // an in-shell web→Codex fallback (it would run Codex twice).
+      // round 2 TOCTOU fix: deliberately do NOT pass env.autonomousCloudConsent
+      // (read once, before this loop started) as the BAKED script value. A
+      // multi-candidate ladder can span a full agent run — up to
+      // AGENT_RUN_WAIT_TIMEOUT_MS (20 minutes) — between attempts via the
+      // waitForAgentRunCompletion await below; that is a real window in which
+      // the user can revoke consent in Settings. Baking the stale `env` value
+      // here for attempt i>0 would re-write a script claiming consent that is
+      // no longer current — the exact fail-closed violation round 1 missed
+      // (it only serialized rematerializeAutonomousAgents against itself, not
+      // against this loop). Leaving autonomousCloudConsent undefined lets
+      // materializeAgent's own queued turn read consent from disk immediately
+      // before ITS write (see materializeAgent's comment), inside the same
+      // queue turn as the write — no other queued write can land between that
+      // read and this attempt's write. `env.autonomousCloudConsent` above is
+      // still used to build `ladder` (line ~676): which tool to TRY next is an
+      // attended/foreground routing choice, not the unattended-safety property
+      // this fixes. If consent is revoked mid-ladder, this attempt's freshly
+      // re-read false value makes generateRunScript refuse/fall back the
+      // now-unauthorized keyed tool and the ladder escalates — the safe
+      // outcome, not a stale ON write surviving to disk.
       suppressWebCodexBake: true,
     });
     await TerminalEmulator.runAgent(agentId);

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -1306,9 +1306,20 @@ export function generateSaveCommand(agent: Agent): string {
   return `mkdir -p ${shellQuote(dir)} && echo '${escaped}' > ${shellQuote(`${dir}/${agent.id}.json`)}`;
 }
 
+/**
+ * Atomic write: `cat > path` would TRUNCATE in place, so an alarm-fired run
+ * already reading the script (bash reads scripts incrementally) could execute
+ * a garbled tail — consent re-bake / startup repair / ladder overrides all
+ * rewrite live scripts. Write to a unique tmp in the same dir and rename
+ * (atomic on the same filesystem). A rename replaces the inode, dropping the
+ * exec bit `cat >` used to preserve — carry it over from the existing file
+ * before the mv so a fire between mv and the caller's chmod +x still runs.
+ */
 function writeFileCommand(path: string, content: string): string {
   const marker = `SHELLY_AGENT_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
-  return `mkdir -p "$(dirname ${shellQuote(path)})" && cat > ${shellQuote(path)} <<'${marker}'
+  const target = shellQuote(path);
+  const tmp = shellQuote(`${path}.${marker}.tmp`);
+  return `mkdir -p "$(dirname ${target})" && cat > ${tmp} <<'${marker}' && { [ ! -x ${target} ] || chmod +x ${tmp}; } && mv -f ${tmp} ${target}
 ${content}
 ${marker}`;
 }

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -345,6 +345,42 @@ async function materializeAgent(
 }
 
 /**
+ * N1 follow-up: the autonomous-cloud consent flags are BAKED into each agent's
+ * on-disk run script at materialize time, so a mid-session settings toggle
+ * leaves the scripts the UNATTENDED alarm/native fires read stale until the
+ * next app-launch startup repair. Call this right AFTER the consent env flush
+ * (the .env write must land first — materializeAgent reads consent from disk)
+ * so every autonomous agent's script re-bakes with the new consent immediately.
+ * Alarms are untouched (the PendingIntent doesn't encode consent). Best-effort:
+ * a failed re-bake self-heals on the next startup repair / foreground run.
+ *
+ * Deliberately includes DISABLED agents: setAgentEnabled(true) re-installs the
+ * alarm without re-materializing, so skipping a disabled agent here would let a
+ * consent REVOKED while it was disabled survive in its baked script — the next
+ * unattended fire after re-enable would still use the keyed web backend. With
+ * installAlarm=false a disabled agent's re-bake writes files only (no schedule),
+ * and the metadata keeps enabled:false.
+ */
+export async function rematerializeAutonomousAgents(
+  runCommand: (cmd: string) => Promise<string>
+): Promise<void> {
+  const autonomousAgents = useAgentStore
+    .getState()
+    .agents.filter((agent) => agent.autonomous);
+  for (const agent of autonomousAgents) {
+    // Skip agents deleted while iterating — re-materializing a captured
+    // snapshot would rewrite its <id>.json and resurrect it (same guard as
+    // the startup repair).
+    if (!useAgentStore.getState().agents.some((a) => a.id === agent.id)) continue;
+    try {
+      await materializeAgent(agent, runCommand, false, false);
+    } catch (error) {
+      logWarn('AgentEnvSync', `failed to re-bake consent into agent ${agent.id}`, error);
+    }
+  }
+}
+
+/**
  * Build the EFFECTIVE agent whose prompt is prefixed with recalled memory (G2)
  * and a reused skill recipe (G3). Both blocks flow through generateRunScript →
  * resolveAgentRoute, which scans agent.prompt with secret-guard, so a secret
@@ -466,8 +502,12 @@ export async function runAgentNow(
 async function ladderEnvFromDisk(runCommand: (cmd: string) => Promise<string>): Promise<LadderEnv> {
   try {
     const out = await runCommand(
-      `for k in CEREBRAS_API_KEY GROQ_API_KEY; do ` +
-        `grep -qE "^$k=.+" "$HOME/.shelly/agents/.env" 2>/dev/null && echo "$k=1" || echo "$k=0"; done; ` +
+      // Key-present check must reject a CLEARED key: settings-store writes values
+      // via dotenvValue() (always single-quoted), so an emptied key remains in the
+      // file as KEY=''. Require a non-quote char after the optional opening quote —
+      // `.+` would match the two bare quotes and misreport the key as present.
+      `for k in CEREBRAS_API_KEY GROQ_API_KEY PERPLEXITY_API_KEY GEMINI_API_KEY; do ` +
+        `grep -qE "^$k=['\\"]?[^'\\"]" "$HOME/.shelly/agents/.env" 2>/dev/null && echo "$k=1" || echo "$k=0"; done; ` +
         // N1: the autonomous-cloud consent flags are written by settings-store as
         // explicit 0/1 (not "key present"), so read their VALUE, defaulting to 0.
         `for k in SHELLY_AUTONOMOUS_CLOUD SHELLY_AUTONOMOUS_CLOUD_STOP; do ` +
@@ -476,6 +516,10 @@ async function ladderEnvFromDisk(runCommand: (cmd: string) => Promise<string>): 
     return {
       hasCerebrasKey: /CEREBRAS_API_KEY=1/.test(out),
       hasGroqKey: /GROQ_API_KEY=1/.test(out),
+      // G4 P1 key preflight: known-missing Perplexity/Gemini keys let the
+      // ladder skip a backend that cannot authenticate (auto-scorer picks only).
+      hasPerplexityKey: /PERPLEXITY_API_KEY=1/.test(out),
+      hasGeminiKey: /GEMINI_API_KEY=1/.test(out),
       // Consent defaults OFF (fail-closed) when the flag is absent/unreadable.
       // Anchor to an exact `1` (optionally quoted — settings-store writes the
       // value via dotenvValue() which wraps it as '1', so the .env line is
@@ -510,8 +554,13 @@ async function runEscalatingAttempts(
   const { ladder } = await runLadderAttempts(agent, agent.id, runCommand, options, runStartedAtMs);
 
   // Restore the agent's own (un-overridden) script so a later scheduled fire uses
-  // the configured tool / fresh route, not the last escalation override.
-  if (!ladder.noEscalation && ladder.tools.length > 1) {
+  // the configured tool / fresh route, not the last escalation override. Any
+  // non-noEscalation ladder pins the attempt tool into the on-disk script — even
+  // a SINGLE-element one (e.g. keyless web-mandatory → [Codex]) — so restore
+  // whenever an override could have been written, not only on multi-tool ladders
+  // (otherwise adding the missing key later wouldn't reach the alarm path until
+  // an unrelated re-materialize).
+  if (!ladder.noEscalation) {
     try {
       await materializeAgent(agent, runCommand, false);
     } catch (error) {

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -361,23 +361,37 @@ async function materializeAgent(
  * installAlarm=false a disabled agent's re-bake writes files only (no schedule),
  * and the metadata keeps enabled:false.
  */
-export async function rematerializeAutonomousAgents(
+let autonomousRematerializeQueue: Promise<void> = Promise.resolve();
+
+export function rematerializeAutonomousAgents(
   runCommand: (cmd: string) => Promise<string>
 ): Promise<void> {
-  const autonomousAgents = useAgentStore
-    .getState()
-    .agents.filter((agent) => agent.autonomous);
-  for (const agent of autonomousAgents) {
-    // Skip agents deleted while iterating — re-materializing a captured
-    // snapshot would rewrite its <id>.json and resurrect it (same guard as
-    // the startup repair).
-    if (!useAgentStore.getState().agents.some((a) => a.id === agent.id)) continue;
-    try {
-      await materializeAgent(agent, runCommand, false, false);
-    } catch (error) {
-      logWarn('AgentEnvSync', `failed to re-bake consent into agent ${agent.id}`, error);
+  // Consent is security-sensitive state baked into scripts that can run
+  // unattended. Queue the entire pass so an older pass can never finish a
+  // stale write after a newer pass. Take the agent snapshot inside the queued
+  // turn; materializeAgent likewise reads consent from disk only once that turn
+  // starts, after the preceding pass has fully completed.
+  const turn = autonomousRematerializeQueue.then(async () => {
+    const autonomousAgents = useAgentStore
+      .getState()
+      .agents.filter((agent) => agent.autonomous);
+    for (const agent of autonomousAgents) {
+      // Skip agents deleted while iterating — re-materializing a captured
+      // snapshot would rewrite its <id>.json and resurrect it (same guard as
+      // the startup repair).
+      if (!useAgentStore.getState().agents.some((a) => a.id === agent.id)) continue;
+      try {
+        await materializeAgent(agent, runCommand, false, false);
+      } catch (error) {
+        logWarn('AgentEnvSync', `failed to re-bake consent into agent ${agent.id}`, error);
+      }
     }
-  }
+  });
+
+  // A rejected turn must not poison the mutex and prevent later revocations
+  // from being applied. Callers still observe their own turn's rejection.
+  autonomousRematerializeQueue = turn.catch(() => undefined);
+  return turn;
 }
 
 /**


### PR DESCRIPTION
## What

Ports 2 already-implemented-and-reviewed commits from `origin/claude/status-assessment-progress-6yur6m` (`43d282b1a` atomic writeFileCommand, `9af50965d` cloud-key preflight + instant consent re-bake), identified by tonight's gap-scoping research as the last unlock for a fully **unattended, scheduled** North-Star run (the escalation ladder, autonomous-cloud opt-in, in-Vault auto-approval, and the G6 STEAM pipeline preset were all already on main).

## Why

1. **Atomic writeFileCommand** — fixes a real correctness bug: the live agent `.sh` script / metadata / PlanSpec files could be truncated if a write raced a read of the same file. Now writes to a same-directory unique tmp file + `mv -f`, preserving the executable bit before rename.
2. **Cloud-key preflight + instant consent re-bake** — two problems: (a) a scheduled/alarm-fired agent's on-disk script previously baked the autonomous-cloud-consent setting at materialize time, so toggling the setting in Settings had no effect on an already-scheduled agent until it was re-materialized; now `.env` consent changes flush and instantly re-bake into every autonomous agent's script (the alarm schedule itself is untouched). (b) the escalation ladder now preflights whether a cloud backend's API key is actually present, dropping keyless candidates upfront instead of wasting a full attempt-and-fail cycle before falling through.

## Safety — fail-closed invariant preserved

Consent is enabled only by an exact `SHELLY_AUTONOMOUS_CLOUD=1` match (`lib/agent-manager.ts:528`); any read failure defaults to `false` (`:534`); the key preflight only ever **removes** candidates from the ladder (`lib/agent-escalation-ladder.ts:197`), never adds one. Unattended capability cannot silently widen without a fresh, explicit consent action — confirmed by the port task and independently re-verified during recovery (see below).

## Provenance note

Implemented by a sandboxed Codex background task, which completed the port (resolving the only real conflict, a DEFERRED.md History-entry collision with the just-merged PR #119, by keeping both entries) and all local verification, but could not push (its sandbox blocked GitHub HTTPS/`gh` entirely). I (CC) recovered its local commits, rebased onto current `main` (one additional DEFERRED.md conflict against PR #119's own new entry, resolved the same way — kept both), ran a real `pnpm install --frozen-lockfile`, and re-verified everything below myself before pushing.

## Verification

- `tsc --noEmit`: clean.
- `__tests__/agent-escalation-ladder.test.ts`: 28/28 pass, including the secret-guard-wins-over-consent and consent-does-not-widen-non-web-autonomous-tasks invariant tests.
- `expo lint`: 0 errors, 2 pre-existing warnings in an unrelated file.
- `git diff --check`: clean.