### PR TITLE
feat(widget): run scheduled agent from home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ No Termux install. No proot. No ttyd. No remote bridge.
 | **Multi-agent AI** | API-backed Gemini, Cerebras, Groq, Perplexity, Local LLM, plus the foreground Codex terminal CLI. Auto-routed or `@mention` where supported. |
 | **Local LLM (on-device, llama.cpp)** | Qwen3.5 models run on-device through the bundled llama.cpp / llama-server flow, with Qwen3.5-2B as the daily-driver default, Qwen3 1.7B / Qwen3.5 0.8B as lighter fallbacks, and 4B+ models reserved for short quality checks. |
 | **Codex on Android** | Shelly keeps Codex on a managed-latest path without trusting upstream blindly: each APK bundles a pinned runtime, the Updates UI can promote verified runtime releases, and Reset falls back to the bundled runtime. Codex runs over the native PTY with a Shelly-owned device-code login wrapper. No proot, no root. |
-| **Scouter home widget** | A translucent Android widget shows Codex state, model, always-on token / context / limit cells, local LLM health, and device load without opening the app. It is interactive: **ASK** can deliver a prompt to a live, resumed, or freshly-started Codex PTY; **Allow / Deny** and up to six widget choice pills answer Codex straight from the launcher. |
+| **Scouter home widget** | A translucent Android widget shows Codex state, model, always-on token / context / limit cells, local LLM health, device load, and the next scheduled agent without opening the app. It is interactive: **RUN** starts that already-registered agent through the unattended execution gates; **ASK**, **Allow / Deny**, and choice pills control the foreground Codex PTY. |
 | **Color themes** | Blue / Red / Purple palettes run on the existing preset IDs, so runtime swaps keep your shell alive without settings migration. |
 | **Voice input** | Speak your commands or AI prompts. Groq Whisper handles transcription, then VoiceChain routes the text through the same input router the keyboard uses. |
 
@@ -256,7 +256,8 @@ Scouter is Shelly's home-screen status layer. It keeps the current Codex
 session, local LLM endpoint, token / context flow, rate-limit windows, and
 device load visible while the phone stays in the launcher or another app.
 It is not read-only — the widget can drive the foreground Codex terminal,
-resume a stale binding, or cold-start a new Codex PTY for a queued prompt.
+resume a stale binding, cold-start a new Codex PTY for a queued prompt, or run
+the next already-registered scheduled agent without opening Shelly.
 
 <details>
 <summary><strong>What it shows</strong></summary>
@@ -268,6 +269,7 @@ resume a stale binding, or cold-start a new Codex PTY for a queued prompt.
 - **Rate-limit override** — when the session is throttled the line collapses to `RATE LIMITED` with the reset detail
 - **Reset / session timer** — a self-ticking chronometer counts down to the rate-limit reset, or counts up the running session
 - **Privacy-safe prompt preview** — only the current widget ASK / approval / choice / error state can occupy the preview; historical JSONL prompts and replies are not surfaced, and closing all Agent Chat tabs blanks the preview area instead of shrinking the widget
+- **Scheduled-agent status** — shows the next registered agent and fire time plus the latest widget-triggered running / success / error result
 - **Local LLM row** — endpoint, backend, queue depth, and ping for the local server
 - **Footer** — CPU / RAM load and last-updated time
 - **Codex pets** — an optional PET button / pet image renders the bundled demo pet or the user's imported Codex pets without bundling private user pets into the APK
@@ -278,6 +280,7 @@ resume a stale binding, or cold-start a new Codex PTY for a queued prompt.
 <summary><strong>Interactive control</strong></summary>
 
 - **ASK** — tap the ASK pill to type a prompt; Shelly writes it into the bound foreground Codex terminal (clear line, paste, Enter) and returns you to the launcher
+- **RUN scheduled agent** — starts the next enabled, scheduled agent directly through the foreground service without opening the app; Shelly revalidates its disk metadata at tap time, honors STOP-ALL, and keeps unattended per-action approval fail-closed
 - **Cold-start ASK** — if no Codex or Agent Chat session is available, Shelly queues the widget prompt, opens a terminal, waits for the PTY to become alive, starts `codex`, waits for the Codex input surface, then delivers the queued prompt
 - **Approval pills** — when Codex is waiting for permission, **Allow** / **Deny** pills write `y` / `n` straight to the Codex PTY
 - **Choice pills** — for a numbered interactive prompt, up to six widget pills write the chosen digit to the PTY, each carrying the option label; Android notifications expose the first three actions
@@ -285,7 +288,7 @@ resume a stale binding, or cold-start a new Codex PTY for a queued prompt.
 - **Pet import** — Settings -> Scouter -> Import pet ZIP installs user pets into app-private storage. Shelly also discovers `Codex/pets` and `shelly-personal-pets.zip` sidecar files on shared storage for users who manage Codex pets outside the APK
 - **Stale-tap guard** — Allow / Deny / choice taps re-parse the live terminal screen and only fire if the same approval anchor or numbered option is still on screen; otherwise they no-op
 - **Resume when unbound** — if the bound terminal has exited, ASK (and a pending approval) queue the prompt/decision and open Agent Chat to resume the session, then drain the queued action
-- **How it reaches the terminal** — the widget's tap handler runs inside the app process and writes straight to the live PTY through the in-process terminal session registry — no `am start`, no IPC; when nothing is bound it opens Agent Chat with a `shelly:///agent-chat` deep-link to resume first
+- **How controls are dispatched** — ASK / approval / choice controls write to the live PTY through the in-process terminal session registry; RUN uses a direct foreground-service PendingIntent matching scheduled fires. Neither path shells out through `am start`
 
 </details>
 

--- a/__tests__/agent-alarm-request-code-race.test.ts
+++ b/__tests__/agent-alarm-request-code-race.test.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const scheduler = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '..',
+    'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmScheduler.kt',
+  ),
+  'utf8',
+);
+
+describe('AgentAlarmScheduler request-code allocation', () => {
+  it('serializes the complete SharedPreferences read-modify-write on a stable object lock', () => {
+    expect(scheduler).toContain('private val requestCodeLock = Any()');
+
+    const start = scheduler.indexOf('fun getAgentRequestCode(');
+    const end = scheduler.indexOf('/** The alarm operation', start);
+    const allocation = start >= 0 && end > start ? scheduler.slice(start, end) : undefined;
+
+    expect(allocation).toBeDefined();
+    expect(allocation).toMatch(
+      /= synchronized\(requestCodeLock\) \{[\s\S]*getSharedPreferences[\s\S]*getInt\(agentId, -1\)[\s\S]*getInt\("_next_id", 1000\)[\s\S]*putInt\(agentId, nextId\)[\s\S]*putInt\("_next_id", nextId \+ 1\)[\s\S]*\.apply\(\)[\s\S]*\n    }/,
+    );
+    expect(allocation).toContain('return@synchronized existing');
+  });
+});

