### PR TITLE
test: sync plan-executor-parity assertions with PR #122 refactor

### DIFF
--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -60,9 +60,14 @@ describe('shelly-plan-executor.js parity', () => {
   });
 
   it('derives unattended mode from scheduled service extras before launching the agent', () => {
+    // PR #122 (widget one-tap run) split this into a named `scheduled` check
+    // and marks a widget-triggered manual run unattended too (`scheduled ||
+    // manual`), so a widget tap keeps per-action approval fail-closed exactly
+    // like an AlarmManager fire, even though it carries no interval/cron.
     expect(terminalSessionService).toContain('val intervalMs = intent.getLongExtra(EXTRA_INTERVAL_MS, 0L)');
-    expect(terminalSessionService).toContain('val unattended = intervalMs > 0 || !cron.isNullOrBlank()');
-    expect(terminalSessionService).toContain('runAgentInBackground(agentId, tainted, unattended)');
+    expect(terminalSessionService).toContain('val scheduled = intervalMs > 0 || !cron.isNullOrBlank()');
+    expect(terminalSessionService).toContain('val unattended = scheduled || manual');
+    expect(terminalSessionService).toContain('runAgentInBackground(agentId, tainted, unattended, manual, widgetAgent?.name)');
     expect(terminalSessionService).toContain('tainted = tainted');
     expect(terminalSessionService).toContain('unattended = unattended');
   });


### PR DESCRIPTION
## Summary
- CI on main is red after PR #122 merged (widget one-tap agent run): `__tests__/plan-executor-parity.test.ts` asserts stale literal source text against `TerminalSessionService.kt` that #122 legitimately refactored.
- Updates the assertions to match the current `scheduled`/`unattended = scheduled || manual` computation and the current 5-arg `runAgentInBackground(...)` call site.
- Zero behavior change — test-assertion sync only.

## Test plan
- [x] `npx jest __tests__/plan-executor-parity.test.ts` — 11/11 passing
- [x] `npx tsc --noEmit` — clean
- [x] Full `npx jest` suite run — 4 pre-existing failing suites, none of them this file (confirmed unrelated: Windows-local temp-path duplication bug in plan-executor-orchestration/agent-executor-autonomous/capability-broker/plan-executor tests, doesn't reproduce on Linux CI runners)