### PR TITLE
feat(agent): add app-act AgentActionType schema (Phase 2, inert)

### DIFF
--- a/__tests__/agent-action-app-act-schema.test.ts
+++ b/__tests__/agent-action-app-act-schema.test.ts
@@ -1,0 +1,125 @@
+jest.mock('@/lib/home-path', () => ({ getHomePath: () => '/home/shelly-test' }));
+
+// Phase 2 of the app-act rollout: schema + secret-scan coverage ONLY.
+// No dispatch/execution logic exists for 'app-act' yet — see
+// lib/agent-plan-spec.ts toPlanAction's default branch and
+// scripts/shelly-plan-executor.js's `action.type === 'unsupported'` refusal,
+// both asserted below as the inertness guarantee.
+
+import { generateRunScript } from '@/lib/agent-executor';
+import { resolveAgentRoute } from '@/lib/agent-tool-router';
+import { buildAgentPlanSpec } from '@/lib/agent-plan-spec';
+import type { Agent, AgentAction } from '@/store/types';
+
+function agent(action: AgentAction, over: Partial<Agent> = {}): Agent {
+  return {
+    id: 'app-act-test',
+    name: 'App Act Test',
+    description: '',
+    prompt: 'summarize the run result for posting',
+    schedule: null,
+    tool: { type: 'local' },
+    outputPath: '~/out',
+    outputTemplate: null,
+    enabled: true,
+    lastRun: null,
+    lastResult: null,
+    createdAt: 0,
+    version: 1,
+    action,
+    ...over,
+  };
+}
+
+describe('app-act action schema (Phase 2 — schema only, no dispatch)', () => {
+  it('round-trips appActRecipeId and appActParams through JSON (persistence shape)', () => {
+    const action: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: '{{result}}' },
+    };
+    const a = agent(action);
+
+    const serialized = JSON.stringify(a);
+    const parsed = JSON.parse(serialized) as Agent;
+
+    expect(parsed.action?.type).toBe('app-act');
+    expect(parsed.action?.appActRecipeId).toBe('x.post');
+    expect(parsed.action?.appActParams).toEqual({ text: '{{result}}' });
+  });
+
+  it('round-trips an explicit appActMethod, and leaves it undefined (== accessibility default) when absent', () => {
+    const apiAction: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: '{{result}}' },
+      appActMethod: 'api',
+    };
+    const parsedApi = JSON.parse(JSON.stringify(agent(apiAction))) as Agent;
+    expect(parsedApi.action?.appActMethod).toBe('api');
+
+    const defaultAction: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: '{{result}}' },
+    };
+    const parsedDefault = JSON.parse(JSON.stringify(agent(defaultAction))) as Agent;
+    expect(parsedDefault.action?.appActMethod).toBeUndefined();
+  });
+
+  it('accepts app-act in the AgentActionType union and in generateRunScript without throwing', () => {
+    const action: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: 'Result: {{result}}' },
+    };
+    expect(() => generateRunScript(agent(action))).not.toThrow();
+  });
+
+  it('frames an app-act result as generic requested app-action content (no post-specific wiring)', () => {
+    const action: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: '{{result}}' },
+    };
+    const script = generateRunScript(agent(action, { tool: { type: 'local' } }));
+    expect(script).toContain('Produce exactly the content needed for the requested app action.');
+  });
+
+  it('is inert: PlanSpec builder refuses app-act as unsupported (fail closed, not a silent draft fallback)', () => {
+    const action: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: '{{result}}' },
+    };
+    const spec = buildAgentPlanSpec(agent(action));
+    expect(spec.action.type).toBe('unsupported');
+    expect((spec.action as { unsupportedReason?: string }).unsupportedReason).toContain('app-act');
+  });
+});
+
+describe('app-act secret scan coverage', () => {
+  const SECRET = 'sk-ant-api03-AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH';
+
+  it('trips the secret guard when a secret is embedded in appActParams.text', () => {
+    const action: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: `Posting with leaked key ${SECRET}` },
+    };
+    const r = resolveAgentRoute(agent(action, { prompt: 'post an update' }));
+    expect(r.decision.guard).toBe('secret');
+    expect(r.decision.route).toBe('on-device');
+    expect(r.decision.noCloudFallback).toBe(true);
+  });
+
+  it('does not trip the secret guard for an app-act agent with no secret-bearing text', () => {
+    const action: AgentAction = {
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: '{{result}}' },
+    };
+    const r = resolveAgentRoute(agent(action, { prompt: 'post an update' }));
+    expect(r.decision.guard).not.toBe('secret');
+  });
+});