--- a/__tests__/widget-agent-run-parity.test.ts
+++ b/__tests__/widget-agent-run-parity.test.ts
@@ -1,0 +1,85 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Offline security gate for the widget RUN path. Jest cannot execute Android
+// PendingIntents, so these checks keep the service contract and its fail-closed
+// guards coupled until the device acceptance pass can exercise them end to end.
+const root = path.resolve(__dirname, '..');
+const read = (p: string) => fs.readFileSync(path.join(root, p), 'utf8');
+
+describe('Scouter widget registered-agent RUN security parity', () => {
+  const scheduler = read(
+    'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmScheduler.kt',
+  );
+  const service = read(
+    'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalSessionService.kt',
+  );
+  const provider = read(
+    'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterWidgetProvider.kt',
+  );
+  const repository = read(
+    'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/WidgetAgentRepository.kt',
+  );
+  const stateStore = read(
+    'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterStateStore.kt',
+  );
+  const layout = read(
+    'modules/terminal-emulator/android/src/main/res/layout/scouter_widget_medium.xml',
+  );
+
+  it('binds RUN directly to the foreground-service contract with a distinct PendingIntent identity', () => {
+    expect(provider).toContain('AgentAlarmScheduler.manualRunPendingIntent(context, target.agentId)');
+    expect(scheduler).toContain('action = TerminalSessionService.ACTION_RUN_AGENT');
+    expect(scheduler).toContain('putExtra(TerminalSessionService.EXTRA_AGENT_ID, agentId)');
+    expect(scheduler).toContain('putExtra(TerminalSessionService.EXTRA_MANUAL, true)');
+    expect(scheduler).toContain('getAgentRequestCode(context, "widget-run:$agentId")');
+    expect(scheduler).toContain('PendingIntent.getForegroundService(context, rc, intent, piFlags())');
+  });
+
+  it('revalidates a scheduled, enabled, materialized agent from disk at render and tap time', () => {
+    expect(provider).toContain('WidgetAgentRepository.nextScheduled(context)');
+    expect(service).toContain('WidgetAgentRepository.scheduledById(applicationContext, agentId)');
+    expect(repository).toContain('HomeInitializer.getHomeDir(context.applicationContext)');
+    expect(repository).toContain('if (id != expectedId || !SAFE_AGENT_ID.matches(id)) return null');
+    expect(repository).toContain('if (!json.optBoolean("enabled", false)) return null');
+    expect(repository).toContain('AgentAlarmScheduler.nextTriggerAt(cron) ?: return null');
+    expect(repository).toContain('run-agent-$id.sh');
+    expect(repository).toContain('plans/plan-agent-$id.json');
+  });
+
+  it('keeps widget runs unattended and does not re-arm their schedule', () => {
+    expect(service).toContain('val unattended = scheduled || manual');
+    expect(service).toContain('if (!manual && scheduled)');
+    expect(service).toContain(
+      'runAgentInBackground(agentId, tainted, unattended, manual, widgetAgent?.name)',
+    );
+  });
+
+  it('checks STOP-ALL before accepting the manual widget marker', () => {
+    const haltCheck = service.indexOf('if (isGloballyHalted())');
+    const manualRead = service.indexOf('getBooleanExtra(EXTRA_MANUAL, false)');
+    const runtimeCall = service.indexOf(
+      'runAgentInBackground(agentId, tainted, unattended, manual, widgetAgent?.name)',
+    );
+    expect(haltCheck).toBeGreaterThan(-1);
+    expect(manualRead).toBeGreaterThan(haltCheck);
+    expect(runtimeCall).toBeGreaterThan(manualRead);
+  });
+
+  it('adds a dedicated status/RUN row without adding a schedule approval action', () => {
+    expect(layout).toContain('@+id/scouter_agent_status');
+    expect(layout).toContain('@+id/scouter_agent_run');
+    expect(service).toContain('recordWidgetAgentRunStarted');
+    expect(service).toContain('recordWidgetAgentRunFinished');
+    expect(stateStore).toContain('widgetAgentRunStatus');
+
+    const runBinding = provider.slice(
+      provider.indexOf('private fun bindWidgetAgentRun'),
+      provider.indexOf('private fun widgetAgentLastRunLabel'),
+    );
+    expect(runBinding).not.toContain('ALLOW');
+    expect(runBinding).not.toContain('DENY');
+    expect(runBinding).not.toContain('writeToSession');
+    expect(runBinding).not.toContain('ScouterWidgetPromptActivity');
+  });
+});

--- a/components/scouter/ScouterDetailModal.tsx
+++ b/components/scouter/ScouterDetailModal.tsx
@@ -74,6 +74,11 @@ type ScouterWidgetConversation = {
   widgetStatus?: string | null;
   widgetStatusAt?: number | null;
   widgetError?: string | null;
+  widgetAgentRunId?: string | null;
+  widgetAgentRunName?: string | null;
+  widgetAgentRunStatus?: 'running' | 'success' | 'error' | null;
+  widgetAgentRunStatusAt?: number | null;
+  widgetAgentRunError?: string | null;
   privacySuppressed?: boolean | null;
 };
 

--- a/docs/superpowers/DEFERRED.md
+++ b/docs/superpowers/DEFERRED.md
@@ -615,21 +615,21 @@ fail-loud する。詳細:
 
 ### Secretary MVP — ウィジェット導線 (Scouter widget 拡張: trigger + status)
 
-**優先度**: P1 (着手条件クリア。実装はモバイル連携セッションで)
-**状態**: 🟢 着手可。**ブロッカー（コアループ未完）は解消** — コアループ (NL→確認カード→ゲート→action→無人 AlarmManager 発火) は **v7.0.0 で on-device 立証・出荷済み** (N=1 デモ)。ユーザー決定 (2026-06-27): **A（入力ショートカット）と B（登録済みエージェントを1タップ RUN＝カード無しの本物）を両方実装**。実装はモバイル連携セッションで後ほど。
-**→ 実装引き継ぎ (cold-start resume)**: `docs/superpowers/specs/2026-06-27-widget-agent-launch-handoff.md`（HEAD の file:line・A/B 設計・ガード・実機検証手順を内蔵）。**B の肝**: widget ボタン → `PendingIntent.getForegroundService` で `TerminalSessionService.ACTION_RUN_AGENT`（v7.0.0 のアラーム発火と同一 intent）を叩く＝アプリを開かずカード無しで既存エージェントを発火。
+**優先度**: Task B ✅ 実装済み (`154525d3fb`、実機検証待ち) / Task A P2
+**状態**: **Task B（登録済みエージェントを1タップ RUN）は 2026-07-13 に実装済み**。Scouter は disk 上の有効な schedule 済み agent から次回 fire が最も近い1件を毎 render / tap 時に再検証し、`PendingIntent.getForegroundService` → `TerminalSessionService.ACTION_RUN_AGENT` で unattended 実行する。STOP-ALL、per-action approval の fail-closed、scheduled fire の re-arm は維持。Task A（入力ショートカット）は今回の B 優先 dispatch では未実装のため P2 として継続。
+**設計・実機検証手順**: `docs/superpowers/specs/2026-06-27-widget-agent-launch-handoff.md`（A/B 設計・ガード・実機検証手順を内蔵）。**B の肝**: widget ボタン → `PendingIntent.getForegroundService` で `TerminalSessionService.ACTION_RUN_AGENT`（v7.0.0 のアラーム発火と同一 contract）を叩く＝アプリを開かずカード無しで既存エージェントを発火。
 
 **何を足すか** (既存 `ScouterWidgetProvider.kt` の拡張であって新規 widget ではない — インフラは 2026-06-10 に実機 PASS 済み):
