### PR TITLE
fix(agent): harden AgentActionApprovalBridge with a replay-guard nonce

### DIFF
--- a/__tests__/agent-action-approval-bridge-hardening.test.ts
+++ b/__tests__/agent-action-approval-bridge-hardening.test.ts
@@ -1,0 +1,117 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Finding 9 (security audit, LOW / defense-in-depth): AgentActionApprovalBridge.writeHumanReply
+// accepted a null expectedRequestSha256 (silently bypassing the content-hash check) and had no
+// nonce/replay guard, unlike its structurally-identical sibling AgentEscalationBridge.writeHumanReply
+// -- the same "one verifier weaker than its sibling" shape already found and fixed for the
+// signed-approval bypass (PR #115) and the request-code allocator race (PR #122). Neither Kotlin
+// file compiles in this environment (no Android toolchain), so -- matching this project's existing
+// pattern in __tests__/plan-executor-parity.test.ts -- these are source-assertion tests: they read
+// the real .kt files and assert the hardened shape is present, byte-for-byte, rather than
+// simulating behavior.
+describe('AgentActionApprovalBridge — Finding 9 hardening (nonce + non-null hash)', () => {
+  const root = path.resolve(__dirname, '..');
+  const scouterDir = path.join(
+    root,
+    'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter',
+  );
+  const actionBridge = fs.readFileSync(path.join(scouterDir, 'AgentActionApprovalBridge.kt'), 'utf8');
+  const escalationBridge = fs.readFileSync(path.join(scouterDir, 'AgentEscalationBridge.kt'), 'utf8');
+  const notificationDispatcher = fs.readFileSync(path.join(scouterDir, 'NotificationDispatcher.kt'), 'utf8');
+  const widgetPromptActivity = fs.readFileSync(path.join(scouterDir, 'ScouterWidgetPromptActivity.kt'), 'utf8');
+  const terminalEmulatorModule = fs.readFileSync(
+    path.join(
+      root,
+      'modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt',
+    ),
+    'utf8',
+  );
+
+  it('no longer accepts a null expectedRequestSha256 (the original bypass)', () => {
+    expect(actionBridge).not.toContain('expectedRequestSha256: String?');
+    expect(actionBridge).not.toContain('expectedRequestSha256 == null ||');
+    expect(actionBridge).toContain('fun writeHumanReply(');
+    expect(actionBridge).toContain('expectedRequestSha256: String,');
+    expect(actionBridge).toContain('actionNonce: String');
+    expect(actionBridge).toContain(
+      'require(expectedRequestSha256.matches(HEX_SHA256_RE) && requestSha256 == expectedRequestSha256)',
+    );
+  });
+
+  it('gained a single-use nonce/replay guard mirroring AgentEscalationBridge', () => {
+    // Same ledger shape as the sibling: an in-memory map of single-use,
+    // SecureRandom-sourced nonces, consumed via an atomic remove(key, value)
+    // so a captured/replayed reply action can't be reprocessed twice.
+    expect(actionBridge).toContain('private val pendingActionNonces = ConcurrentHashMap<String, String>()');
+    expect(actionBridge).toContain('private val secureRandom = SecureRandom()');
+    expect(actionBridge).toContain('fun registerActionNonce(runId: String): String');
+    expect(actionBridge).toContain('fun hasActionNonce(runId: String): Boolean');
+    expect(actionBridge).toContain('require(!expectedNonce.isNullOrBlank() && expectedNonce == actionNonce)');
+    expect(actionBridge).toContain('require(pendingActionNonces.remove(runId, expectedNonce))');
+
+    // The sibling's equivalent guard, to prove this is genuinely the same
+    // pattern and not a look-alike.
+    expect(escalationBridge).toContain('private val pendingActionNonces = ConcurrentHashMap<String, String>()');
+    expect(escalationBridge).toContain('require(!expectedNonce.isNullOrBlank() && expectedNonce == actionNonce)');
+    expect(escalationBridge).toContain('require(pendingActionNonces.remove(nonceKey, expectedNonce))');
+  });
+
+  it('notification Allow/Deny path registers a nonce before it can be tapped, mirroring notifyAgentEscalationNeeded', () => {
+    expect(notificationDispatcher).toContain(
+      'val needsFreshAction = !AgentActionApprovalBridge.hasActionNonce(request.runId)',
+    );
+    expect(notificationDispatcher).toContain(
+      'val actionNonce = AgentActionApprovalBridge.registerActionNonce(request.runId)',
+    );
+    // Both Allow and Deny PendingIntents must carry the nonce, not just Allow.
+    expect(notificationDispatcher).toContain(
+      'agentActionApprovalPendingIntent(true, request, actionNonce, requestSha256)',
+    );
+    expect(notificationDispatcher).toContain(
+      'agentActionApprovalPendingIntent(false, request, actionNonce, requestSha256)',
+    );
+    expect(notificationDispatcher).toContain('.putExtra(ScouterWidgetPromptActivity.EXTRA_AGENT_ACTION_NONCE, actionNonce)');
+  });
+
+  it('the widget Activity refuses to resolve an approval when the nonce extra is missing or blank', () => {
+    expect(widgetPromptActivity).toContain('const val EXTRA_AGENT_ACTION_NONCE');
+    expect(widgetPromptActivity).toContain(
+      'val actionNonce = intent.getStringExtra(EXTRA_AGENT_ACTION_NONCE)',
+    );
+    expect(widgetPromptActivity).toContain(
+      'if (runId.isBlank() || actionNonce.isNullOrBlank() || expectedRequestSha256.isNullOrBlank())',
+    );
+    expect(widgetPromptActivity).toContain(
+      'AgentActionApprovalBridge.writeHumanReply(this, runId, decision, expectedRequestSha256, actionNonce)',
+    );
+  });
+
+  it('the in-app review-card path (JS AsyncFunction bridge) mints and threads the same nonce', () => {
+    // readAgentActionApprovalRequest mints a nonce the moment the request is
+    // disclosed to the human for review, and resolveAgentActionApproval now
+    // requires both the hash and the nonce as mandatory (non-null) params --
+    // no more silent bypass via an omitted argument.
+    expect(terminalEmulatorModule).toContain(
+      'val actionNonce = AgentActionApprovalBridge.registerActionNonce(runId)',
+    );
+    expect(terminalEmulatorModule).toContain(
+      'AgentActionApprovalBridge.toMap(parsed) + mapOf("actionNonce" to actionNonce)',
+    );
+    expect(terminalEmulatorModule).toContain(
+      'AsyncFunction("resolveAgentActionApproval") { runId: String, decision: String, expectedRequestSha256: String, actionNonce: String ->',
+    );
+    expect(terminalEmulatorModule).toContain(
+      'AgentActionApprovalBridge.writeHumanReply(context, runId, decision, expectedRequestSha256, actionNonce)',
+    );
+  });
+
+  it('app/_layout.tsx fails closed instead of passing a missing hash/nonce through as null', () => {
+    const rootLayout = fs.readFileSync(path.join(root, 'app/_layout.tsx'), 'utf8');
+    expect(rootLayout).not.toContain('request.requestSha256 ?? null');
+    expect(rootLayout).toContain('if (!requestSha256 || !actionNonce)');
+    expect(rootLayout).toContain(
+      "await TerminalEmulator.resolveAgentActionApproval?.(request.runId, 'decline', requestSha256, actionNonce)",
+    );
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -123,6 +123,7 @@ type AgentActionApprovalRequest = {
   dmPairingId?: string | null;
   dmPairingLabel?: string | null;
   dmReplyText?: string | null;
+  actionNonce?: string | null;
 };
 
 export default function RootLayout() {
@@ -142,6 +143,17 @@ export default function RootLayout() {
     const request = pendingAgentActionApproval;
     if (!request) return;
     if (!TerminalEmulator.resolveAgentActionApproval) {
+      Alert.alert(t('agent_action_confirm_not_ready'));
+      return;
+    }
+    // Fail closed: the native writeHumanReply now requires both the content
+    // hash and the single-use action nonce minted when this request was read
+    // for review (readAgentActionApprovalRequest). Bail out here with a clear
+    // message rather than letting a missing value reach the native call and
+    // surface as a generic error.
+    const requestSha256 = request.requestSha256;
+    const actionNonce = request.actionNonce;
+    if (!requestSha256 || !actionNonce) {
       Alert.alert(t('agent_action_confirm_not_ready'));
       return;
     }
@@ -165,7 +177,7 @@ export default function RootLayout() {
         logError('AgentActionApproval', `fireAgentIntent failed: ${errorKind}`);
         // Fail closed: tell the waiting executor "declined" (a fast, honest
         // signal) rather than leaving it to time out after a failed fire.
-        await TerminalEmulator.resolveAgentActionApproval?.(request.runId, 'decline', request.requestSha256 ?? null).catch(() => undefined);
+        await TerminalEmulator.resolveAgentActionApproval?.(request.runId, 'decline', requestSha256, actionNonce).catch(() => undefined);
         setPendingAgentActionApproval(null);
         setAgentActionResolving(false);
         Alert.alert(t('agent_action_confirm_intent_failed'));
@@ -186,7 +198,8 @@ export default function RootLayout() {
         await TerminalEmulator.resolveAgentActionApproval(
           request.runId,
           'decline',
-          request.requestSha256 ?? null,
+          requestSha256,
+          actionNonce,
         ).catch(() => undefined);
         setPendingAgentActionApproval(null);
         setAgentActionResolving(false);
@@ -198,7 +211,8 @@ export default function RootLayout() {
       await TerminalEmulator.resolveAgentActionApproval(
         request.runId,
         decision,
-        request.requestSha256 ?? null,
+        requestSha256,
+        actionNonce,
       );
       setPendingAgentActionApproval(null);
     } catch (e) {
@@ -807,6 +821,12 @@ export default function RootLayout() {
         dmPairingId: str('dmPairingId') || null,
         dmPairingLabel: str('dmPairingLabel') || null,
         dmReplyText: typeof value.dmReplyText === 'string' ? value.dmReplyText : null,
+        // Only ever populated by the native readAgentActionApprovalRequest
+        // round trip (freshly minted per read). The raw-JSON fallback path
+        // and the notify-only poll loop below never set it, and must not --
+        // resolvePendingAgentActionApproval treats a missing nonce as "not
+        // ready" rather than silently skipping the replay check.
+        actionNonce: str('actionNonce') || null,
       };
     };
 

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
@@ -1393,7 +1393,13 @@ class TerminalEmulatorModule : Module() {
                 ?: throw IllegalStateException("React context unavailable")
             val parsed = AgentActionApprovalBridge.fromRequestFile(context, runId)
                 ?: throw IllegalArgumentException("invalid agent action approval request")
-            AgentActionApprovalBridge.toMap(parsed)
+            // Mint a fresh single-use nonce the moment the request is disclosed
+            // for in-app review, mirroring the notification path's registration
+            // in NotificationDispatcher.notifyAgentActionApprovalNeeded. Both
+            // channels feed the same pendingActionNonces ledger, so whichever
+            // decision the human actually makes consumes it exactly once.
+            val actionNonce = AgentActionApprovalBridge.registerActionNonce(runId)
+            AgentActionApprovalBridge.toMap(parsed) + mapOf("actionNonce" to actionNonce)
         }
 
         AsyncFunction("notifyAgentActionApprovalNeeded") { request: Map<String, Any?> ->
@@ -1407,10 +1413,10 @@ class TerminalEmulatorModule : Module() {
             null
         }
 
-        AsyncFunction("resolveAgentActionApproval") { runId: String, decision: String, expectedRequestSha256: String? ->
+        AsyncFunction("resolveAgentActionApproval") { runId: String, decision: String, expectedRequestSha256: String, actionNonce: String ->
             val context = appContext.reactContext
                 ?: throw IllegalStateException("React context unavailable")
-            AgentActionApprovalBridge.writeHumanReply(context, runId, decision, expectedRequestSha256)
+            AgentActionApprovalBridge.writeHumanReply(context, runId, decision, expectedRequestSha256, actionNonce)
             AgentActionApprovalBridge.clearRequest(context, runId)
             context.getSystemService(NotificationManager::class.java)
                 ?.cancel(AgentActionApprovalBridge.notificationId(runId))

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/AgentActionApprovalBridge.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/AgentActionApprovalBridge.kt
@@ -2,11 +2,14 @@ package expo.modules.terminalemulator.scouter
 
 import android.content.Context
 import android.net.Uri
+import android.util.Base64
 import expo.modules.terminalemulator.HomeInitializer
 import org.json.JSONObject
 import java.io.File
 import java.security.MessageDigest
+import java.security.SecureRandom
 import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 
 data class AgentActionApprovalRequest(
     val runId: String,
@@ -43,6 +46,17 @@ data class AgentActionApprovalRequest(
 object AgentActionApprovalBridge {
     private val unsafeFilePart = Regex("[^A-Za-z0-9_.=-]")
 
+    // Single-use, in-memory replay guard (mirrors AgentEscalationBridge's
+    // pendingActionNonces exactly). Minted whenever the request is disclosed
+    // to the human for a decision -- either via the Allow/Deny notification
+    // PendingIntents (NotificationDispatcher.notifyAgentActionApprovalNeeded)
+    // or via the in-app review card (TerminalEmulatorModule.readAgentActionApprovalRequest)
+    // -- and consumed atomically by the first writeHumanReply call that
+    // presents it, so a captured/replayed Intent or reply call can't be
+    // reprocessed a second time.
+    private val pendingActionNonces = ConcurrentHashMap<String, String>()
+    private val secureRandom = SecureRandom()
+
     fun requestDir(context: Context): File =
         File(HomeInitializer.getHomeDir(context), ".shelly/agents/action-approvals").also { it.mkdirs() }
 
@@ -59,6 +73,16 @@ object AgentActionApprovalBridge {
 
     fun notificationId(runId: String): Int =
         NOTIFICATION_ID_PREFIX or (stableHash("agent-action:$runId") and NOTIFICATION_ID_MASK)
+
+    fun registerActionNonce(runId: String): String {
+        val nonce = ByteArray(24)
+        secureRandom.nextBytes(nonce)
+        val encoded = Base64.encodeToString(nonce, Base64.NO_WRAP)
+        pendingActionNonces[runId] = encoded
+        return encoded
+    }
+
+    fun hasActionNonce(runId: String): Boolean = pendingActionNonces.containsKey(runId)
 
     fun anchorFromMap(raw: Map<String, Any?>): String? =
         raw["runId"]?.toString()?.trim()?.takeIf { it.isNotBlank() }
@@ -144,20 +168,28 @@ object AgentActionApprovalBridge {
         context: Context,
         runId: String,
         decision: String,
-        expectedRequestSha256: String?
+        expectedRequestSha256: String,
+        actionNonce: String
     ): File {
         require(decision == "accept" || decision == "decline") { "invalid action decision" }
+        val expectedNonce = pendingActionNonces[runId]
         val request = requireCanonicalChild(requestFile(context, runId), requestDir(context))
         require(request.isFile) { "action approval request is no longer pending" }
         val bytes = request.readBytes()
-        val requestSha256 = sha256Hex(bytes)
-        require(expectedRequestSha256 == null || (expectedRequestSha256.matches(HEX_SHA256_RE) && requestSha256 == expectedRequestSha256)) {
-            "action approval no longer matches the displayed request"
-        }
         val requestJson = JSONObject(bytes.toString(Charsets.UTF_8))
         require(requestJson.optString("runId") == runId) { "action approval anchor mismatch" }
+        val requestSha256 = sha256Hex(bytes)
+        require(expectedRequestSha256.matches(HEX_SHA256_RE) && requestSha256 == expectedRequestSha256) {
+            "action approval no longer matches the displayed request"
+        }
         val expiresAt = requestJson.optLong("expiresAt")
         require(expiresAt <= 0L || System.currentTimeMillis() <= expiresAt) { "action approval expired" }
+        require(!expectedNonce.isNullOrBlank() && expectedNonce == actionNonce) {
+            "action approval action is stale or unauthenticated"
+        }
+        require(pendingActionNonces.remove(runId, expectedNonce)) {
+            "action approval action is stale or unauthenticated"
+        }
 
         val reply = requireCanonicalChild(replyFile(context, runId), replyDir(context))
         reply.parentFile?.mkdirs()

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/NotificationDispatcher.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/NotificationDispatcher.kt
@@ -129,8 +129,9 @@ class NotificationDispatcher(private val context: Context) {
 
     fun notifyAgentActionApprovalNeeded(request: AgentActionApprovalRequest) {
         runCatching {
+            val needsFreshAction = !AgentActionApprovalBridge.hasActionNonce(request.runId)
             val shouldNotify = shouldFire(KEY_LAST_AGENT_ACTION, request.key)
-            if (!shouldNotify) return
+            if (!needsFreshAction && !shouldNotify) return
             val requestSha256 = request.requestSha256
                 ?.takeIf { HEX_SHA256_RE.matches(it) }
                 ?: return
@@ -191,15 +192,16 @@ class NotificationDispatcher(private val context: Context) {
                     previewText?.let { context.getString(R.string.scouter_notification_agent_action_preview, it) },
                 ).joinToString("\n")
             }
+            val actionNonce = AgentActionApprovalBridge.registerActionNonce(request.runId)
             val actions = if (request.actionType == "cli" || request.actionType == "intent" || request.actionType == "dm-reply") {
                 listOf(
                     action(context.getString(R.string.scouter_notification_action_review), agentActionReviewPendingIntent(request, requestSha256)),
-                    action(context.getString(R.string.scouter_notification_action_deny), agentActionApprovalPendingIntent(false, request, requestSha256)),
+                    action(context.getString(R.string.scouter_notification_action_deny), agentActionApprovalPendingIntent(false, request, actionNonce, requestSha256)),
                 )
             } else {
                 listOf(
-                    action(context.getString(R.string.scouter_notification_action_allow), agentActionApprovalPendingIntent(true, request, requestSha256)),
-                    action(context.getString(R.string.scouter_notification_action_deny), agentActionApprovalPendingIntent(false, request, requestSha256)),
+                    action(context.getString(R.string.scouter_notification_action_allow), agentActionApprovalPendingIntent(true, request, actionNonce, requestSha256)),
+                    action(context.getString(R.string.scouter_notification_action_deny), agentActionApprovalPendingIntent(false, request, actionNonce, requestSha256)),
                 )
             }
             notify(
@@ -590,6 +592,7 @@ class NotificationDispatcher(private val context: Context) {
     private fun agentActionApprovalPendingIntent(
         allow: Boolean,
         request: AgentActionApprovalRequest,
+        actionNonce: String,
         requestSha256: String
     ): PendingIntent {
         val decision = if (allow) "allow" else "deny"
@@ -607,6 +610,7 @@ class NotificationDispatcher(private val context: Context) {
                 )
             )
             .putExtra(ScouterWidgetPromptActivity.EXTRA_AGENT_ACTION_RUN_ID, request.runId)
+            .putExtra(ScouterWidgetPromptActivity.EXTRA_AGENT_ACTION_NONCE, actionNonce)
             .putExtra(ScouterWidgetPromptActivity.EXTRA_AGENT_ACTION_REQUEST_SHA256, requestSha256)
             .addFlags(
                 Intent.FLAG_ACTIVITY_NEW_TASK or

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterWidgetPromptActivity.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/ScouterWidgetPromptActivity.kt
@@ -407,15 +407,16 @@ class ScouterWidgetPromptActivity : Activity() {
             else -> return false
         }
         val runId = intent.getStringExtra(EXTRA_AGENT_ACTION_RUN_ID)?.trim().orEmpty()
+        val actionNonce = intent.getStringExtra(EXTRA_AGENT_ACTION_NONCE)
         val expectedRequestSha256 = intent.getStringExtra(EXTRA_AGENT_ACTION_REQUEST_SHA256)
-        if (runId.isBlank()) {
+        if (runId.isBlank() || actionNonce.isNullOrBlank() || expectedRequestSha256.isNullOrBlank()) {
             Toast.makeText(this, R.string.scouter_widget_approval_not_ready, Toast.LENGTH_SHORT).show()
             finishQuietly()
             return true
         }
 
         runCatching {
-            AgentActionApprovalBridge.writeHumanReply(this, runId, decision, expectedRequestSha256)
+            AgentActionApprovalBridge.writeHumanReply(this, runId, decision, expectedRequestSha256, actionNonce)
             AgentActionApprovalBridge.clearRequest(this, runId)
         }.fold(onSuccess = {
             getSystemService(NotificationManager::class.java)
@@ -728,6 +729,7 @@ class ScouterWidgetPromptActivity : Activity() {
         const val EXTRA_AGENT_ESCALATION_ACTION_NONCE = "expo.modules.terminalemulator.scouter.AGENT_ESCALATION_ACTION_NONCE"
         const val EXTRA_AGENT_ESCALATION_REQUEST_SHA256 = "expo.modules.terminalemulator.scouter.AGENT_ESCALATION_REQUEST_SHA256"
         const val EXTRA_AGENT_ACTION_RUN_ID = "expo.modules.terminalemulator.scouter.AGENT_ACTION_RUN_ID"
+        const val EXTRA_AGENT_ACTION_NONCE = "expo.modules.terminalemulator.scouter.AGENT_ACTION_NONCE"
         const val EXTRA_AGENT_ACTION_REQUEST_SHA256 = "expo.modules.terminalemulator.scouter.AGENT_ACTION_REQUEST_SHA256"
         const val EXTRA_CHOICE_INDEX = "expo.modules.terminalemulator.scouter.CHOICE_INDEX"
         const val EXTRA_CHOICE_LABEL = "expo.modules.terminalemulator.scouter.CHOICE_LABEL"

--- a/modules/terminal-emulator/src/TerminalEmulatorModule.ts
+++ b/modules/terminal-emulator/src/TerminalEmulatorModule.ts
@@ -197,6 +197,7 @@ declare class TerminalEmulatorModuleType extends NativeModule {
     dmPairingId?: string | null;
     dmPairingLabel?: string | null;
     dmReplyText?: string | null;
+    actionNonce?: string | null;
   }>;
   notifyAgentActionApprovalNeeded?(request: {
     runId: string;
@@ -221,7 +222,8 @@ declare class TerminalEmulatorModuleType extends NativeModule {
   resolveAgentActionApproval?(
     runId: string,
     decision: 'accept' | 'decline',
-    expectedRequestSha256?: string | null
+    expectedRequestSha256: string,
+    actionNonce: string
   ): Promise<void>;
   cancelAgentActionApproval?(runId: string): Promise<void>;
   fireAgentIntent?(mode: 'launch' | 'share', target: string, shareText?: string | null): Promise<void>;


### PR DESCRIPTION
## Summary
- `AgentActionApprovalBridge.writeHumanReply` accepted a null `expectedRequestSha256` (explicit bypass) and had no replay protection, unlike its sibling `AgentEscalationBridge` which requires a non-null hash plus a single-use nonce.
- Hardens the bridge to match: mints a nonce whenever a request is disclosed for review (notification Allow/Deny or the in-app review card), requires it alongside the content hash, atomically consumes it on use.
- RN-side (`app/_layout.tsx`) fails closed ("not ready") when either value is missing instead of falling back to null.

## Test plan
- [x] New test: `agent-action-approval-bridge-hardening.test.ts` (6 source-assertion tests)
- [x] `npx tsc --noEmit` clean
- [x] Full `agent*` test sweep green (443 tests, pre-existing unrelated Windows ENAMETOOLONG failures only)