### PR TITLE
fix(agent): scan intent/dm-reply fields for secrets, redact live egress, forward taint on PlanSpec path

### DIFF
--- a/__tests__/agent-executor-autonomous.test.ts
+++ b/__tests__/agent-executor-autonomous.test.ts
@@ -396,11 +396,33 @@ describe('generateRunScript — abort-safe shell (exit 141 root-causes)', () => 
     // sed | head -c 500 SIGPIPEs sed on any result > 500 bytes (every real answer)
     // → exit 141 under set -euo pipefail. Must filter to a file, then head the file.
     expect(s).toContain('sed -E \'/^(AUDIT|AUDIT_FALLBACK|GATE|C->S|S->C|STDERR|ESCALATE|ESCALATE_RESOLVED) /d\' "$file" 2>/dev/null > "$cleaned"');
-    expect(s).toContain('head -c 500 "$cleaned" 2>/dev/null | tr');
+    // SECRET-001: redact_secrets_text now runs against the $cleaned FILE (still
+    // file-not-pipe, same abort-safety) BEFORE the 500-byte head, and head reads
+    // ITS output file ($redacted) rather than $cleaned directly.
+    expect(s).toContain('redact_secrets_text "$cleaned" > "$redacted" 2>/dev/null');
+    expect(s).toContain('head -c 500 "$redacted" 2>/dev/null | tr');
     // The OLD sed-piped-into-head form (the SIGPIPE source) must be gone. (A fixed
     // short error string at line ~255 still pipes into head -c 500 — that is safe
     // because its producer never exceeds 500 bytes, so it is not matched here.)
     expect(s).not.toContain('2>/dev/null \\\n    | head -c 500 | tr');
+  });
+
+  it('redact_secrets_text mirrors PlanSpec REDACT_PATTERNS and stays file-based (no stdin-pipe SIGPIPE)', () => {
+    const s = generateRunScript(agent({ type: 'local' }));
+    expect(s).toContain("redact_secrets_text() {");
+    // Takes a file path (process.argv[2]), never stdin — a heredoc already owns
+    // fd0 for the node script source itself, so reading real data from stdin
+    // too would silently read empty/garbage.
+    expect(s).toContain("const file = process.argv[2];");
+    expect(s).toContain('try { data = fs.readFileSync(file, \'utf8\'); } catch (_) {}');
+    // Same secret classes as scripts/shelly-plan-executor.js's REDACT_PATTERNS.
+    expect(s).toContain('/\\bsk-ant-[A-Za-z0-9_-]{20,}\\b/g');
+    expect(s).toContain('/\\bAIza[0-9A-Za-z_-]{25,}\\b/g');
+    expect(s).toContain('/\\bBearer\\s+[A-Za-z0-9._~+/=-]{16,}\\b/gi');
+    // Non-node fallback still redacts (best-effort) instead of silently passing
+    // raw secrets through when node is unavailable.
+    expect(s).toContain("sed -E \\");
+    expect(s).toContain("-e 's/sk-ant-[A-Za-z0-9_-]{20,}/<redacted>/g'");
   });
 
   it('the concurrency check uses find|while, not find -exec sh -c with {} (toybox-safe)', () => {

--- a/__tests__/agent-router-scoring.test.ts
+++ b/__tests__/agent-router-scoring.test.ts
@@ -145,6 +145,23 @@ describe('hard guards always win over the scorer', () => {
     expect(r.decision.noCloudFallback).toBe(true);
   });
 
+  // Regression coverage for the audit-flagged gap: intentShareText/dmReplyText/
+  // intentTarget/dmPairingId were added to AgentActionType later than
+  // webhookUrl/command but textForSecretScan never grew to include them, so a
+  // secret embedded in an intent-share or dm-reply template silently bypassed
+  // the on-device-only guard and could route to a cloud tool.
+  it.each([
+    ['intentShareText', { type: 'intent' as const, intentMode: 'share' as const, intentShareText: 'ship key sk-ant-api03-AAAABBBBCCCCDDDD to {{result}}' }],
+    ['intentTarget', { type: 'intent' as const, intentMode: 'launch' as const, intentTarget: 'sk-ant-api03-AAAABBBBCCCCDDDD' }],
+    ['dmReplyText', { type: 'dm-reply' as const, dmReplyText: 'here is the key sk-ant-api03-AAAABBBBCCCCDDDD' }],
+    ['dmPairingId', { type: 'dm-reply' as const, dmPairingId: 'sk-ant-api03-AAAABBBBCCCCDDDD' }],
+  ])('secret-guard also scans action.%s', (_label, action) => {
+    const r = resolveAgentRoute(mkAgent({ prompt: 'summarize this', action }));
+    expect(r.decision.guard).toBe('secret');
+    expect(r.decision.route).toBe('on-device');
+    expect(r.decision.noCloudFallback).toBe(true);
+  });
+
   it('manual on-device pin overrides the scorer', () => {
     const r = resolveAgentRoute(mkAgent({ prompt: 'review github PR', runOn: 'on-device' }));
     expect(r.decision.guard).toBe('manual-pin');

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -111,4 +111,30 @@ describe('shelly-plan-executor.js parity', () => {
     expect(executorSrc).toContain('paths.haltSentinel');
     expect(executorSrc).toContain("haltSentinel: path.join(agentsDir, '.halted')");
   });
+
+  it('threads notification taint into the PlanSpec executor path, not just the legacy .sh path', () => {
+    // Companion to notify-listener/parity.test.ts's "threads notification taint
+    // into the legacy generated-agent broker path": that test only covers the
+    // .sh branch of AgentRuntime.runAgent. Before this fix, runAgent's
+    // shouldRunPlanExecutor branch called runPlanAgent(...) WITHOUT the
+    // `tainted` value it already has in scope, so a notification-triggered
+    // (tainted=true) run silently lost its taint on the PlanSpec path and
+    // classifyEgress's tainted-secret-spend gate (shelly-capability-broker.js)
+    // never applied once SHELLY_PLAN_EXECUTOR flips on.
+    const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
+    expect(agentRuntime).toContain('return runPlanAgent(appContext, homeDir, libDir, bashPath, agentId, tainted, unattended)');
+    expect(agentRuntime).toMatch(/private fun runPlanAgent\(\s*context: Context,\s*homeDir: File,\s*libDir: File,\s*bashPath: String,\s*agentId: String,\s*tainted: Boolean,\s*unattended: Boolean/);
+    // The env-var builder exports SHELLY_CAP_TAINTED=1 right after the other
+    // CAP-001 flags (SHELLY_CAP_BROKER/FS/EXEC), guarded by the same `tainted`
+    // param the legacy .sh path already gates its own export on.
+    expect(agentRuntime).toMatch(/export SHELLY_CAP_BROKER=1 SHELLY_CAP_FS=1 SHELLY_CAP_EXEC=1"\)\s*\n\s*if \(tainted\) \{\s*\n\s*append\(" && export SHELLY_CAP_TAINTED=1"\)\s*\n\s*\}/);
+    // JS-side contract: the executor must actually read the env var and forward
+    // --tainted to the broker's http.request op (shelly-capability-broker.js
+    // parses `args.tainted === '1'` and feeds it into classifyEgress), mirroring
+    // the legacy .sh's http_post_json which always forwards
+    // "${SHELLY_CAP_TAINTED:-0}" via --tainted. Without this, exporting the env
+    // var alone would be inert dead code.
+    expect(executorSrc).toContain("tainted: process.env.SHELLY_CAP_TAINTED === '1'");
+    expect(executorSrc).toContain("if (opts.tainted) args.push('--tainted', '1');");
+  });
 });

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -537,11 +537,61 @@ json_string_file() {
   printf '"'
 }
 
+# Mirrors scripts/shelly-plan-executor.js's REDACT_PATTERNS/redact() so a live
+# agent result gets the same secret-scrubbing guarantee whether it reaches a
+# webhook body, notification, intent-share text, or dm-reply text through this
+# .sh executor or through the PlanSpec executor. Takes a FILE PATH (not stdin)
+# so it composes with clean_result_preview's file-not-pipe SIGPIPE safety below.
+redact_secrets_text() {
+  file="$1"
+  [ -f "$file" ] || return 0
+  if node_usable; then
+    if shelly_node - "$file" <<'NODEEOF' 2>/dev/null
+const fs = require('fs');
+const file = process.argv[2];
+let data = '';
+try { data = fs.readFileSync(file, 'utf8'); } catch (_) {}
+const patterns = [
+  /\\bsk-ant-[A-Za-z0-9_-]{20,}\\b/g,
+  /\\bsk-proj-[A-Za-z0-9_-]{20,}\\b/g,
+  /\\bsk-[A-Za-z0-9_-]{20,}\\b/g,
+  /\\bAIza[0-9A-Za-z_-]{25,}\\b/g,
+  /\\bgsk_[A-Za-z0-9_-]{20,}\\b/g,
+  /\\bcsk-[A-Za-z0-9_-]{20,}\\b/g,
+  /\\bgh[pousr]_[A-Za-z0-9_]{20,}\\b/g,
+  /\\bBearer\\s+[A-Za-z0-9._~+/=-]{16,}\\b/gi,
+];
+let out = data;
+for (const p of patterns) out = out.replace(p, '<redacted>');
+process.stdout.write(out);
+NODEEOF
+    then
+      return 0
+    fi
+  fi
+  sed -E \\
+    -e 's/sk-ant-[A-Za-z0-9_-]{20,}/<redacted>/g' \\
+    -e 's/sk-proj-[A-Za-z0-9_-]{20,}/<redacted>/g' \\
+    -e 's/sk-[A-Za-z0-9_-]{20,}/<redacted>/g' \\
+    -e 's/AIza[0-9A-Za-z_-]{25,}/<redacted>/g' \\
+    -e 's/gsk_[A-Za-z0-9_-]{20,}/<redacted>/g' \\
+    -e 's/csk-[A-Za-z0-9_-]{20,}/<redacted>/g' \\
+    -e 's/gh[pousr]_[A-Za-z0-9_]{20,}/<redacted>/g' \\
+    -e 's/[Bb]earer +[A-Za-z0-9._~+/=-]{16,}/<redacted>/g' \\
+    "$file" 2>/dev/null || cat "$file" 2>/dev/null || true
+}
+
 # Strip the autonomous driver's structured telemetry (AUDIT/GATE/protocol/STDERR/
 # escalation) from a result file so the user-facing preview shows real content,
 # never the internal driver_start JSON. Backends that write a plain answer
 # (local/perplexity/gemini) have no such lines, so this is a harmless no-op for
-# them. Whitespace-collapsed and length-capped for a notification body.
+# them. Whitespace-collapsed and length-capped for a notification body. Also
+# secret-redacted (SECRET-001 parity with PlanSpec's previewText()) BEFORE the
+# 500-byte truncation below, so a secret straddling the cut is never
+# half-redacted — the .sh executor's clean_result_preview() feeds this preview
+# into webhook bodies, notifications, intent-share text, and dm-reply text via
+# {{result}} substitution (see write_action_approval_request), so it must never
+# carry a live secret from the raw agent-tool result.
 clean_result_preview() {
   file="$1"
   [ -f "$file" ] || return 0
@@ -549,11 +599,15 @@ clean_result_preview() {
   # Piping sed directly into "head -c 500" SIGPIPEs sed the moment head closes the
   # pipe early (any cleaned result > 500 bytes — i.e. every real answer); under
   # 'set -euo pipefail' that 141 propagates and aborts the whole run. head reading
-  # a regular file has no upstream producer to signal, so it is abort-safe.
+  # a regular file has no upstream producer to signal, so it is abort-safe. Same
+  # reasoning applies to redact_secrets_text below: it runs against the $cleaned
+  # FILE (not a live pipe), so head reading its output FILE stays abort-safe too.
   cleaned="$file.preview"
+  redacted="$file.preview.redacted"
   sed -E '/^(AUDIT|AUDIT_FALLBACK|GATE|C->S|S->C|STDERR|ESCALATE|ESCALATE_RESOLVED) /d' "$file" 2>/dev/null > "$cleaned" || true
-  head -c 500 "$cleaned" 2>/dev/null | tr '\\n' ' '
-  rm -f "$cleaned"
+  redact_secrets_text "$cleaned" > "$redacted" 2>/dev/null || true
+  head -c 500 "$redacted" 2>/dev/null | tr '\\n' ' '
+  rm -f "$cleaned" "$redacted"
 }
 
 write_native_notification_request() {

--- a/lib/agent-tool-router.ts
+++ b/lib/agent-tool-router.ts
@@ -109,6 +109,10 @@ function textForSecretScan(agent: Agent): string {
     agent.outputTemplate,
     agent.action?.webhookUrl,
     agent.action?.command,
+    agent.action?.intentTarget,
+    agent.action?.intentShareText,
+    agent.action?.dmPairingId,
+    agent.action?.dmReplyText,
   ].filter(Boolean).join('\n');
 }
 

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -404,6 +404,7 @@ function brokerHttpBodyFile(paths, opts, plan, request) {
   ];
   if (request.authRef) args.push('--auth-ref', request.authRef);
   if (request.approved) args.push('--approved', '1');
+  if (opts.tainted) args.push('--tainted', '1');
   const rc = runBroker(paths, opts, args);
   const response = readFile(outFile);
   const errorText = readFile(errFile);
@@ -1408,6 +1409,12 @@ function run(args) {
   const opts = {
     libDir: args['lib-dir'] || process.env.SHELLY_LIB_DIR || '',
     broker: args.broker || '',
+    // Mirrors the legacy .sh executor's http_post_json, which always forwards
+    // "${SHELLY_CAP_TAINTED:-0}" to the broker's --tainted flag. Native sets
+    // this env var for notification-triggered (tainted) runs (see
+    // AgentRuntime.kt's runPlanAgent) so classifyEgress's tainted-secret-spend
+    // gate applies on the PlanSpec path too, not just the legacy .sh path.
+    tainted: process.env.SHELLY_CAP_TAINTED === '1',
   };
   ensureDir(paths.tmpDir);
   ensureDir(paths.locksDir);

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -57,7 +57,7 @@ object AgentRuntime {
         val bashPath = LibExtractor.getBashPath(appContext)
 
         if (shouldRunPlanExecutor(homeDir, agentId)) {
-            return runPlanAgent(appContext, homeDir, libDir, bashPath, agentId, unattended)
+            return runPlanAgent(appContext, homeDir, libDir, bashPath, agentId, tainted, unattended)
         }
 
         val scriptPath = File(homeDir, ".shelly/agents/run-agent-$agentId.sh").absolutePath
@@ -164,6 +164,7 @@ object AgentRuntime {
         libDir: File,
         bashPath: String,
         agentId: String,
+        tainted: Boolean,
         unattended: Boolean
     ): AgentRunResult {
         val libPath = libDir.absolutePath
@@ -237,6 +238,9 @@ object AgentRuntime {
             append(" && export SHELLY_LIB_DIR=")
             append(shellQuote(libPath))
             append(" && export SHELLY_CAP_BROKER=1 SHELLY_CAP_FS=1 SHELLY_CAP_EXEC=1")
+            if (tainted) {
+                append(" && export SHELLY_CAP_TAINTED=1")
+            }
             append(" && export SSL_CERT_FILE=")
             append(shellQuote("${homeDir.absolutePath}/.shelly-ssl/ca-certificates.crt"))
             append(" && export CURL_CA_BUNDLE=")

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -404,6 +404,7 @@ function brokerHttpBodyFile(paths, opts, plan, request) {
   ];
   if (request.authRef) args.push('--auth-ref', request.authRef);
   if (request.approved) args.push('--approved', '1');
+  if (opts.tainted) args.push('--tainted', '1');
   const rc = runBroker(paths, opts, args);
   const response = readFile(outFile);
   const errorText = readFile(errFile);
@@ -1408,6 +1409,12 @@ function run(args) {
   const opts = {
     libDir: args['lib-dir'] || process.env.SHELLY_LIB_DIR || '',
     broker: args.broker || '',
+    // Mirrors the legacy .sh executor's http_post_json, which always forwards
+    // "${SHELLY_CAP_TAINTED:-0}" to the broker's --tainted flag. Native sets
+    // this env var for notification-triggered (tainted) runs (see
+    // AgentRuntime.kt's runPlanAgent) so classifyEgress's tainted-secret-spend
+    // gate applies on the PlanSpec path too, not just the legacy .sh path.
+    tainted: process.env.SHELLY_CAP_TAINTED === '1',
   };
   ensureDir(paths.tmpDir);
   ensureDir(paths.locksDir);


### PR DESCRIPTION
## Summary
Two HIGH-severity gaps found in tonight's security audit:

1. **Secret-scan field gaps + missing egress redaction.** \`textForSecretScan()\` omitted \`intentTarget\`/\`intentShareText\`/\`dmPairingId\`/\`dmReplyText\` — the newer action-type fields. Separately, the live \`.sh\` executor substituted the raw tool result into webhook bodies/notifications/intent-share/dm-reply text via \`{{result}}\` with no redaction call anywhere. Adds \`redact_secrets_text()\`, mirroring \`scripts/shelly-plan-executor.js\`'s existing \`REDACT_PATTERNS\`/\`redact()\` exactly, applied before the 500-byte preview truncation (so a secret straddling the cut is never half-redacted).

2. **Notification-triggered taint dropped on the PlanSpec path.** \`runPlanAgent()\` never received/forwarded the \`tainted\` flag \`runAgent()\` already computes correctly, so \`SHELLY_CAP_TAINTED\` was never exported and the tainted-secret-spend approval gate never fired for PlanSpec-executed notification-triggered agents. Threads the flag through, exports it, and the JS broker now reads it and forwards \`--tainted\` — matching the legacy \`.sh\` path's existing behavior.

## Test plan
- [x] New/extended tests: \`agent-router-scoring.test.ts\` (4 cases), \`agent-executor-autonomous.test.ts\`, \`plan-executor-parity.test.ts\` (full taint-chain assertion)
- [x] \`npx tsc --noEmit\` clean
- [x] 95/99 relevant tests pass; 4 pre-existing Windows-only \`ENAMETOOLONG\` failures unrelated to this change