-- **トリガー導線** — ウィジェットから「〇〇やって」を最短距離で開始。`ScouterWidgetPromptActivity` に deep-link action (例 `shelly://agent/new?voice=1`) を1本追加し、tap → チャットを音声待機状態で開く。配線 (`promptPendingIntent` / `ScouterWidgetPromptActivity` / `$HOME/.shelly-deep-link-queue` poll) は全て既存・実証済み。**ほぼタダ。**
-- **ステータス行** — 次回スケジュール実行 (agent name + 次 fire 時刻) と直近結果 (success/error) を `ScouterStateStore` snapshot に2フィールド追加してレンダ。上の「Scouter Widget 残ポリッシュ (gitBranch/lastError を widget へ)」と同じ snapshot 拡張パターン。**安い。**
+- **Task A — 入力ショートカット (P2、未実装)** — ウィジェットから「〇〇やって」を最短距離で開始。`ScouterWidgetPromptActivity` に deep-link action (例 `shelly://agent/new?voice=1`) を1本追加し、tap → チャットを音声待機状態で開く。配線 (`promptPendingIntent` / `ScouterWidgetPromptActivity` / `$HOME/.shelly-deep-link-queue` poll) は全て既存・実証済み。
+- **Task B — 登録済み agent RUN + status (✅ `154525d3fb`)** — 次 scheduled agent の RUN ボタン、次回 fire 時刻、直近の running/success/error を表示。manual marker により schedule を re-arm せず、実行自体は unattended として approval を fail-closed にする。
 
 **やらないこと / ガード**:
 - **スケジュール自律実行の承認をウィジェットに置かない。** 既存の widget 承認ピル (ALLOW/DENY) は*ライブ Codex PTY* に `y\r` を書く方式で、スケジュール実行には PTY が無い。スケジュール承認は MVP §2.6 の「run-id 束縛・単回・期限付き」を満たす net-new ハンドラ (B5) が必要で、これは**通知側に置く**。ウィジェットの既存ライブ PTY 承認は残すが、スケジュール承認導線は足さない (replay/stale を招くため)。
 - 承認をどうしてもウィジェットに出す場合は B5 の stored-action dispatch ハンドラに相乗りし、single-use/expiry を必ず共有すること。別実装で速攻ボタンを作らない。
 
-**Why not now**: MVP の "one outcome" は NL→カード→ゲート→action のコアループ。ウィジェット導線は追加導線であって核ではなく、コアループ未完で先に作っても見せ場が無い。ただしインフラが既存なので、コアループ着地後の着手コストは小さい (trigger=deep-link 1本 / status=snapshot 2フィールド)。
+**Why Task A remains deferred**: 今回の dispatch は security-sensitive な Task B を完全に着地させることを最優先とし、別の deep-link / 音声待機 UI と実機 QA を要する Task A を同じ差分へ混ぜなかった。
 
-→ sync: 着手時に MVP spec の §7 Parked から本項へ移動し、README Secretary 節に widget 導線を追記。
+→ sync: ✅ MVP Phase 0 spec §8 と README Scouter Widget に反映済み（本 PR）。
 
 ### 一過性レイアウト崩れ — Updates モーダル開閉
 
