### PR TITLE
fix(agent): refuse dm-reply when unattended, matching intent's guard

### DIFF
--- a/__tests__/agent-executor-dm-reply-action.test.ts
+++ b/__tests__/agent-executor-dm-reply-action.test.ts
@@ -25,6 +25,19 @@ describe('legacy executor dm-reply action', () => {
     expect(script).toContain('wait_action_approval "dm-reply"');
   });
 
+  it('rejects autonomous execution before requesting attended Review approval', () => {
+    const dmCase = script.slice(script.indexOf('\n    dm-reply)'), script.indexOf('\n    *)', script.indexOf('\n    dm-reply)')));
+    expect(dmCase).toContain('[ "${AGENT_AUTONOMOUS:-0}" = "1" ]');
+    expect(dmCase).toContain('DM-reply actions require an attended Review.');
+    expect(dmCase).toContain('write_action_approval_request "dm-reply" "$preview" "$result_file"');
+    expect(dmCase).toContain('wait_action_approval "dm-reply" || return 1');
+    expect(dmCase.indexOf('AGENT_AUTONOMOUS')).toBeLessThan(dmCase.indexOf('write_action_approval_request'));
+    // No broker/native dispatch call after approval — RN sends natively before
+    // the accept reply is published.
+    expect(dmCase).not.toContain('cap_workspace_exec');
+    expect(dmCase).not.toContain('http_post_json');
+  });
+
   it('fails closed for absent, revoked, and unverifiable pairings', () => {
     expect(script).toContain('DM-reply target is no longer paired.');
     expect(script).toContain('Could not verify the DM-reply pairing.');

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -1052,6 +1052,12 @@ dispatch_agent_action() {
       return 0
       ;;
     dm-reply)
+      if [ "\${AGENT_AUTONOMOUS:-0}" = "1" ] || [ "\${SHELLY_RUN_UNATTENDED:-0}" = "1" ]; then
+        ACTION_DISPATCH_STATUS="skipped"
+        ACTION_DISPATCH_MESSAGE="DM-reply actions require an attended Review."
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
       if [ -z "$ACTION_DM_PAIRING_ID" ]; then
         ACTION_DISPATCH_STATUS="error"
         ACTION_DISPATCH_MESSAGE="DM-reply action is missing a paired conversation."


### PR DESCRIPTION
## Summary
- Tonight's security audit found `dm-reply` (external message send) lacked the unattended/autonomous hard-refusal that its peer action `intent` already has — both are external-message-egress actions with identical risk shape.
- Adds the exact same guard to `dm-reply)`, byte-for-byte structural mirror of `intent)`'s existing guard (verified in the PlanSpec executor too — both are already excluded from the unattended allowlist there).

## Test plan
- [x] New test: `agent-executor-dm-reply-action.test.ts` — rejects autonomous execution before requesting attended Review
- [x] `npx tsc --noEmit` clean
- [x] Full `agent-executor*` test sweep green (pre-existing unrelated Windows ENAMETOOLONG failures only)