--- a/components/panes/AgentConfirmCard.tsx
+++ b/components/panes/AgentConfirmCard.tsx
@@ -55,7 +55,7 @@ export interface ConfirmedAgentDraft {
 type RunOn = 'auto' | 'on-device' | 'cloud';
 
 const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土']; // cron dow 0..6
-const ACTION_TYPES: AgentActionType[] = ['draft', 'notify', 'webhook', 'cli', 'intent', 'dm-reply'];
+const ACTION_TYPES: AgentActionType[] = ['draft', 'notify', 'webhook', 'cli', 'intent', 'dm-reply', 'app-act'];
 const RUN_ON: RunOn[] = ['auto', 'on-device', 'cloud'];
 
 function clampInt(raw: string, min: number, max: number): number {

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -33,6 +33,9 @@ const ACTION_OUTPUT_INSTRUCTIONS: Record<AgentActionType, string> = {
   cli: 'Produce exactly the content needed by the requested command or command workflow.',
   intent: 'Produce exactly the text or content needed for the requested app or share action.',
   'dm-reply': 'Write the reply message itself as a natural, short conversational response unless explicit user instructions request otherwise.',
+  // Schema only (Phase 2 of the app-act rollout) — no dispatch path reads this
+  // yet; see agent-plan-spec.ts toPlanAction's default 'unsupported' branch.
+  'app-act': 'Produce exactly the content needed for the requested app action.',
 };
 const ACTION_OUTPUT_RULES = 'Follow explicit user instructions for content, format, length, and tone. When they are not specified, be direct and concise. Output only the requested deliverable. Never add meta-commentary about your reasoning or interpretation of the request.';
 

--- a/lib/agent-tool-router.ts
+++ b/lib/agent-tool-router.ts
@@ -113,6 +113,7 @@ function textForSecretScan(agent: Agent): string {
     agent.action?.intentShareText,
     agent.action?.dmPairingId,
     agent.action?.dmReplyText,
+    agent.action?.appActParams ? Object.values(agent.action.appActParams).join('\n') : undefined,
   ].filter(Boolean).join('\n');
 }
 

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -213,6 +213,7 @@ const en: Record<string, string> = {
   'agentcard.action_cli': 'command',
   'agentcard.action_intent': 'App / Share',
   'agentcard.action_dm-reply': 'DM reply',
+  'agentcard.action_app-act': 'App action',
   'agentcard.dmreply_pairing_label': 'Paired conversation',
   'agentcard.dmreply_no_pairings': 'Pair a conversation in Settings first.',
   'agentcard.dmreply_text_label': 'Reply text',

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -213,6 +213,7 @@ const ja: Record<string, string> = {
   'agentcard.action_cli': 'コマンド',
   'agentcard.action_intent': 'アプリ起動・共有',
   'agentcard.action_dm-reply': 'DM返信',
+  'agentcard.action_app-act': 'アプリ操作',
   'agentcard.dmreply_pairing_label': 'ペアリング済みの会話',
   'agentcard.dmreply_no_pairings': '先に設定から会話をペアリングしてください。',
   'agentcard.dmreply_text_label': '返信テキスト',

--- a/lib/model-router/wiring.ts
+++ b/lib/model-router/wiring.ts
@@ -64,6 +64,11 @@ function textForSecretScan(agent: Agent): string {
     agent.outputTemplate,
     agent.action?.webhookUrl,
     agent.action?.command,
+    agent.action?.intentTarget,
+    agent.action?.intentShareText,
+    agent.action?.dmPairingId,
+    agent.action?.dmReplyText,
+    agent.action?.appActParams ? Object.values(agent.action.appActParams).join('\n') : undefined,
   ].filter(Boolean).join('\n');
 }
 

--- a/store/types.ts
+++ b/store/types.ts
@@ -499,8 +499,27 @@ export type ToolChoice =
  * keyed off `type`: draft/notify = one-tap; webhook = one-tap with host+payload shown;
  * cli/intent/dm-reply = never one-tap (in-app Review before Allow) — intent additionally shows
  * the resolved target app/URI/share-text so the user sees exactly what will fire.
+ *
+ * `app-act` is a DELIBERATE exception to that pattern: it is Tier-B and
+ * unattended/autonomous-run-capable, unlike its `cli`/`intent`/`dm-reply` siblings
+ * which either hard-refuse unattended execution or are refused when running
+ * unattended. This is intentional, not an oversight a future reader should "fix"
+ * by adding a matching hard-refusal — do not do that. The reason it's safe: unlike
+ * `intent`/`dm-reply`, which can point at an arbitrary target resolved at run time
+ * (a package/URI or a paired notification fingerprint chosen dynamically), an
+ * `app-act` action's recipe + target + content-pipeline (`appActRecipeId` +
+ * `appActParams`) is fixed and explicitly consented to once at registration time,
+ * and remains visible in the Sidebar for the lifetime of the agent — there is no
+ * run-time target resolution step that could diverge from what the user approved.
  */
-export type AgentActionType = 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply';
+export type AgentActionType =
+  | 'draft'
+  | 'notify'
+  | 'webhook'
+  | 'cli'
+  | 'intent'
+  | 'dm-reply'
+  | 'app-act';
 
 export interface AgentAction {
   type: AgentActionType;
@@ -527,6 +546,22 @@ export interface AgentAction {
   dmPairingId?: string;
   /** dm-reply: reply text template. A literal {{result}} is replaced with the run preview. */
   dmReplyText?: string;
+  /** app-act: which registered app-action recipe to invoke (e.g. 'x.post').
+   *  Schema only in this phase — no dispatch logic reads this yet. */
+  appActRecipeId?: string;
+  /** app-act: recipe parameters (e.g. { text: '{{result}}' } for 'x.post').
+   *  Values may contain the literal placeholder "{{result}}", string-replaced
+   *  (no template engine) with the agent's run preview text, following the same
+   *  convention as intentShareText/dmReplyText. Schema only in this phase. */
+  appActParams?: Record<string, string>;
+  /** app-act: delivery mechanism for the recipe. 'accessibility' = drive the
+   *  target app's UI via AccessibilityService (what Phase 3/4 implement first);
+   *  'api' = call the target service's own API (e.g. X API v2 OAuth 1.0a
+   *  user-context) as a forward-compatible alternative, not yet implemented.
+   *  Absent/undefined means 'accessibility' — kept optional so existing
+   *  app-act actions written before this field existed don't need a migration.
+   *  Schema only in this phase; no dispatch logic reads this yet. */
+  appActMethod?: 'accessibility' | 'api';
 }
 
 /** Phase 1 persistent memory (lib/agent-memory.ts). On-device only. */


### PR DESCRIPTION
## Summary
- Schema-only groundwork for X-post delivery, part of the Hermes-parity STEAM×AI pipeline goal. Adds \`'app-act'\` to \`AgentActionType\` with \`appActRecipeId\`/\`appActParams\`/\`appActMethod\` fields.
- Documents \`app-act\` as a deliberate exception to the \`cli\`/\`intent\`/\`dm-reply\` "never one-tap" pattern: the recipe+target+content-pipeline is fixed and consented to once at registration, with ongoing Sidebar visibility — unlike \`intent\`/\`dm-reply\` which resolve a target at run time.
- \`appActMethod: 'accessibility' | 'api'\` keeps the door open for X API v2 posting later without a schema migration (absent = accessibility, what the following phases implement first).
- **Verified inert**: an \`app-act\` agent fails closed today via \`toPlanAction\`'s default \`'unsupported'\` branch — no dispatch code reads these fields yet.
- **Found during rebase**: PR #127 added \`intentTarget\`/\`intentShareText\`/\`dmPairingId\`/\`dmReplyText\` to \`lib/agent-tool-router.ts\`'s \`textForSecretScan\` but not the mirrored \`lib/model-router/wiring.ts\` copy. Synced them here for consistency — that file's own header comment confirms this is a bounded shadow-comparator drift risk, not a live secret-scan bypass (the dormant Phase A/B model-router shadow path never reaches production).

## Test plan
- [x] New test: \`agent-action-app-act-schema.test.ts\` (9 cases — round-trip, secret-scan coverage, PlanSpec fail-closed)
- [x] \`npx tsc --noEmit\` clean
- [x] \`model-router/*\` + schema test suite: 47/47 pass