@@ -2177,6 +2177,8 @@ claude() {
 
 - **2026-07-13 (Batch 10)**: BOOT-AUTOSTART の dormant port を `58a378834` / `20ae526c3` / `c85f4ca1e` から再構成。`BOOT_COMPLETED` receiver と Doze exemption permission、native persisted-schedule re-arm、host reference/tests を追加し、receiver-level `android:permission` は送信者を制約して配信を壊すため除去、receiver 登録は prebuild で残る `plugins/with-terminal-service.js` を source of truth（checked-in manifest は readability mirror）とした。native flag `shelly_boot_autostart.enabled` は既定 `false`、production setter なしのため既存 agent は reboot 時も再 arm されない。将来の flag enable に備え、`$HOME/.shelly/agents/.halted` 存在時は persisted schedule を一件も再 arm しない STOP-ALL guard も追加。host gate（`pnpm run check` / `expo lint` / boot-autostart 16 tests / `git diff --check`）PASS。**実機 reboot / Doze / One UI / flag-enabled end-to-end は未検証であり、有効化前の follow-up 必須**。新規 L1 permission（`RECEIVE_BOOT_COMPLETED` / `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`）反映には APK rebuild + reinstall が必要。→ sync: なし（既定 OFF の内部基盤）。
 - **2026-07-13（main 追いつかせバッチ、実機検証セッション）**: PR #98〜#112（SKILL-001 / CAP-001·SECRET-001·HTTP-001 broker / agent scheduling hourly·multi-daily / EVENT-001 core / capability-broker redaction fix / agent-store name guard / NOTIFY-001 / PlanSpec executor core+FS-001·EXEC-001 / MODEL-001 / boot-autostart / INTENT-001 / MEMORY-001 / DM-pairing）を全て `main` にマージ。マージ過程で2件の実マージリグレッションを検出・修正——① `AgentRuntime.kt` の `PLAN_EXECUTOR_ACTIONS` allowlist が PR #112（dm-reply）ベースにコンフリクト解消され `intent` が脱落し、attended な PlanSpec 経由 intent action が全拒否される状態になっていた（Codex 発見）。② legacy `.sh` executor の `intent)` ケースが `return 0` を失い次ケースへフォールスルーする潜在バグ（CC 発見、実害なし）。両方とも独立レビュー→修正コミット→再レビューを経てマージ。build 1872（PR #110 マージ後、versionCode 1872）で実機（Galaxy Z Fold6、Android 16、SM-F956Q）検証: Notification Access 許可（`dev.shelly.terminal/expo.modules.terminalemulator.ShellyNotificationListener`）は Samsung の設定画面が adb 合成タップを受け付けないため物理タップが必須（自動化不可、既知の制約として記録）——付与後は `settings get secure enabled_notification_listeners` で確認可能。DM-pairing の自己完結型ラウンドトリップテスト（Settings → DM PAIRING → RUN SELF-CONTAINED REPLY TEST）は **実機で PASS**（"Self-contained notification reply round trip passed."）——ただしこのテストは通知投稿から返信送信までの内部ラウンドトリップを検証するもので、通知の可視時間は1秒未満（RemoteInput 返信で即座に消える設計であり正常）。ログで `onNotificationPosted` の発火自体も確認。副次的な軽微バグを発見：`findAgentsTriggeredBy`（`ShellyNotificationListener.kt:355`）が `.shelly/agents/` 配下の全ファイルを agent JSON として無条件パースしており、`custom-auth-refs.json`（JSON 配列、agent 設定ではない）に対して通知ごとに `JSONException` を投げてログをスパムする（catch 済みで機能的には無害、ノイズのみ）——P2 として別途登録が必要。ワイヤレス adb は最新の Wireless Debugging ペアリング（`adb pair`）が2種類の adb バイナリ（scrcpy 同梱版・公式 platform-tools 版）両方で `protocol fault (couldn't read status message)` を再現性高く起こし、コード更新・ネットワーク疎通確認をしても解消せず未解決のまま——回避策として USB 接続確立後に `adb tcpip 5555` → `adb connect <ip>:5555` で無線に切り替える方式が有効だったと確認（ペアリングフロー自体を迂回）。NOTIFY-001 の実機 end-to-end（外部アプリ通知でのエージェント起動）は本エントリ時点で未実施、次回に持ち越し。→ sync: なし（内部検証ログ）。
+
+- **2026-07-13 (Scouter widget agent RUN / Task B)**: `154525d3fb` で、home widget から既存の schedule 済み agent をアプリ画面なしで1タップ実行する導線を実装。対象は `~/.shelly/agents/*.json` と materialized run artifact を render/tap の両時点で再検証し、削除・disabled・不正 id・schedule 無し・artifact 無しを拒否。direct foreground-service PendingIntent は alarm と別 request code にして extras 上書きを防止し、native chokepoint の `.halted` check を通過した場合だけ `unattended=true` で実行、manual run は schedule を re-arm しない。widget には next fire と直近 running/success/error のみを表示し、schedule approval action は追加していない。Task A（入力 shortcut）は P2 継続。TypeScript check、focused parity tests 5件、focused test source lint、`git diff --check` は PASS。Gradle wrapper / system Gradle が無く Kotlin compile は未実施、実機 tap / STOP-ALL / fail-closed / scheduled re-arm 非干渉は PR review 後の device gate。→ sync: README Scouter Widget / Phase 0 spec。
 
 - **2026-07-13 (P1, Batch 6 DM pairing)**: current main の schema-v1 PlanSpec と既存 generic Review 契約へ、承認コードによる通知会話ペアリング + `dm-reply` を手動再構成。通知 read/trigger と reply-send の独立2フラグはともに既定 OFF、返信は毎回 in-app Review 必須で、自動承認 (`0686f4a7` 以降) は不採用。disk mirror は atomic rename の前後で `sync` し、native send 時に再読込・取消即時反映・live fingerprint 完全一致・10秒 send debounce・本文非ログを適用。自己完結テストは Shelly 自身の通知だけを使う。**実機の Notification Access grant、実アプリの承認コード検出、実会話への reply round-trip、OEM/Android 16 の RemoteInput 挙動は未検証で、有効化前の必須 P1 gate**。→ sync: なし（既定 OFF の内部機能）。
 

--- a/docs/superpowers/specs/2026-06-16-hermes-secretary-mvp-phase0.md
+++ b/docs/superpowers/specs/2026-06-16-hermes-secretary-mvp-phase0.md
@@ -104,3 +104,9 @@ Per project rule, changes touching native (notification handler, deep-link bridg
 - **Shelly-side multi-step agentic orchestration / parallel sub-agents** — North Star Phase 4.
 - **Persistent memory layer, skill auto-generation, inbound messaging gateway, browser automation** — North Star Phases 1–4.
 - **`publish` action capability** — distinct type, deliberately not shipped.
+
+## 8. Completed fast-follow — Scouter widget registered-agent RUN
+
+- **Task B shipped in `154525d3fb` (2026-07-13; device verification pending).** The widget selects the next enabled scheduled agent from `~/.shelly/agents/*.json`, revalidates metadata and its materialized run artifact at tap time, then dispatches the existing `TerminalSessionService.ACTION_RUN_AGENT` contract with `PendingIntent.getForegroundService`.
+- The widget run is explicitly unattended, so runtime action approval remains fail-closed; STOP-ALL is enforced at the service chokepoint; the manual marker prevents schedule re-arm; and the widget exposes only next-run plus latest running/success/error status, never a scheduled-run approval shortcut.
+- **Task A (new-agent input / voice shortcut) remains P2** in `DEFERRED.md`; it is a separate deep-link and mobile-UX surface and was not mixed into this security-sensitive native change.

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmScheduler.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmScheduler.kt
@@ -33,6 +33,7 @@ import java.util.Calendar
 object AgentAlarmScheduler {
     private const val TAG = "AgentAlarmScheduler"
     private const val PREFS = "shelly_agent_ids"
+    private val requestCodeLock = Any()
 
     // ── L1 BOOT-AUTOSTART (dormant, flag-OFF) ──────────────────────────────────
     // AlarmManager alarms are cleared on reboot, so scheduled agents stop firing
@@ -107,13 +108,13 @@ object AgentAlarmScheduler {
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
 
     /** Stable per-agent request code, shared with the legacy receiver path. */
-    fun getAgentRequestCode(context: Context, agentId: String): Int {
+    fun getAgentRequestCode(context: Context, agentId: String): Int = synchronized(requestCodeLock) {
         val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
         val existing = prefs.getInt(agentId, -1)
-        if (existing >= 0) return existing
+        if (existing >= 0) return@synchronized existing
         val nextId = prefs.getInt("_next_id", 1000)
         prefs.edit().putInt(agentId, nextId).putInt("_next_id", nextId + 1).apply()
-        return nextId
+        nextId
     }
 
     /** The alarm operation: launch the FGS directly (no broadcast hop). */

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmScheduler.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentAlarmScheduler.kt
@@ -137,6 +137,28 @@ object AgentAlarmScheduler {
         }
     }
 
+    /**
+     * Widget/manual operation using the exact RUN_AGENT service contract as an
+     * alarm fire, but with a separate request-code allocation and a manual marker.
+     * The separate allocation is security/reliability critical: PendingIntent
+     * identity ignores extras, so reusing the alarm request code with
+     * FLAG_UPDATE_CURRENT would replace the scheduled operation's interval/cron
+     * extras and silently break its re-arm loop.
+     */
+    fun manualRunPendingIntent(context: Context, agentId: String): PendingIntent {
+        val intent = Intent(context, TerminalSessionService::class.java).apply {
+            action = TerminalSessionService.ACTION_RUN_AGENT
+            putExtra(TerminalSessionService.EXTRA_AGENT_ID, agentId)
+            putExtra(TerminalSessionService.EXTRA_MANUAL, true)
+        }
+        val rc = getAgentRequestCode(context, "widget-run:$agentId")
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PendingIntent.getForegroundService(context, rc, intent, piFlags())
+        } else {
+            PendingIntent.getService(context, rc, intent, piFlags())
+        }
+    }
+
     /** Legacy broadcast PI — only built to CANCEL alarms armed before this fix. */
     private fun legacyBroadcastPendingIntent(context: Context, agentId: String): PendingIntent {
         val intent = Intent(context, AgentAlarmReceiver::class.java).apply {

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalSessionService.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalSessionService.kt
@@ -15,6 +15,9 @@ import android.os.PowerManager
 import android.util.Log
 import expo.modules.terminalemulator.scouter.AgentActionApprovalBridge
 import expo.modules.terminalemulator.scouter.NotificationDispatcher
+import expo.modules.terminalemulator.scouter.ScouterStateStore
+import expo.modules.terminalemulator.scouter.ScouterWidgetProvider
+import expo.modules.terminalemulator.scouter.WidgetAgentRepository
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -44,6 +47,7 @@ class TerminalSessionService : Service() {
         const val EXTRA_INTERVAL_MS = "interval_ms"
         const val EXTRA_CRON = "cron"
         const val EXTRA_TAINTED = "tainted"
+        const val EXTRA_MANUAL = "manual"
 
         /**
          * Authoritative session registry. Lives here (Service companion) rather
@@ -109,13 +113,42 @@ class TerminalSessionService : Service() {
                 val tainted = intent.getBooleanExtra(EXTRA_TAINTED, false)
                 val intervalMs = intent.getLongExtra(EXTRA_INTERVAL_MS, 0L)
                 val cron = intent.getStringExtra(EXTRA_CRON)
-                val unattended = intervalMs > 0 || !cron.isNullOrBlank()
+                val manual = intent.getBooleanExtra(EXTRA_MANUAL, false)
+                val scheduled = intervalMs > 0 || !cron.isNullOrBlank()
+                val widgetAgent = if (manual) WidgetAgentRepository.scheduledById(applicationContext, agentId) else null
+                if (manual && widgetAgent == null) {
+                    // A widget PendingIntent can outlive the rendered RemoteViews.
+                    // Re-read disk at tap time and refuse deleted, disabled,
+                    // malformed, or no-longer-scheduled agents rather than trusting
+                    // stale extras or an RN in-memory reference.
+                    Log.i(TAG, "Manual widget RUN_AGENT for $agentId refused: registered scheduled agent not found")
+                    if (!hasProtectedWork()) {
+                        startForegroundWithNotification(null)
+                        stopForeground(STOP_FOREGROUND_REMOVE)
+                        stopSelf(startId)
+                        return START_NOT_STICKY
+                    }
+                    startForegroundWithNotification(null)
+                    return START_STICKY
+                }
+                // A widget tap runs without an Activity/attending user. Mark it
+                // unattended so per-action approval remains fail-closed exactly as
+                // for an AlarmManager fire, even though it intentionally carries no
+                // interval/cron extras and must not re-arm the schedule.
+                val unattended = scheduled || manual
                 startForegroundWithNotification("Agent running in background")
-                runAgentInBackground(agentId, tainted, unattended)
+                if (manual) {
+                    ScouterStateStore(applicationContext).recordWidgetAgentRunStarted(
+                        agentId,
+                        widgetAgent!!.name
+                    )
+                    ScouterWidgetProvider.updateAll(applicationContext, force = true)
+                }
+                runAgentInBackground(agentId, tainted, unattended, manual, widgetAgent?.name)
                 // Alarm-fired runs carry interval/cron — re-arm the next fire here now
                 // that the alarm targets this service directly (no receiver in the
                 // loop). A manual run (no interval/cron extras) is a no-op.
-                if (intervalMs > 0 || !cron.isNullOrBlank()) {
+                if (!manual && scheduled) {
                     try {
                         AgentAlarmScheduler.scheduleNext(applicationContext, agentId, intervalMs, cron)
                     } catch (e: Exception) {
@@ -249,7 +282,13 @@ class TerminalSessionService : Service() {
         nm.notify(NOTIFICATION_ID, notification)
     }
 
-    private fun runAgentInBackground(agentId: String, tainted: Boolean, unattended: Boolean) {
+    private fun runAgentInBackground(
+        agentId: String,
+        tainted: Boolean,
+        unattended: Boolean,
+        widgetManual: Boolean = false,
+        widgetAgentName: String? = null
+    ) {
         activeAgentRuns.incrementAndGet()
         Thread {
             val wakeLock = acquireAgentWakeLock(agentId)
@@ -258,10 +297,12 @@ class TerminalSessionService : Service() {
             // backgrounded or the RN JS thread is paused/thermal-killed (the RN
             // 500ms poll in app/_layout.tsx only runs while the Activity is alive).
             val approvalObserver = startAgentActionApprovalObserver()
+            var runResult: AgentRunResult? = null
+            var crashType: String? = null
             try {
                 // AgentRuntime announces the run outcome itself (agent-result /
                 // error notification); we don't need its return value here.
-                AgentRuntime.runAgent(
+                runResult = AgentRuntime.runAgent(
                     applicationContext,
                     agentId,
                     tainted = tainted,
@@ -269,9 +310,26 @@ class TerminalSessionService : Service() {
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "Agent $agentId crashed while running", e)
+                crashType = e.javaClass.simpleName
             } finally {
                 runCatching { approvalObserver?.stopWatching() }
                 releaseAgentWakeLock(wakeLock, agentId)
+            }
+
+            if (widgetManual) {
+                val result = runResult
+                ScouterStateStore(applicationContext).recordWidgetAgentRunFinished(
+                    agentId = agentId,
+                    agentName = widgetAgentName ?: agentId,
+                    success = result?.success == true,
+                    error = when {
+                        crashType != null -> "runtime $crashType"
+                        result == null -> "runtime unavailable"
+                        result.success -> null
+                        else -> "exit ${result.exitCode}"
+                    }
+                )
+                ScouterWidgetProvider.updateAll(applicationContext, force = true)
             }
 
             // The run outcome (success/failure + a readable preview) is announced

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterStateStore.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterStateStore.kt
@@ -17,6 +17,11 @@ data class ScouterWidgetConversation(
     val widgetStatus: String?,
     val widgetStatusAt: Long?,
     val widgetError: String?,
+    val widgetAgentRunId: String?,
+    val widgetAgentRunName: String?,
+    val widgetAgentRunStatus: String?,
+    val widgetAgentRunStatusAt: Long?,
+    val widgetAgentRunError: String?,
     val privacySuppressed: Boolean = false,
     val choiceOptions: List<ChoiceOption> = emptyList()
 )
@@ -225,6 +230,46 @@ class ScouterStateStore(context: Context) {
             .remove(KEY_WIDGET_PRIVACY_SUPPRESSED_CODEX_SESSION_ID)
             .commit()
         writeHelperState()
+    }
+
+    fun recordWidgetAgentRunStarted(agentId: String, agentName: String) {
+        val now = System.currentTimeMillis()
+        synchronized(lock) {
+            prefs.edit()
+                .putString(KEY_WIDGET_AGENT_RUN_ID, agentId)
+                .putString(KEY_WIDGET_AGENT_RUN_NAME, agentName.take(MAX_WIDGET_TEXT_LENGTH))
+                .putString(KEY_WIDGET_AGENT_RUN_STATUS, WIDGET_AGENT_STATUS_RUNNING)
+                .putLong(KEY_WIDGET_AGENT_RUN_STATUS_AT, now)
+                .remove(KEY_WIDGET_AGENT_RUN_ERROR)
+                .commit()
+            writeHelperStateLocked(readAllMutable())
+        }
+    }
+
+    fun recordWidgetAgentRunFinished(
+        agentId: String,
+        agentName: String,
+        success: Boolean,
+        error: String?
+    ) {
+        val now = System.currentTimeMillis()
+        synchronized(lock) {
+            val editor = prefs.edit()
+                .putString(KEY_WIDGET_AGENT_RUN_ID, agentId)
+                .putString(KEY_WIDGET_AGENT_RUN_NAME, agentName.take(MAX_WIDGET_TEXT_LENGTH))
+                .putString(
+                    KEY_WIDGET_AGENT_RUN_STATUS,
+                    if (success) WIDGET_AGENT_STATUS_SUCCESS else WIDGET_AGENT_STATUS_ERROR
+                )
+                .putLong(KEY_WIDGET_AGENT_RUN_STATUS_AT, now)
+            if (error.isNullOrBlank()) {
+                editor.remove(KEY_WIDGET_AGENT_RUN_ERROR)
+            } else {
+                editor.putString(KEY_WIDGET_AGENT_RUN_ERROR, error.take(MAX_WIDGET_TEXT_LENGTH))
+            }
+            editor.commit()
+            writeHelperStateLocked(readAllMutable())
+        }
     }
 
     fun recordWidgetChoicePending(message: String, options: List<ChoiceOption> = emptyList()) {
@@ -598,6 +643,11 @@ class ScouterStateStore(context: Context) {
                 widgetStatusAt = widgetStatusAt?.takeIf { widgetStatusVisible && !privacySuppressed },
                 widgetError = prefs.getString(KEY_WIDGET_ERROR, null)?.ifBlank { null }
                     ?.takeIf { widgetStatusVisible && !privacySuppressed },
+                widgetAgentRunId = prefs.getString(KEY_WIDGET_AGENT_RUN_ID, null)?.ifBlank { null },
+                widgetAgentRunName = prefs.getString(KEY_WIDGET_AGENT_RUN_NAME, null)?.ifBlank { null },
+                widgetAgentRunStatus = prefs.getString(KEY_WIDGET_AGENT_RUN_STATUS, null)?.ifBlank { null },
+                widgetAgentRunStatusAt = prefs.getLong(KEY_WIDGET_AGENT_RUN_STATUS_AT, 0L).takeIf { it > 0L },
+                widgetAgentRunError = prefs.getString(KEY_WIDGET_AGENT_RUN_ERROR, null)?.ifBlank { null },
                 privacySuppressed = privacySuppressed,
                 choiceOptions = if (widgetStatus == WIDGET_STATUS_CHOICE_PENDING) {
                     ChoiceOption.listFromJson(prefs.getString(KEY_WIDGET_CHOICE_OPTIONS, null))
@@ -621,6 +671,11 @@ class ScouterStateStore(context: Context) {
             widgetStatus = null,
             widgetStatusAt = null,
             widgetError = null,
+            widgetAgentRunId = null,
+            widgetAgentRunName = null,
+            widgetAgentRunStatus = null,
+            widgetAgentRunStatusAt = null,
+            widgetAgentRunError = null,
             privacySuppressed = false,
             choiceOptions = emptyList()
         )
@@ -1056,6 +1111,11 @@ class ScouterStateStore(context: Context) {
         private const val KEY_WIDGET_STATUS = "widget_status"
         private const val KEY_WIDGET_STATUS_AT = "widget_status_at"
         private const val KEY_WIDGET_ERROR = "widget_error"
+        private const val KEY_WIDGET_AGENT_RUN_ID = "widget_agent_run_id"
+        private const val KEY_WIDGET_AGENT_RUN_NAME = "widget_agent_run_name"
+        private const val KEY_WIDGET_AGENT_RUN_STATUS = "widget_agent_run_status"
+        private const val KEY_WIDGET_AGENT_RUN_STATUS_AT = "widget_agent_run_status_at"
+        private const val KEY_WIDGET_AGENT_RUN_ERROR = "widget_agent_run_error"
         private const val KEY_WIDGET_CHOICE_OPTIONS = "widget_choice_options"
         private const val KEY_WIDGET_PRIVACY_CLEARED_AT = "widget_privacy_cleared_at"
         private const val KEY_WIDGET_PRIVACY_SUPPRESSED_AT = "widget_privacy_suppressed_at"
@@ -1072,6 +1132,9 @@ class ScouterStateStore(context: Context) {
         private const val KEY_WIDGET_USAGE_LIMITED_AT = "widget_usage_limited_at"
         private const val KEY_WIDGET_USAGE_LIMITED_RESET_AT = "widget_usage_limited_reset_at"
         private const val WIDGET_STATUS_PENDING_TERMINAL = "pending_terminal"
+        const val WIDGET_AGENT_STATUS_RUNNING = "running"
+        const val WIDGET_AGENT_STATUS_SUCCESS = "success"
+        const val WIDGET_AGENT_STATUS_ERROR = "error"
         private const val WIDGET_STATUS_SENDING = "sending"
         private const val WIDGET_STATUS_CHOICE_PENDING = "choice_pending"
         private const val WIDGET_STATUS_CHOICE_SENT = "choice_sent"
@@ -1134,6 +1197,11 @@ private fun ScouterWidgetConversation.toJson(): JSONObject = JSONObject().apply 
     widgetStatus?.let { put("widgetStatus", it) }
     widgetStatusAt?.let { put("widgetStatusAt", it) }
     widgetError?.let { put("widgetError", it) }
+    widgetAgentRunId?.let { put("widgetAgentRunId", it) }
+    widgetAgentRunName?.let { put("widgetAgentRunName", it) }
+    widgetAgentRunStatus?.let { put("widgetAgentRunStatus", it) }
+    widgetAgentRunStatusAt?.let { put("widgetAgentRunStatusAt", it) }
+    widgetAgentRunError?.let { put("widgetAgentRunError", it) }
     put("privacySuppressed", privacySuppressed)
     if (choiceOptions.isNotEmpty()) put("choiceOptions", ChoiceOption.listToJson(choiceOptions))
 }

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterWidgetProvider.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterWidgetProvider.kt
@@ -18,6 +18,7 @@ import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
 import expo.modules.terminalemulator.R
+import expo.modules.terminalemulator.AgentAlarmScheduler
 import expo.modules.terminalemulator.TerminalSessionService
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -130,6 +131,7 @@ class ScouterWidgetProvider : AppWidgetProvider() {
             val conversation = if (enabled) store.widgetConversation(binding?.codexSessionId) else null
             val usageLimited = if (enabled) store.widgetUsageLimited() else null
             val lastCodexUsage = store.lastCodexUsageSnapshot()
+            val widgetAgent = if (enabled) WidgetAgentRepository.nextScheduled(context) else null
             val load = runCatching { ScouterSystemSampler(context).sample() }
                 .getOrElse {
                     Log.w(TAG, "Scouter widget system sample failed; using lightweight load", it)
@@ -140,7 +142,7 @@ class ScouterWidgetProvider : AppWidgetProvider() {
                 runCatching {
                     manager.updateAppWidget(
                         id,
-                        render(context, snapshots, binding, conversation, load, usageLimited, lastCodexUsage)
+                        render(context, snapshots, binding, conversation, widgetAgent, load, usageLimited, lastCodexUsage)
                     )
                 }
                     .onFailure { Log.w(TAG, "Scouter widget update failed for id=$id", it) }
@@ -228,6 +230,7 @@ class ScouterWidgetProvider : AppWidgetProvider() {
             snapshots: List<SessionSnapshot>,
             binding: ScouterWidgetCodexBinding?,
             conversation: ScouterWidgetConversation?,
+            widgetAgent: ScouterWidgetAgentTarget?,
             load: ScouterSystemLoad,
             usageLimited: ScouterWidgetUsageLimited? = null,
             lastCodexUsage: SessionSnapshot? = null
@@ -235,6 +238,7 @@ class ScouterWidgetProvider : AppWidgetProvider() {
             val views = RemoteViews(context.packageName, R.layout.scouter_widget_medium)
             launchPendingIntent(context)?.let { views.setOnClickPendingIntent(R.id.scouter_widget_root, it) }
             promptPendingIntent(context)?.let { views.setOnClickPendingIntent(R.id.scouter_codex_ask, it) }
+            bindWidgetAgentRun(views, context, widgetAgent, conversation)
 
             val privacySuppressed = conversation?.privacySuppressed == true
             val latestCodex = latestFor(snapshots, ScouterSource.CODEX)
@@ -346,6 +350,73 @@ class ScouterWidgetProvider : AppWidgetProvider() {
             )
             return views
         }
+
+        private fun bindWidgetAgentRun(
+            views: RemoteViews,
+            context: Context,
+            target: ScouterWidgetAgentTarget?,
+            conversation: ScouterWidgetConversation?
+        ) {
+            if (target == null) {
+                views.setTextViewText(
+                    R.id.scouter_agent_status,
+                    context.getString(R.string.scouter_widget_agent_none)
+                )
+                views.setViewVisibility(R.id.scouter_agent_run, View.GONE)
+                return
+            }
+
+            val next = formatAgentRunTime(target.nextRunAt)
+            val last = widgetAgentLastRunLabel(context, conversation)
+            views.setTextViewText(
+                R.id.scouter_agent_status,
+                context.getString(
+                    R.string.scouter_widget_agent_next_last,
+                    shorten(target.name.redactForScouter(), 18),
+                    next,
+                    last
+                )
+            )
+            views.setTextViewText(
+                R.id.scouter_agent_run,
+                context.getString(
+                    R.string.scouter_widget_agent_run_named,
+                    shorten(target.name.redactForScouter(), 14)
+                )
+            )
+            views.setViewVisibility(R.id.scouter_agent_run, View.VISIBLE)
+            views.setOnClickPendingIntent(
+                R.id.scouter_agent_run,
+                AgentAlarmScheduler.manualRunPendingIntent(context, target.agentId)
+            )
+        }
+
+        private fun widgetAgentLastRunLabel(
+            context: Context,
+            conversation: ScouterWidgetConversation?
+        ): String {
+            val status = conversation?.widgetAgentRunStatus
+                ?: return context.getString(R.string.scouter_widget_agent_last_never)
+            val statusLabel = when (status) {
+                ScouterStateStore.WIDGET_AGENT_STATUS_RUNNING ->
+                    context.getString(R.string.scouter_widget_agent_last_running)
+                ScouterStateStore.WIDGET_AGENT_STATUS_SUCCESS ->
+                    context.getString(R.string.scouter_widget_agent_last_success)
+                ScouterStateStore.WIDGET_AGENT_STATUS_ERROR ->
+                    context.getString(R.string.scouter_widget_agent_last_error)
+                else -> context.getString(R.string.scouter_widget_agent_last_never)
+            }
+            val at = conversation.widgetAgentRunStatusAt?.let(::formatTime)
+            val name = conversation.widgetAgentRunName?.takeIf { it.isNotBlank() }
+            return listOfNotNull(
+                name?.let { shorten(it.redactForScouter(), 12) },
+                statusLabel,
+                at
+            ).joinToString(" ")
+        }
+
+        private fun formatAgentRunTime(timestamp: Long): String =
+            SimpleDateFormat("EEE HH:mm", Locale.getDefault()).format(Date(timestamp))
 
         private fun bindCodexPet(
             views: RemoteViews,

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/WidgetAgentRepository.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/WidgetAgentRepository.kt
@@ -1,0 +1,90 @@
+package expo.modules.terminalemulator.scouter
+
+import android.content.Context
+import android.util.Log
+import expo.modules.terminalemulator.AgentAlarmScheduler
+import expo.modules.terminalemulator.HomeInitializer
+import java.io.File
+import org.json.JSONObject
+
+data class ScouterWidgetAgentTarget(
+    val agentId: String,
+    val name: String,
+    val cron: String,
+    val nextRunAt: Long
+)
+
+/**
+ * Disk-backed source of truth for the widget's single RUN target.
+ *
+ * The RN agent store is intentionally not persisted, so native widget rendering
+ * must never retain an in-memory Agent reference. Every render and every tap
+ * re-reads ~/.shelly/agents/<id>.json, verifies that the filename and embedded id
+ * match, and requires a materialized run artifact. This also prevents a stale
+ * widget PendingIntent from running an agent that was deleted or disabled after
+ * the widget was rendered.
+ */
+object WidgetAgentRepository {
+    private const val TAG = "WidgetAgentRepository"
+    private val SAFE_AGENT_ID = Regex("^[A-Za-z0-9_-]+$")
+
+    fun nextScheduled(context: Context): ScouterWidgetAgentTarget? {
+        val candidates = readScheduledAgents(context)
+        return candidates.minWithOrNull(compareBy<ScouterWidgetAgentTarget> { it.nextRunAt }.thenBy { it.agentId })
+    }
+
+    fun scheduledById(context: Context, agentId: String): ScouterWidgetAgentTarget? {
+        if (!SAFE_AGENT_ID.matches(agentId)) return null
+        return readScheduledAgent(context, agentId)
+    }
+
+    private fun readScheduledAgents(context: Context): List<ScouterWidgetAgentTarget> {
+        val agentsDir = agentsDir(context)
+        val files = agentsDir.listFiles { file -> file.isFile && file.extension == "json" } ?: return emptyList()
+        return files.mapNotNull { file ->
+            val fileId = file.name.removeSuffix(".json")
+            if (!SAFE_AGENT_ID.matches(fileId)) return@mapNotNull null
+            readScheduledAgentFile(agentsDir, file, fileId)
+        }
+    }
+
+    private fun readScheduledAgent(context: Context, agentId: String): ScouterWidgetAgentTarget? {
+        val agentsDir = agentsDir(context)
+        val file = File(agentsDir, "$agentId.json")
+        if (!file.isFile) return null
+        return readScheduledAgentFile(agentsDir, file, agentId)
+    }
+
+    private fun readScheduledAgentFile(
+        agentsDir: File,
+        file: File,
+        expectedId: String
+    ): ScouterWidgetAgentTarget? {
+        return try {
+            val json = JSONObject(file.readText())
+            val id = json.optString("id").trim()
+            if (id != expectedId || !SAFE_AGENT_ID.matches(id)) return null
+            if (!json.optBoolean("enabled", false)) return null
+            val cron = (
+                if (json.isNull("schedule")) null
+                else json.optString("schedule").trim().ifBlank { null }
+            ) ?: return null
+            val nextRunAt = AgentAlarmScheduler.nextTriggerAt(cron) ?: return null
+            val hasRunArtifact = File(agentsDir, "run-agent-$id.sh").isFile ||
+                File(agentsDir, "plans/plan-agent-$id.json").isFile
+            if (!hasRunArtifact) return null
+            ScouterWidgetAgentTarget(
+                agentId = id,
+                name = json.optString("name").trim().ifBlank { id },
+                cron = cron,
+                nextRunAt = nextRunAt
+            )
+        } catch (error: Exception) {
+            Log.w(TAG, "Ignoring invalid agent metadata ${file.name}", error)
+            null
+        }
+    }
+
+    private fun agentsDir(context: Context): File =
+        File(HomeInitializer.getHomeDir(context.applicationContext), ".shelly/agents")
+}

--- a/modules/terminal-emulator/android/src/main/res/layout/scouter_widget_medium.xml
+++ b/modules/terminal-emulator/android/src/main/res/layout/scouter_widget_medium.xml
@@ -329,6 +329,46 @@
       android:shadowRadius="6"
       android:includeFontPadding="false" />
 
+    <!-- One-tap execution for the next registered scheduled agent. The
+         PendingIntent targets TerminalSessionService directly; this row is
+         status/run only and is never reused for schedule approvals. -->
+    <TextView
+      android:id="@+id/scouter_agent_status"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="7dp"
+      android:ellipsize="end"
+      android:singleLine="true"
+      android:text="@string/scouter_widget_agent_none"
+      android:textColor="#66FF88"
+      android:textSize="10sp"
+      android:typeface="monospace"
+      android:includeFontPadding="false" />
+
+    <TextView
+      android:id="@+id/scouter_agent_run"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="5dp"
+      android:gravity="center"
+      android:minHeight="32dp"
+      android:background="@drawable/scouter_ask_pill_bg"
+      android:contentDescription="@string/scouter_widget_agent_run"
+      android:paddingStart="14dp"
+      android:paddingEnd="14dp"
+      android:paddingTop="7dp"
+      android:paddingBottom="7dp"
+      android:text="@string/scouter_widget_agent_run"
+      android:textColor="#00FF41"
+      android:textSize="13sp"
+      android:letterSpacing="0.04"
+      android:typeface="monospace"
+      android:textStyle="bold"
+      android:shadowColor="#B300FF41"
+      android:shadowRadius="6"
+      android:includeFontPadding="false"
+      android:visibility="gone" />
+
     <!-- divider — must be a TextView (plain <View> is not in the App Widget
          RemoteViews class allowlist and throws InflateException in the host) -->
     <TextView

--- a/modules/terminal-emulator/android/src/main/res/values-ja/scouter_strings.xml
+++ b/modules/terminal-emulator/android/src/main/res/values-ja/scouter_strings.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string name="scouter_widget_agent_run">予定済みエージェントを実行</string>
+  <string name="scouter_widget_agent_run_named">実行 %1$s</string>
+  <string name="scouter_widget_agent_none">エージェント  予定なし</string>
+  <string name="scouter_widget_agent_next_last">次回 %1$s %2$s · 前回 %3$s</string>
+  <string name="scouter_widget_agent_last_never">--</string>
+  <string name="scouter_widget_agent_last_running">実行中</string>
+  <string name="scouter_widget_agent_last_success">成功</string>
+  <string name="scouter_widget_agent_last_error">失敗</string>
   <string name="scouter_widget_prompt_title">Codex に依頼</string>
   <string name="scouter_widget_prompt_hint">紐づいた Codex ターミナルへ送るプロンプト</string>
   <string name="scouter_widget_prompt_send">送信</string>

--- a/modules/terminal-emulator/android/src/main/res/values/scouter_strings.xml
+++ b/modules/terminal-emulator/android/src/main/res/values/scouter_strings.xml
@@ -3,6 +3,14 @@
   <string name="scouter_status_dot">Scouter status</string>
   <string name="scouter_ask_agent_chat_short">ASK</string>
   <string name="scouter_ask_agent_chat">Ask Codex from widget</string>
+  <string name="scouter_widget_agent_run">Run scheduled agent</string>
+  <string name="scouter_widget_agent_run_named">RUN %1$s</string>
+  <string name="scouter_widget_agent_none">AGENT  no scheduled agent</string>
+  <string name="scouter_widget_agent_next_last">NEXT %1$s %2$s · LAST %3$s</string>
+  <string name="scouter_widget_agent_last_never">--</string>
+  <string name="scouter_widget_agent_last_running">RUNNING</string>
+  <string name="scouter_widget_agent_last_success">OK</string>
+  <string name="scouter_widget_agent_last_error">ERROR</string>
   <string name="scouter_widget_prompt_title">Ask Codex</string>
   <string name="scouter_widget_prompt_hint">Type a prompt for the bound Codex terminal</string>
   <string name="scouter_widget_prompt_send">Send</string>

--- a/store/agent-chat-store.ts
+++ b/store/agent-chat-store.ts
@@ -122,6 +122,11 @@ type ScouterWidgetConversation = {
   widgetStatus?: string | null;
   widgetStatusAt?: number | null;
   widgetError?: string | null;
+  widgetAgentRunId?: string | null;
+  widgetAgentRunName?: string | null;
+  widgetAgentRunStatus?: 'running' | 'success' | 'error' | null;
+  widgetAgentRunStatusAt?: number | null;
+  widgetAgentRunError?: string | null;
   privacySuppressed?: boolean | null;
 };
 


### PR DESCRIPTION
## What

Implements Task B from `docs/superpowers/specs/2026-06-27-widget-agent-launch-handoff.md`: a RUN button on the Scouter home-screen widget that fires an already-registered, scheduled agent directly — no app open, no confirm card. Task A (input shortcut) is deliberately deferred so the security-sensitive path (Task B) stayed the sole focus.

## Design

Widget RUN button → `PendingIntent.getForegroundService(...)` targeting `TerminalSessionService` with `ACTION_RUN_AGENT` + `EXTRA_AGENT_ID` — the exact same intent shape the existing v7.0.0 `AgentAlarmScheduler` scheduled-fire path already uses. A widget tap is architecturally equivalent to a scheduled fire or Sidebar "Run now": the agent's gates were set once at creation time, so no new approval surface is introduced.

## Invariant-by-invariant safety confirmation

- **No schedule-approval pills on the widget.** Not touched — approval stays on the existing notification/B5 path. No new fast-path button was added.
- **Runs EXISTING agents only, no ad-hoc prompt execution.** `WidgetAgentRepository.kt:66` only accepts an agent that is enabled, scheduled, and materialized on disk — a new/ad-hoc prompt cannot reach this path card-less.
- **`getForegroundService`, never `am start`.** `AgentAlarmScheduler.kt:148` builds a direct foreground-service PendingIntent with a distinct request-code identity from the alarm path (so the two don't collide/cancel each other).
- **Ground-truth agent state, not stale in-memory list.** `WidgetAgentRepository.kt:66` revalidates the agent from disk at both render time and tap time — never trusts a cached snapshot.
- **STOP-ALL kill-switch respected.** `TerminalSessionService.kt:95` checks the halted flag before accepting the manual widget marker; execution is refused while halted.
- **No schedule re-arm for a manual run.** `TerminalSessionService.kt:151` — a widget-triggered run does not call `AgentAlarmScheduler.scheduleNext`, so the existing alarm schedule is left intact.
- **Fail-closed for approval-requiring actions.** `TerminalSessionService.kt:138` — an unattended widget run of an action requiring approval fails closed exactly as a scheduled fire would; it does not perform an unreviewed action.

## Verification

- `tsc --noEmit`: clean.
- `__tests__/widget-agent-run-parity.test.ts` (offline security-parity gate, since Jest can't drive Android PendingIntents): 5/5 pass — verifies the RUN→foreground-service binding, disk revalidation, no-re-arm, STOP-ALL gate, and no-approval-fast-path via static analysis of the actual Kotlin source.
- `expo lint`: 0 errors, 2 pre-existing warnings in an unrelated file.
- `git diff --check`: clean.
- Gradle/Kotlin compile: not runnable in this environment (no Gradle wrapper/Android SDK reachable) — CI's `Build Android APK` workflow is the first real compile gate for the Kotlin changes.

## Still required before this ships

On-device verification (from the design doc, §6, steps 2-4 — needs a physical device):
1. Add the widget, tap RUN on a pre-registered agent → app does NOT open, agent runs, output lands where configured, widget status row shows success, `dumpsys alarm` confirms the schedule is unchanged.
2. Enable STOP-ALL → tapping RUN produces no execution, status unchanged.
3. An agent whose action needs approval, run via the widget while unattended → fails closed, no unreviewed action performed.

## Provenance note

Implemented by a sandboxed Codex background task, which completed the work and all runnable local verification but could not push (sandbox blocked GitHub HTTPS). I (CC) recovered the local commits, rebased cleanly onto current `main` (no conflicts), and re-verified everything above myself. One recovery-specific note: the worktree Codex created used a dot-prefixed directory name (`.codex-widget-agent-run`), which caused Jest to silently discover zero test files in that directory (confirmed by testing a known-good, unrelated test file in the same worktree — also 0 matches; renaming to a non-dot-prefixed path immediately fixed it). Not a code issue, just a recovery-environment quirk worth noting in case it recurs.