### PR TITLE
feat(agent): port app-act native AccessibilityService layer (Phase 3, dead code)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -124,6 +124,7 @@ const config: ExpoConfig & { android?: any } = {
     "./plugins/with-saved-instance-state",
     "./plugins/with-configuration-change-guard",
     "./plugins/with-agent-launch-queries",
+    "./plugins/with-accessibility-service",
     [
       "expo-audio",
       {

--- a/modules/terminal-emulator/android/src/main/AndroidManifest.xml
+++ b/modules/terminal-emulator/android/src/main/AndroidManifest.xml
@@ -10,6 +10,24 @@
       android:taskAffinity=""
       android:theme="@style/ShellyScouterPromptTheme" />
 
+    <!-- Deliberately NOT singleTop (found by independent review 2026-07-11):
+         ensureUnlocked()'s per-instance latch/result capture in onCreate()
+         means a reused instance (routed via onNewIntent under singleTop)
+         would keep operating on a PRIOR call's already-timed-out latch,
+         making every retry after a timeout silently fail forever. Each call
+         must always get a fresh onCreate(). See ensureUnlocked()'s companion
+         `currentInstance` handling for the matching fix that ensures a
+         timed-out instance actually gets finish()'d, so a stale one is
+         never still around for the OS to route a new intent into anyway. -->
+    <activity
+      android:name=".LockPromptActivity"
+      android:excludeFromRecents="true"
+      android:exported="false"
+      android:finishOnTaskLaunch="true"
+      android:noHistory="true"
+      android:taskAffinity=""
+      android:theme="@style/ShellyLockPromptTheme" />
+
     <receiver
       android:name=".scouter.ScouterWidgetProvider"
       android:exported="false">

--- a/modules/terminal-emulator/android/src/main/assets/app-act-recipes/line.send-message.json
+++ b/modules/terminal-emulator/android/src/main/assets/app-act-recipes/line.send-message.json
@@ -1,0 +1,46 @@
+{
+  "id": "line.send-message",
+  "pkg": "jp.naver.line.android",
+  "operation": "send-message",
+  "displayName": "Send a LINE message to a contact",
+  "tier": "C",
+  "params": [
+    { "name": "contact", "description": "Exact LINE conversation/contact name to search for", "required": true },
+    { "name": "message", "description": "Message text to send", "required": true }
+  ],
+  "steps": [
+    {
+      "op": "launch",
+      "target": "jp.naver.line.android",
+      "intent": "Bring LINE to the foreground (or launch it) so the rest of the recipe has a window to act on."
+    },
+    {
+      "op": "click",
+      "matcher": { "label": "検索" },
+      "intent": "Open LINE's search screen from whatever screen is currently showing. label (not contentDescription) because ホーム/トーク/ニュース tabs show \"検索\" as visible placeholder text, while VOOM/ミニアプリ expose it only via contentDescription — confirmed on-device 2026-07-12.",
+      "recoverOnZeroMatch": ["back", "back", "scrollToTop"]
+    },
+    {
+      "op": "setText",
+      "matcher": { "resourceId": "jp.naver.line.android:id/input_text" },
+      "param": "contact",
+      "intent": "Type the target contact/conversation name into the search field."
+    },
+    {
+      "op": "click",
+      "matcher": { "resourceId": "jp.naver.line.android:id/name_text_view", "text": "{{contact}}" },
+      "intent": "Tap the single exact-matching search result row to open that conversation."
+    },
+    {
+      "op": "setText",
+      "matcher": { "resourceId": "jp.naver.line.android:id/chat_ui_message_edit" },
+      "param": "message",
+      "intent": "Type the message body into the open conversation's message field."
+    },
+    {
+      "op": "click",
+      "matcher": { "resourceId": "jp.naver.line.android:id/chat_ui_send_button_image" },
+      "intent": "Tap the send button to deliver the message. resourceId only (not also contentDescription) — the button's contentDescription is state-dependent (flips between e.g. \"ボイスメッセージ\"/\"送信\"), so pinning both risks a spurious zero-match if the observed string differs at click time; the old hand-written flow this recipe replaces matched by resourceId alone for the same reason."
+    }
+  ]
+}

--- a/modules/terminal-emulator/android/src/main/assets/app-act-recipes/x.post.json
+++ b/modules/terminal-emulator/android/src/main/assets/app-act-recipes/x.post.json
@@ -1,0 +1,28 @@
+{
+  "id": "x.post",
+  "pkg": "com.twitter.android",
+  "operation": "post",
+  "displayName": "Post to X",
+  "tier": "B",
+  "params": [
+    { "name": "text", "description": "Post text", "required": true }
+  ],
+  "steps": [
+    {
+      "op": "launch",
+      "target": "com.twitter.android",
+      "intent": "Bring X to the foreground (or launch it) so the rest of the recipe has a window to act on."
+    },
+    {
+      "op": "setText",
+      "matcher": { "resourceId": "com.twitter.android:id/tweet_text" },
+      "param": "text",
+      "intent": "Type the post text into the compose screen's body field."
+    },
+    {
+      "op": "click",
+      "matcher": { "resourceId": "com.twitter.android:id/button_tweet" },
+      "intent": "Tap the post button to publish."
+    }
+  ]
+}

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AppActExecutor.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AppActExecutor.kt
@@ -1,0 +1,723 @@
+package expo.modules.terminalemulator
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
+import android.content.Intent
+import android.graphics.Rect
+import android.os.Bundle
+import android.util.Log
+import android.view.accessibility.AccessibilityNodeInfo
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * app.act Track 2 (docs/superpowers/specs/2026-07-11-app-act-design.md,
+ * 2026-07-11-post-ui-automation-agent-architecture.md, 2026-07-12
+ * implementation-detail plan) — the general recipe/step-walker engine.
+ *
+ * Replaces the three hand-written, hardcoded flows in
+ * [ShellyAccessibilityService] (`debugSendLineMessageToContactInner`,
+ * `debugPostToXInner`, and their shared node-finding helpers) with a single
+ * generic walker driven by [AppActRecipeStore.Recipe] data. Every node/
+ * candidate-list resolution goes through [pollForCandidates] — one polling
+ * primitive generalizing what used to be three separate hand-written
+ * pollers (`pollForNodeByResourceId`, `pollForNodeByContentDescription`,
+ * `pollForStableLineSearchResults`).
+ *
+ * Still reachable ONLY from the same debug entry points as before
+ * (SettingsDropdown.tsx's AppActDebugSection, via
+ * [ShellyAccessibilityService.debugSendLineMessageToContact] /
+ * [ShellyAccessibilityService.debugPostToX]) — NOT wired into the agent/
+ * PlanSpec pipeline. [resolveMatcherMiss] is a Track 3 (LLM fallback) stub
+ * that always returns null (fail-closed, identical to today's zero-match
+ * behavior); Track 3 will fill it in later without needing to change any
+ * step's control flow.
+ */
+object AppActExecutor {
+    private const val TAG = "AppActExecutor"
+    private const val DEFAULT_STEP_TIMEOUT_MS = 3000L
+    private const val LAUNCH_TIMEOUT_MS = 5000L
+    private const val POLL_INTERVAL_MS = 150L
+    private const val SCROLL_TO_TOP_MAX_STEPS = 10
+    private const val SCROLL_STABLE_SAMPLES_TO_STOP = 2
+
+    /** Single re-entrancy guard for ALL app.act runs — replaces
+     *  [ShellyAccessibilityService]'s own per-file `busy` companion val.
+     *  All recipes act through the same single AccessibilityService
+     *  instance, so one guard across every recipe is correct, same as
+     *  before. */
+    private val busy = AtomicBoolean(false)
+
+    fun execute(service: ShellyAccessibilityService, context: Context, recipeId: String, params: Map<String, String>): AppActDebugResult =
+        runGuarded { executeInner(service, context, recipeId, params) }
+
+    /** Shared re-entrancy guard + exception boundary for EVERY app.act
+     *  entry point — recipe-driven ([execute]) and the two remaining
+     *  hand-written entry points in [ShellyAccessibilityService]
+     *  ([ShellyAccessibilityService.debugSendLineMessage], which has no
+     *  recipe equivalent since it deliberately skips the search/navigate
+     *  steps and sends into whatever conversation is already open). All
+     *  app.act actions go through the same single AccessibilityService
+     *  instance, so one guard across every call site is correct — mirrors
+     *  [ShellyAccessibilityService]'s former per-file `busy` companion val,
+     *  now centralized here since it must also cover recipe-driven runs. */
+    internal fun runGuarded(action: () -> AppActDebugResult): AppActDebugResult {
+        if (!busy.compareAndSet(false, true)) {
+            return AppActDebugResult(false, "Another app.act run is already in progress")
+        }
+        return try {
+            action()
+        } catch (e: Exception) {
+            Log.e(TAG, "runGuarded action threw", e)
+            AppActDebugResult(false, "Exception: ${e.message}")
+        } finally {
+            busy.set(false)
+        }
+    }
+
+    private fun executeInner(service: ShellyAccessibilityService, context: Context, recipeId: String, params: Map<String, String>): AppActDebugResult {
+        val recipe = AppActRecipeStore.load(context, recipeId)
+            ?: return AppActDebugResult(false, "Recipe not found: $recipeId")
+        for (spec in recipe.params) {
+            if (spec.required && params[spec.name].isNullOrEmpty()) {
+                return AppActDebugResult(false, "Missing required param \"${spec.name}\" for recipe $recipeId")
+            }
+        }
+        recipe.steps.forEachIndexed { index, step ->
+            val outcome = executeStep(service, recipeId, index, recipe.pkg, step, params)
+            if (!outcome.success) return outcome
+        }
+        return AppActDebugResult(true, "Recipe $recipeId completed")
+    }
+
+    private fun executeStep(
+        service: ShellyAccessibilityService,
+        recipeId: String,
+        stepIndex: Int,
+        pkg: String,
+        step: AppActRecipeStore.RecipeStep,
+        params: Map<String, String>,
+    ): AppActDebugResult = when (step.op) {
+        "launch" -> executeLaunch(service, step)
+        "click" -> executeClick(service, recipeId, stepIndex, pkg, step, params)
+        "setText" -> executeSetText(service, recipeId, stepIndex, pkg, step, params)
+        "scroll" -> executeScroll(service, recipeId, stepIndex, pkg, step, params)
+        else -> AppActDebugResult(false, "Unknown recipe step op \"${step.op}\" at step $stepIndex")
+    }
+
+    // ---- launch --------------------------------------------------------
+
+    private fun executeLaunch(service: ShellyAccessibilityService, step: AppActRecipeStore.RecipeStep): AppActDebugResult {
+        val target = step.target
+            ?: return AppActDebugResult(false, "launch step missing target package")
+        val timeoutMs = step.timeoutMs ?: LAUNCH_TIMEOUT_MS
+        return if (ensureForeground(service, target, timeoutMs)) {
+            AppActDebugResult(true, "$target foregrounded")
+        } else {
+            AppActDebugResult(false, "Could not bring $target to the foreground (not installed, didn't respond in time, or device locked)")
+        }
+    }
+
+    /** Ports [ShellyAccessibilityService]'s former `ensureForeground`
+     *  near-verbatim: lock-screen wall FIRST (safety-critical, must not be
+     *  dropped — see the original doc comment for why: rootInActiveWindow
+     *  only ever returns the keyguard while locked), then "already active"
+     *  short-circuit, then launch intent + poll. Shared by [executeLaunch]
+     *  (recipe `launch` steps) AND
+     *  [ShellyAccessibilityService.debugSendLineMessage] (the one entry
+     *  point with no recipe equivalent, since it deliberately skips
+     *  search/navigate and needs the exact same "bring LINE back to
+     *  whatever it was last showing" behavior tonight's hardcoded flow
+     *  relied on). `internal` (not private) so that call site can reach
+     *  it. */
+    internal fun ensureForeground(service: ShellyAccessibilityService, targetPackage: String, timeoutMs: Long = LAUNCH_TIMEOUT_MS): Boolean {
+        if (!LockPromptActivity.ensureUnlocked(service)) {
+            return false
+        }
+        service.rootInActiveWindow?.let { current ->
+            val alreadyActive = current.packageName?.toString() == targetPackage
+            current.recycle()
+            if (alreadyActive) return true
+        }
+        val launchIntent = service.packageManager.getLaunchIntentForPackage(targetPackage) ?: return false
+        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        service.startActivity(launchIntent)
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            Thread.sleep(POLL_INTERVAL_MS)
+            service.rootInActiveWindow?.let { root ->
+                val active = root.packageName?.toString() == targetPackage
+                root.recycle()
+                if (active) return true
+            }
+        }
+        return false
+    }
+
+    // ---- click -----------------------------------------------------------
+
+    private fun executeClick(
+        service: ShellyAccessibilityService,
+        recipeId: String,
+        stepIndex: Int,
+        pkg: String,
+        step: AppActRecipeStore.RecipeStep,
+        params: Map<String, String>,
+    ): AppActDebugResult {
+        val matcher = step.matcher
+            ?: return AppActDebugResult(false, "click step at $stepIndex missing matcher")
+        val substituted = substituteMatcher(matcher, params)
+        val timeoutMs = step.timeoutMs ?: DEFAULT_STEP_TIMEOUT_MS
+        var candidates = pollForCandidates(service, pkg, substituted, timeoutMs)
+
+        // See RecipeStep.recoverOnZeroMatch's doc comment: launch/ensureForeground
+        // resumes the target app's last task state, so the first navigational
+        // click can start from a deeper screen or a scrolled list. Recovery is
+        // ordered, bounded, and per-step opt-in.
+        val recoveryActions = step.recoverOnZeroMatch.orEmpty()
+        val recoveryNotes = mutableListOf<String>()
+        for (action in recoveryActions) {
+            if (candidates.isNotEmpty()) break
+            val recovery = recoverZeroMatch(service, pkg, action)
+            recoveryNotes.add(recovery.note)
+            if (!recovery.shouldRepoll) break
+            candidates = pollForCandidates(service, pkg, substituted, timeoutMs)
+        }
+
+        if (candidates.size == 1) {
+            return performClick(service, pkg, candidates[0])
+        }
+
+        if (candidates.isEmpty()) {
+            val fallback = resolveMatcherMiss(recipeId, stepIndex, step, service)
+            if (fallback != null) return performClick(service, pkg, fallback)
+            val diag = service.diagnoseCurrentScreen()
+            val recoveryNote = if (recoveryNotes.isNotEmpty()) " (recoveries: ${recoveryNotes.joinToString(", ")})" else ""
+            return AppActDebugResult(false, "Zero-match: no node under $pkg matched click step $stepIndex (${step.intent}) after ${timeoutMs}ms$recoveryNote.$diag")
+        }
+
+        val diag = service.diagnoseCurrentScreen()
+        candidates.forEach { it.recycle() }
+        return AppActDebugResult(false, "Ambiguous-multiple-match: ${candidates.size} nodes matched click step $stepIndex (${step.intent}) — refusing to guess, nothing was tapped.$diag")
+    }
+
+    private data class ZeroMatchRecovery(
+        val shouldRepoll: Boolean,
+        val note: String,
+    )
+
+    private data class ScrollableLookup(
+        val foregroundMatches: Boolean,
+        val foregroundPackage: String?,
+        val node: AccessibilityNodeInfo?,
+        val signature: String?,
+    )
+
+    private fun recoverZeroMatch(service: ShellyAccessibilityService, pkg: String, action: String): ZeroMatchRecovery =
+        when (action) {
+            "back" -> {
+                if (pressBackIfStillForeground(service, pkg)) {
+                    ZeroMatchRecovery(shouldRepoll = true, note = "back:ok")
+                } else {
+                    ZeroMatchRecovery(shouldRepoll = false, note = "back:foreground-mismatch-or-no-window")
+                }
+            }
+            "scrollToTop" -> scrollForegroundToTop(service, pkg)
+            else -> ZeroMatchRecovery(shouldRepoll = false, note = "unknown:$action")
+        }
+
+    /** `back` recovery action: fires the
+     *  Android system BACK global action, but ONLY after re-confirming the
+     *  foreground package still matches [pkg] immediately before acting —
+     *  a back-press is state-changing (can dismiss a dialog, discard a
+     *  draft, exit the app entirely) unlike a click on an already-resolved
+     *  node, so it needs its own pre-action foreground check rather than
+     *  relying on the next poll's package-mismatch tolerance (review
+     *  finding, 2026-07-12). Returns false — and presses nothing — if the
+     *  foreground has already drifted away from [pkg]; the caller treats
+     *  that as "stop retrying," not "try again." A short sleep after a
+     *  successful press lets the back-navigation settle before the caller
+     *  re-polls. */
+    private fun pressBackIfStillForeground(service: ShellyAccessibilityService, pkg: String): Boolean {
+        val stillForeground = service.rootInActiveWindow?.let { r ->
+            val ok = r.packageName?.toString() == pkg
+            r.recycle()
+            ok
+        } ?: false
+        if (!stillForeground) return false
+        service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK)
+        Thread.sleep(POLL_INTERVAL_MS)
+        return true
+    }
+
+    /** `scrollToTop` recovery action: used when the desired node is absent
+     *  because the target app's list is already visible but scrolled far
+     *  enough that its header/search entry has left the accessibility tree.
+     *
+     *  The target node itself is missing, so this deliberately does NOT use
+     *  the step matcher. Instead it picks the most likely vertical,
+     *  high-content scrollable descendant of the current foreground root
+     *  (favoring RecyclerView/ListView/ScrollView and penalizing short
+     *  horizontal strips), then sends ACTION_SCROLL_BACKWARD up to a small
+     *  fixed bound. `performAction` returning false is treated as "probably
+     *  already at top"; a fresh-root signature check stops early if a widget
+     *  keeps returning true without changing visible children. */
+    private fun scrollForegroundToTop(service: ShellyAccessibilityService, pkg: String): ZeroMatchRecovery {
+        var moved = 0
+        var unchangedSamples = 0
+        var previousSignature: String? = null
+
+        repeat(SCROLL_TO_TOP_MAX_STEPS) {
+            val before = findBestScrollableInForeground(service, pkg)
+            if (!before.foregroundMatches) {
+                before.node?.recycle()
+                return ZeroMatchRecovery(
+                    shouldRepoll = false,
+                    note = "scrollToTop:foreground=${before.foregroundPackage ?: "none"}",
+                )
+            }
+            val node = before.node
+                ?: return ZeroMatchRecovery(shouldRepoll = true, note = "scrollToTop:no-scrollable")
+            val beforeSignature = before.signature
+            val ok = try {
+                node.performAction(AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD)
+            } finally {
+                node.recycle()
+            }
+            if (!ok) {
+                return ZeroMatchRecovery(shouldRepoll = true, note = "scrollToTop:top-after-$moved")
+            }
+
+            moved++
+            Thread.sleep(POLL_INTERVAL_MS)
+
+            val after = findBestScrollableInForeground(service, pkg)
+            if (!after.foregroundMatches) {
+                after.node?.recycle()
+                return ZeroMatchRecovery(
+                    shouldRepoll = false,
+                    note = "scrollToTop:foreground-after=${after.foregroundPackage ?: "none"}",
+                )
+            }
+            val afterSignature = after.signature
+            after.node?.recycle()
+            if (afterSignature == beforeSignature || afterSignature == previousSignature) {
+                unchangedSamples++
+            } else {
+                unchangedSamples = 0
+            }
+            previousSignature = afterSignature
+            if (unchangedSamples >= SCROLL_STABLE_SAMPLES_TO_STOP) {
+                return ZeroMatchRecovery(shouldRepoll = true, note = "scrollToTop:stable-after-$moved")
+            }
+        }
+
+        return ZeroMatchRecovery(shouldRepoll = true, note = "scrollToTop:max-after-$moved")
+    }
+
+    private fun findBestScrollableInForeground(service: ShellyAccessibilityService, pkg: String): ScrollableLookup {
+        val root = service.rootInActiveWindow
+            ?: return ScrollableLookup(false, null, null, null)
+        val foregroundPackage = root.packageName?.toString()
+        if (foregroundPackage != pkg) {
+            root.recycle()
+            return ScrollableLookup(false, foregroundPackage, null, null)
+        }
+        val scrollable = findBestScrollableDescendant(root)
+        val signature = scrollable?.let { scrollableSignature(it) }
+        root.recycle()
+        return ScrollableLookup(true, foregroundPackage, scrollable, signature)
+    }
+
+    private fun findBestScrollableDescendant(root: AccessibilityNodeInfo): AccessibilityNodeInfo? {
+        val candidates = mutableListOf<AccessibilityNodeInfo>()
+        collectScrollableNodes(root, candidates)
+        var best: AccessibilityNodeInfo? = null
+        var bestScore = Int.MIN_VALUE
+        for (candidate in candidates) {
+            val score = scoreScrollableCandidate(root, candidate)
+            if (score > bestScore) {
+                best?.recycle()
+                best = candidate
+                bestScore = score
+            } else {
+                candidate.recycle()
+            }
+        }
+        return best
+    }
+
+    private fun collectScrollableNodes(node: AccessibilityNodeInfo, out: MutableList<AccessibilityNodeInfo>) {
+        if (node.isScrollable) {
+            out.add(AccessibilityNodeInfo.obtain(node))
+        }
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            try {
+                collectScrollableNodes(child, out)
+            } finally {
+                child.recycle()
+            }
+        }
+    }
+
+    private fun scoreScrollableCandidate(root: AccessibilityNodeInfo, node: AccessibilityNodeInfo): Int {
+        val rootBounds = Rect()
+        val bounds = Rect()
+        root.getBoundsInScreen(rootBounds)
+        node.getBoundsInScreen(bounds)
+
+        val rootWidth = rootBounds.width().coerceAtLeast(1)
+        val rootHeight = rootBounds.height().coerceAtLeast(1)
+        val width = bounds.width().coerceAtLeast(0)
+        val height = bounds.height().coerceAtLeast(0)
+        val className = node.className?.toString().orEmpty()
+
+        var score = height * 2 + width / 4
+        if (className.contains("RecyclerView", ignoreCase = true)) score += 10_000
+        if (className.contains("ListView", ignoreCase = true)) score += 8_000
+        if (className.contains("ScrollView", ignoreCase = true)) score += 4_000
+        if (height.toDouble() >= rootHeight * 0.35) score += 3_000
+        if (width.toDouble() >= rootWidth * 0.60) score += 1_000
+        if (height < minOf(160, rootHeight / 5)) score -= 5_000
+        if (width > height * 2) score -= 2_000
+        score += minOf(node.childCount, 8) * 250
+        if (node.childCount <= 1) score -= 1_500
+        return score
+    }
+
+    private fun scrollableSignature(node: AccessibilityNodeInfo): String {
+        val bounds = Rect()
+        node.getBoundsInScreen(bounds)
+        val out = StringBuilder()
+        out.append(node.className?.toString().orEmpty())
+            .append('|')
+            .append(rectSignature(bounds))
+            .append('|')
+            .append(node.childCount)
+
+        val childSampleCount = minOf(node.childCount, 6)
+        for (i in 0 until childSampleCount) {
+            val child = node.getChild(i) ?: continue
+            try {
+                val childBounds = Rect()
+                child.getBoundsInScreen(childBounds)
+                out.append('|')
+                    .append(child.className?.toString().orEmpty())
+                    .append(':')
+                    .append(child.viewIdResourceName.orEmpty())
+                    .append(':')
+                    .append(child.text?.toString()?.take(32).orEmpty())
+                    .append(':')
+                    .append(child.contentDescription?.toString()?.take(32).orEmpty())
+                    .append(':')
+                    .append(rectSignature(childBounds))
+            } finally {
+                child.recycle()
+            }
+        }
+        return out.toString()
+    }
+
+    private fun rectSignature(rect: Rect): String =
+        "${rect.left},${rect.top},${rect.right},${rect.bottom}"
+
+    /** [node] is caller-owned going in; always recycled (directly or via
+     *  [findClickableAncestor]'s ancestor-walk) by the time this returns. */
+    private fun performClick(service: ShellyAccessibilityService, pkg: String, node: AccessibilityNodeInfo): AppActDebugResult {
+        val stillForeground = service.rootInActiveWindow?.let { r ->
+            val ok = r.packageName?.toString() == pkg
+            r.recycle()
+            ok
+        } ?: false
+        if (!stillForeground) {
+            node.recycle()
+            return AppActDebugResult(false, "Foreground app changed away from $pkg before tapping the matched node")
+        }
+
+        val clickable = findClickableAncestor(node, 4)
+        if (clickable == null) {
+            node.recycle()
+            return AppActDebugResult(false, "Matched node found but has no clickable ancestor within 4 levels")
+        }
+        val ok = try {
+            clickable.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        } finally {
+            if (clickable !== node) node.recycle()
+            clickable.recycle()
+        }
+        return if (ok) AppActDebugResult(true, "Clicked") else AppActDebugResult(false, "performAction(ACTION_CLICK) failed")
+    }
+
+    // ---- setText -----------------------------------------------------------
+
+    private fun executeSetText(
+        service: ShellyAccessibilityService,
+        recipeId: String,
+        stepIndex: Int,
+        pkg: String,
+        step: AppActRecipeStore.RecipeStep,
+        params: Map<String, String>,
+    ): AppActDebugResult {
+        val matcher = step.matcher
+            ?: return AppActDebugResult(false, "setText step at $stepIndex missing matcher")
+        val paramName = step.param
+            ?: return AppActDebugResult(false, "setText step at $stepIndex missing param")
+        val rawValue = params[paramName]
+            ?: return AppActDebugResult(false, "setText step at $stepIndex references unknown param \"$paramName\"")
+        val value = substitute(rawValue, params)
+        val substituted = substituteMatcher(matcher, params)
+        val timeoutMs = step.timeoutMs ?: DEFAULT_STEP_TIMEOUT_MS
+        val candidates = pollForCandidates(service, pkg, substituted, timeoutMs)
+
+        if (candidates.size == 1) {
+            return performSetText(service, pkg, candidates[0], value)
+        }
+
+        if (candidates.isEmpty()) {
+            val fallback = resolveMatcherMiss(recipeId, stepIndex, step, service)
+            if (fallback != null) return performSetText(service, pkg, fallback, value)
+            val diag = service.diagnoseCurrentScreen()
+            return AppActDebugResult(false, "Zero-match: no node under $pkg matched setText step $stepIndex (${step.intent}) after ${timeoutMs}ms.$diag")
+        }
+
+        val diag = service.diagnoseCurrentScreen()
+        candidates.forEach { it.recycle() }
+        return AppActDebugResult(false, "Ambiguous-multiple-match: ${candidates.size} nodes matched setText step $stepIndex (${step.intent}) — refusing to guess, nothing was typed.$diag")
+    }
+
+    /** [node] is caller-owned going in; always recycled by the time this
+     *  returns (no ancestor-walk for setText — matches the original file's
+     *  contract). */
+    private fun performSetText(service: ShellyAccessibilityService, pkg: String, node: AccessibilityNodeInfo, value: String): AppActDebugResult {
+        try {
+            val stillForeground = service.rootInActiveWindow?.let { r ->
+                val ok = r.packageName?.toString() == pkg
+                r.recycle()
+                ok
+            } ?: false
+            if (!stillForeground) {
+                return AppActDebugResult(false, "Foreground app changed away from $pkg before typing into the matched node")
+            }
+            if (!node.isEditable) {
+                return AppActDebugResult(false, "Matched node is not editable, refusing to setText")
+            }
+            val args = Bundle()
+            args.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, value)
+            val ok = node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+            return if (ok) AppActDebugResult(true, "Typed") else AppActDebugResult(false, "performAction(ACTION_SET_TEXT) failed")
+        } finally {
+            node.recycle()
+        }
+    }
+
+    // ---- scroll (untested — no current recipe exercises this; kept simple) --
+
+    private fun executeScroll(
+        service: ShellyAccessibilityService,
+        recipeId: String,
+        stepIndex: Int,
+        pkg: String,
+        step: AppActRecipeStore.RecipeStep,
+        params: Map<String, String>,
+    ): AppActDebugResult {
+        val matcher = step.matcher
+            ?: return AppActDebugResult(false, "scroll step at $stepIndex missing matcher")
+        val substituted = substituteMatcher(matcher, params)
+        val timeoutMs = step.timeoutMs ?: DEFAULT_STEP_TIMEOUT_MS
+        val candidates = pollForCandidates(service, pkg, substituted, timeoutMs)
+
+        if (candidates.size != 1) {
+            val diag = service.diagnoseCurrentScreen()
+            candidates.forEach { it.recycle() }
+            return if (candidates.isEmpty()) {
+                AppActDebugResult(false, "Zero-match: no node under $pkg matched scroll step $stepIndex (${step.intent}) after ${timeoutMs}ms.$diag")
+            } else {
+                AppActDebugResult(false, "Ambiguous-multiple-match: ${candidates.size} nodes matched scroll step $stepIndex (${step.intent}) — refusing to guess, nothing was scrolled.$diag")
+            }
+        }
+
+        val node = candidates[0]
+        val stillForeground = service.rootInActiveWindow?.let { r ->
+            val ok = r.packageName?.toString() == pkg
+            r.recycle()
+            ok
+        } ?: false
+        if (!stillForeground) {
+            node.recycle()
+            return AppActDebugResult(false, "Foreground app changed away from $pkg before scrolling")
+        }
+
+        val scrollable = findAncestor(node, 4) { it.isScrollable }
+        if (scrollable == null) {
+            node.recycle()
+            return AppActDebugResult(false, "Matched node found but has no scrollable ancestor within 4 levels")
+        }
+        val ok = try {
+            scrollable.performAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD)
+        } finally {
+            if (scrollable !== node) node.recycle()
+            scrollable.recycle()
+        }
+        return if (ok) AppActDebugResult(true, "Scrolled") else AppActDebugResult(false, "performAction(ACTION_SCROLL_FORWARD) failed")
+    }
+
+    // ---- shared polling / matching primitives ---------------------------
+
+    /** THE single node/candidate-list resolution primitive for every step.
+     *  Generalizes what used to be three separate hand-written pollers in
+     *  [ShellyAccessibilityService] (`pollForNodeByResourceId`,
+     *  `pollForNodeByContentDescription`, `pollForStableLineSearchResults`).
+     *
+     *  Two phases, deliberately kept separate (2026-07-12 review fix):
+     *  1. [pollStructural] polls using every [matcher] field EXCEPT [text]
+     *     until that STRUCTURAL candidate list is non-zero and
+     *     size-stable, or [timeoutMs] elapses.
+     *  2. If [matcher.text] is non-null, it is applied as a filter AFTER
+     *     structural stability is reached — never as part of what
+     *     determines stability.
+     *
+     *  Phase 1/2 must stay separate: determining "stability" against an
+     *  ALREADY text-filtered set would hide a second, identically-named
+     *  candidate that renders on a delay — e.g. LINE search results for a
+     *  duplicate-named contact/group — silently defeating the zero/multiple
+     *  exact-match safety check `text` filtering exists to enforce. The
+     *  original hand-written `pollForStableLineSearchResults` collected
+     *  every unfiltered `name_text_view` row and waited for THAT raw count
+     *  to stabilize before separately counting exact-text matches; this is
+     *  that same two-phase shape, generalized. For a matcher with no
+     *  [text] field (the common case — resourceId/contentDescription/label
+     *  lookups), phase 2 is a no-op and behavior is unchanged from a
+     *  single-phase poll. */
+    private fun pollForCandidates(service: ShellyAccessibilityService, pkg: String, matcher: AppActRecipeStore.Matcher, timeoutMs: Long): List<AccessibilityNodeInfo> {
+        val structural = pollStructural(service, pkg, matcher, timeoutMs)
+        val text = matcher.text ?: return structural
+        val matched = mutableListOf<AccessibilityNodeInfo>()
+        for (node in structural) {
+            if (nodeMatchesText(node, text)) matched.add(node) else node.recycle()
+        }
+        return matched
+    }
+
+    /** Polls on every [AppActRecipeStore.Matcher] field EXCEPT [text] (see
+     *  [pollForCandidates]) until the result count is non-zero AND
+     *  unchanged across two consecutive [POLL_INTERVAL_MS] samples, or
+     *  [timeoutMs] elapses. Deliberately never treats an all-zero streak as
+     *  "stable" (ported from `pollForStableLineSearchResults`'s 2026-07-12
+     *  fix) — a persistent zero-match always costs the full [timeoutMs],
+     *  matching every other poller's "never fail fast on absence"
+     *  philosophy. Re-checks the foreground package on EVERY iteration (a
+     *  root snapshot whose package doesn't match [pkg] counts as "not
+     *  ready yet", i.e. empty, not an error). Recycles every discarded
+     *  intermediate sample; the caller owns recycling whatever list is
+     *  finally returned. */
+    private fun pollStructural(service: ShellyAccessibilityService, pkg: String, matcher: AppActRecipeStore.Matcher, timeoutMs: Long): List<AccessibilityNodeInfo> {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var previous: List<AccessibilityNodeInfo>? = null
+        while (System.currentTimeMillis() < deadline) {
+            val root = service.rootInActiveWindow
+            val snapshot = if (root != null && root.packageName?.toString() == pkg) {
+                val out = mutableListOf<AccessibilityNodeInfo>()
+                val rootConsumed = collectMatchingNodes(root, matcher, out)
+                if (!rootConsumed) root.recycle()
+                out
+            } else {
+                root?.recycle()
+                emptyList()
+            }
+            val prev = previous
+            if (prev != null && prev.isNotEmpty() && prev.size == snapshot.size) {
+                prev.forEach { it.recycle() }
+                return snapshot
+            }
+            prev?.forEach { it.recycle() }
+            previous = snapshot
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        return previous ?: emptyList()
+    }
+
+    /** Recursively collects every descendant of [node] that
+     *  [nodeMatchesStructural] [matcher] into [out] (the [Matcher.text]
+     *  field, if any, is NOT applied here — see [pollForCandidates]).
+     *  Returns true iff [node] itself was appended (so the caller knows
+     *  not to also recycle it). Every visited node NOT appended to [out]
+     *  is recycled before returning; nodes appended to [out] are owned by
+     *  the caller. Mirrors `collectNodesByResourceId`'s exact contract,
+     *  generalized to [AppActRecipeStore.Matcher]'s structural fields. */
+    private fun collectMatchingNodes(node: AccessibilityNodeInfo, matcher: AppActRecipeStore.Matcher, out: MutableList<AccessibilityNodeInfo>): Boolean {
+        if (nodeMatchesStructural(node, matcher)) {
+            out.add(node)
+            return true
+        }
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            val consumed = collectMatchingNodes(child, matcher, out)
+            if (!consumed) child.recycle()
+        }
+        return false
+    }
+
+    /** Matches every field of [matcher] EXCEPT [Matcher.text] — see
+     *  [pollForCandidates]'s doc comment for why `text` is deliberately
+     *  excluded from the "structural" matcher used to determine polling
+     *  stability. */
+    private fun nodeMatchesStructural(node: AccessibilityNodeInfo, matcher: AppActRecipeStore.Matcher): Boolean {
+        if (matcher.resourceId != null && node.viewIdResourceName != matcher.resourceId) return false
+        if (matcher.contentDescription != null && node.contentDescription?.toString() != matcher.contentDescription) return false
+        if (matcher.label != null && node.contentDescription?.toString() != matcher.label && node.text?.toString() != matcher.label) return false
+        return true
+    }
+
+    private fun nodeMatchesText(node: AccessibilityNodeInfo, text: String): Boolean =
+        node.text?.toString()?.equals(text, ignoreCase = true) == true
+
+    /** Substitutes every `{{name}}` placeholder in [matcher.text] with
+     *  `params[name]` (literal string replace, no regex) — the only field
+     *  of [AppActRecipeStore.Matcher] that ever carries a template. */
+    private fun substituteMatcher(matcher: AppActRecipeStore.Matcher, params: Map<String, String>): AppActRecipeStore.Matcher =
+        if (matcher.text == null) matcher else matcher.copy(text = substitute(matcher.text, params))
+
+    private fun substitute(template: String, params: Map<String, String>): String {
+        var result = template
+        for ((key, value) in params) {
+            result = result.replace("{{$key}}", value)
+        }
+        return result
+    }
+
+    /** Walks up from [node] via [AccessibilityNodeInfo.getParent] (up to
+     *  [maxLevels] ancestors) looking for the first node matching
+     *  [predicate], [node] itself included. Does NOT recycle [node] itself
+     *  (caller-owned); every intermediate parent fetched along the way
+     *  that is NOT the returned node is recycled before returning. Returns
+     *  null (having recycled every parent visited) if no match is found
+     *  within [maxLevels]. Ported from [ShellyAccessibilityService]'s
+     *  former `findClickableAncestor`, generalized with a predicate so
+     *  both [findClickableAncestor] and the scroll step's ancestor-walk
+     *  share one implementation. */
+    private fun findAncestor(node: AccessibilityNodeInfo, maxLevels: Int, predicate: (AccessibilityNodeInfo) -> Boolean): AccessibilityNodeInfo? {
+        if (predicate(node)) return node
+        var current = node
+        var ownsCurrent = false
+        repeat(maxLevels) {
+            val parent = current.parent
+            if (ownsCurrent) current.recycle()
+            if (parent == null) return null
+            if (predicate(parent)) return parent
+            current = parent
+            ownsCurrent = true
+        }
+        if (ownsCurrent) current.recycle()
+        return null
+    }
+
+    private fun findClickableAncestor(node: AccessibilityNodeInfo, maxLevels: Int = 4): AccessibilityNodeInfo? =
+        findAncestor(node, maxLevels) { it.isClickable }
+
+    /** Track 3 (LLM fallback) stub — always returns null (fail closed,
+     *  identical to today's zero-match behavior). This is the ONLY
+     *  function Track 3 will need to fill in later; [executeClick] /
+     *  [executeSetText] / [executeScroll]'s control flow must not need to
+     *  change when that happens. */
+    private fun resolveMatcherMiss(recipeId: String, stepIndex: Int, step: AppActRecipeStore.RecipeStep, service: ShellyAccessibilityService): AccessibilityNodeInfo? = null
+}

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AppActRecipeStore.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AppActRecipeStore.kt
@@ -1,0 +1,198 @@
+package expo.modules.terminalemulator
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * app.act Track 1/2 (docs/superpowers/specs/2026-07-11-app-act-design.md,
+ * 2026-07-11-post-ui-automation-agent-architecture.md, 2026-07-12
+ * implementation-detail plan) — recipe schema, storage, and loader.
+ *
+ * Recipes are bundled as plain JSON under APK assets
+ * (`app-act-recipes/<id>.json`) and loaded on demand via
+ * [Context.getAssets]. No `$HOME/.shelly/app-act-recipes/` mirror or
+ * override layer exists — that's explicitly deferred Track 3 machinery
+ * with no consumer yet.
+ *
+ * The matcher schema deliberately has NO `textRegex` field: only exact
+ * (case-insensitive) [Matcher.text] matching is supported, mirroring the
+ * already-proven `it.text?.toString()?.equals(trimmedTarget,
+ * ignoreCase = true)` pattern from ShellyAccessibilityService's hardcoded
+ * LINE flow. This avoids the unescaped-regex-metacharacter bug a
+ * `textRegex` design would introduce.
+ */
+object AppActRecipeStore {
+    private const val TAG = "AppActRecipeStore"
+
+    /** One step of a [Recipe]. [matcher] is null only for `op == "launch"`
+     *  (which targets a package, not a node). [param] names which entry of
+     *  the caller-supplied params map to type, for `op == "setText"`.
+     *  [target] is the package name to launch, for `op == "launch"`.
+     *  [intent] is a required free-text human-readable description of what
+     *  the step does — every step must carry one, purely for
+     *  diagnostics/logging, never parsed. [timeoutMs] overrides the
+     *  per-op default poll timeout when present.
+     *
+     *  [recoverOnZeroMatch] (`click` steps only; null/empty = disabled,
+     *  the default) — added 2026-07-12 after finding on-device that
+     *  `launch`/`ensureForeground` resumes whatever screen the target app
+     *  was LAST showing (standard Android task-stack behavior), which for
+     *  a messaging app is often an individual conversation screen or a
+     *  scrolled list with its header/search affordance hidden. A recipe's
+     *  first real navigational `click` step (e.g. "open the search
+     *  screen") can therefore start from an arbitrary nav depth or scroll
+     *  position. This ordered list lets that one step opt into bounded
+     *  recovery actions such as `back` and `scrollToTop`, re-polling after
+     *  each action before falling through to the existing zero-match
+     *  fail-close. Deliberately a per-step opt-in, not a blanket engine
+     *  behavior: only the FIRST navigational step after `launch` should
+     *  ever set this — a zero-match on a LATER step (e.g. "no search
+     *  result matched this contact name") is a genuine failure, and
+     *  blindly navigating there could leave the target app somewhere the
+     *  human didn't expect. */
+    data class RecipeStep(
+        val op: String,
+        val matcher: Matcher? = null,
+        val param: String? = null,
+        val target: String? = null,
+        val intent: String,
+        val timeoutMs: Long? = null,
+        val recoverOnZeroMatch: List<String>? = null,
+    )
+
+    /** A node matches iff ALL non-null fields here match (AND semantics).
+     *  [resourceId] is compared against [android.view.accessibility.AccessibilityNodeInfo.getViewIdResourceName]
+     *  exactly; [contentDescription] against
+     *  [android.view.accessibility.AccessibilityNodeInfo.getContentDescription]
+     *  exactly; [text] against
+     *  [android.view.accessibility.AccessibilityNodeInfo.getText]
+     *  case-insensitively. `{{param}}` placeholders inside [text] are
+     *  substituted with the caller-supplied params map (literal string
+     *  replace) before matching.
+     *
+     *  [label] is a separate OR-across-two-fields matcher (exact,
+     *  case-sensitive): matches if EITHER `contentDescription` OR `text`
+     *  equals [label]. Exists because some icon-only buttons expose their
+     *  label via contentDescription while equivalent buttons on other
+     *  screens of the SAME app expose the identical label as visible text
+     *  instead — found on-device 2026-07-12 for LINE's search entry point,
+     *  which is a pill-shaped bar with "検索" as placeholder TEXT on the
+     *  ホーム/トーク/ニュース tabs, but a bare icon whose label (if any)
+     *  lives in contentDescription on VOOM/ミニアプリ. A plain
+     *  `contentDescription`-only matcher missed the text-based tabs
+     *  entirely. [label] ANDs with any other non-null matcher field, same
+     *  as every other field here. */
+    data class Matcher(
+        val resourceId: String? = null,
+        val contentDescription: String? = null,
+        val text: String? = null,
+        val label: String? = null,
+    )
+
+    data class ParamSpec(
+        val name: String,
+        val description: String,
+        val required: Boolean,
+    )
+
+    data class Recipe(
+        val id: String,
+        val pkg: String,
+        val operation: String,
+        val displayName: String,
+        val tier: String,
+        val params: List<ParamSpec>,
+        val steps: List<RecipeStep>,
+    )
+
+    /** Loads and parses `app-act-recipes/$recipeId.json` from APK assets.
+     *  Returns null (logging the reason) on any I/O or parse failure —
+     *  never throws past this boundary, matching this module's general
+     *  fail-closed-with-a-reason convention. */
+    fun load(context: Context, recipeId: String): Recipe? =
+        try {
+            val json = context.assets.open("app-act-recipes/$recipeId.json").use { stream ->
+                JSONObject(stream.readBytes().decodeToString())
+            }
+            parseRecipe(json)
+        } catch (e: Exception) {
+            Log.e(TAG, "load($recipeId) failed: ${e.message}", e)
+            null
+        }
+
+    private fun parseRecipe(o: JSONObject): Recipe {
+        val paramsArray = o.optJSONArray("params") ?: JSONArray()
+        val params = mutableListOf<ParamSpec>()
+        for (i in 0 until paramsArray.length()) {
+            val p = paramsArray.getJSONObject(i)
+            params.add(
+                ParamSpec(
+                    name = p.getString("name"),
+                    description = p.optString("description", ""),
+                    required = p.optBoolean("required", false),
+                ),
+            )
+        }
+
+        val stepsArray = o.getJSONArray("steps")
+        val steps = mutableListOf<RecipeStep>()
+        for (i in 0 until stepsArray.length()) {
+            val s = stepsArray.getJSONObject(i)
+            val matcherObj = s.optJSONObject("matcher")
+            val matcher = if (matcherObj == null) {
+                null
+            } else {
+                Matcher(
+                    resourceId = if (matcherObj.has("resourceId") && !matcherObj.isNull("resourceId")) matcherObj.getString("resourceId") else null,
+                    contentDescription = if (matcherObj.has("contentDescription") && !matcherObj.isNull("contentDescription")) matcherObj.getString("contentDescription") else null,
+                    text = if (matcherObj.has("text") && !matcherObj.isNull("text")) matcherObj.getString("text") else null,
+                    label = if (matcherObj.has("label") && !matcherObj.isNull("label")) matcherObj.getString("label") else null,
+                )
+            }
+            steps.add(
+                RecipeStep(
+                    op = s.getString("op"),
+                    matcher = matcher,
+                    param = if (s.has("param") && !s.isNull("param")) s.getString("param") else null,
+                    target = if (s.has("target") && !s.isNull("target")) s.getString("target") else null,
+                    intent = s.getString("intent"),
+                    timeoutMs = if (s.has("timeoutMs") && !s.isNull("timeoutMs")) s.getLong("timeoutMs") else null,
+                    recoverOnZeroMatch = parseRecoverOnZeroMatch(s),
+                ),
+            )
+        }
+
+        return Recipe(
+            id = o.getString("id"),
+            pkg = o.getString("pkg"),
+            operation = o.getString("operation"),
+            displayName = o.optString("displayName", o.getString("id")),
+            tier = o.optString("tier", "C"),
+            params = params,
+            steps = steps,
+        )
+    }
+
+    private fun parseRecoverOnZeroMatch(step: JSONObject): List<String>? {
+        val recoverArray = step.optJSONArray("recoverOnZeroMatch")
+        if (recoverArray != null) {
+            val actions = mutableListOf<String>()
+            for (i in 0 until recoverArray.length()) {
+                val action = recoverArray.getString(i).trim()
+                if (action.isNotEmpty()) actions.add(action)
+            }
+            return actions.ifEmpty { null }
+        }
+
+        // Backward-compatible loader for recipes built before the
+        // generalized recovery list existed.
+        val legacyBackRetries = if (step.has("retryBackOnZeroMatch") && !step.isNull("retryBackOnZeroMatch")) {
+            step.getInt("retryBackOnZeroMatch").coerceAtLeast(0)
+        } else {
+            0
+        }
+        return if (legacyBackRetries > 0) List(legacyBackRetries) { "back" } else null
+    }
+}

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/LockPromptActivity.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/LockPromptActivity.kt
@@ -1,0 +1,306 @@
+package expo.modules.terminalemulator
+
+import android.app.Activity
+import android.app.KeyguardManager
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.Gravity
+import android.view.WindowManager
+import android.widget.FrameLayout
+import android.widget.TextView
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Lock-screen "wake, prompt, continue after genuine unlock" bridge for
+ * `app.act` (docs/superpowers/specs/2026-07-11-app-act-design.md §0.1).
+ *
+ * §0.1 documents a hard OS wall: once the device locks,
+ * `AccessibilityService.rootInActiveWindow` only ever returns the keyguard
+ * window, never the target app's node tree — `app.act` cannot act at all
+ * while locked, and Shelly cannot dismiss a secured (PIN/pattern/biometric)
+ * lock screen from user code at any privilege level; that boundary is
+ * hardware-security-backed, not a permission gap SHELL-001's shell-uid
+ * access (or any other privilege Shelly holds) can close.
+ *
+ * This class is explicitly NOT a bypass of that boundary. It is the
+ * well-established "incoming call screen / alarm app" pattern:
+ * `setShowWhenLocked` + `setTurnScreenOn` bring this Activity's UI up over
+ * the lock screen, and `KeyguardManager.requestDismissKeyguard` then hands
+ * control to the OS's own unlock challenge — the exact same PIN/pattern/
+ * biometric prompt the user would see anywhere else. Shelly never sees or
+ * handles the credential; it only ever learns whether the OS reports the
+ * dismiss attempt as succeeded, cancelled, or errored.
+ *
+ * [ensureUnlocked] is the only public surface: a synchronous/blocking call
+ * (deliberately `CountDownLatch`-based rather than a `suspend` function —
+ * there is no existing coroutine-bridging precedent anywhere in this native
+ * module) that callers such as `ShellyAccessibilityService.ensureForeground`
+ * and a `TerminalEmulatorModule` `AsyncFunction` body can call directly from
+ * a background thread, mirroring how `ShellyAccessibilityService.
+ * debugSendLineMessage` already blocks its calling thread synchronously
+ * today.
+ */
+class LockPromptActivity : Activity() {
+
+    /** This instance's own copy of the in-flight ensureUnlocked() call's
+     *  latch/result, captured once in [onCreate] (see the comment there for
+     *  why capturing rather than reading the companion fields live on every
+     *  callback matters). */
+    private var myLatch: CountDownLatch? = null
+    private var myResult: AtomicBoolean? = null
+
+    /** Guards against recording an outcome more than once. All three
+     *  KeyguardDismissCallback methods plus the defensive [onDestroy] path
+     *  funnel through [completeOnce] — only the first arrival is allowed to
+     *  write [myResult] and count down [myLatch]; later arrivals are
+     *  logged and dropped. */
+    private val completedOnce = AtomicBoolean(false)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Snapshot the in-flight call's latch/result at the moment this
+        // instance is created. The companion's `busy` guard guarantees at
+        // most one ensureUnlocked() call is in flight at a time, so these
+        // are guaranteed to be THIS call's pair, not some other call's —
+        // and because we capture them into instance fields here rather
+        // than reading the companion's (mutable) fields later from the
+        // KeyguardDismissCallback, this instance can never clobber a LATER
+        // ensureUnlocked() invocation's latch/result even if this call
+        // already timed out on the caller side (busy released, a fresh
+        // call started, reassigning the companion fields) before the user
+        // finally responds to this still-visible prompt.
+        val pending = pendingCall
+        myLatch = pending?.latch
+        myResult = pending?.result
+        if (myLatch == null || myResult == null) {
+            Log.w(TAG, "onCreate: no in-flight ensureUnlocked() call registered, finishing")
+            finish()
+            return
+        }
+        // Tracked so ensureUnlocked()'s timeout path can finish() this
+        // instance if the user never responds in time (see that method) —
+        // found missing by independent review 2026-07-11: without this, a
+        // timed-out prompt would linger over the lock screen indefinitely.
+        currentInstance = this
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        } else {
+            // API 26 (O) has requestDismissKeyguard but not the Activity-level
+            // setShowWhenLocked/setTurnScreenOn convenience methods (added in
+            // O_MR1 / API 27) — fall back to the equivalent window flags.
+            // ensureUnlocked() already refuses to run below API 26 entirely.
+            @Suppress("DEPRECATION")
+            window.addFlags(
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+            )
+        }
+
+        setContentView(buildContentView())
+
+        val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+        if (keyguardManager == null) {
+            Log.w(TAG, "onCreate: KeyguardManager unavailable")
+            completeOnce(false, "KeyguardManager unavailable")
+            finish()
+            return
+        }
+
+        keyguardManager.requestDismissKeyguard(
+            this,
+            object : KeyguardManager.KeyguardDismissCallback() {
+                override fun onDismissSucceeded() {
+                    Log.i(TAG, "requestDismissKeyguard: onDismissSucceeded")
+                    completeOnce(true, "onDismissSucceeded")
+                    finish()
+                }
+
+                override fun onDismissError() {
+                    Log.w(TAG, "requestDismissKeyguard: onDismissError")
+                    completeOnce(false, "onDismissError")
+                    finish()
+                }
+
+                override fun onDismissCancelled() {
+                    Log.i(TAG, "requestDismissKeyguard: onDismissCancelled (user backed out)")
+                    completeOnce(false, "onDismissCancelled")
+                    finish()
+                }
+            }
+        )
+    }
+
+    /** Defensive fallback: if the OS destroys this Activity before any
+     *  KeyguardDismissCallback method ever fires (task killed, user force-
+     *  swiped it from Recents, low-memory reclaim), the latch must still
+     *  count down — otherwise ensureUnlocked() would block its calling
+     *  thread until timeoutMs regardless of what actually happened on
+     *  screen. [completeOnce]'s guard makes this a no-op whenever a real
+     *  callback already recorded an outcome (mirrors the identity-guarded
+     *  defensive clear in ShellyAccessibilityService.onDestroy). */
+    override fun onDestroy() {
+        completeOnce(false, "onDestroy fired with no prior keyguard callback")
+        super.onDestroy()
+    }
+
+    private fun completeOnce(success: Boolean, reason: String) {
+        if (!completedOnce.compareAndSet(false, true)) {
+            Log.i(TAG, "completeOnce(success=$success, reason=$reason) ignored — outcome already recorded")
+            return
+        }
+        if (currentInstance === this) {
+            currentInstance = null
+        }
+        myResult?.set(success)
+        Log.i(TAG, "LockPromptActivity outcome: success=$success reason=$reason")
+        myLatch?.countDown()
+    }
+
+    private fun buildContentView(): FrameLayout {
+        val density = resources.displayMetrics.density
+        fun dp(value: Int): Int = (value * density).toInt()
+        val message = TextView(this).apply {
+            text = "Shelly wants to continue an action — unlock to proceed"
+            setTextColor(COLOR_TEXT)
+            textSize = 16f
+            gravity = Gravity.CENTER
+        }
+        return FrameLayout(this).apply {
+            setBackgroundColor(COLOR_BACKGROUND)
+            addView(
+                message,
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.WRAP_CONTENT,
+                    FrameLayout.LayoutParams.WRAP_CONTENT,
+                    Gravity.CENTER
+                ).apply {
+                    leftMargin = dp(32)
+                    rightMargin = dp(32)
+                }
+            )
+        }
+    }
+
+    companion object {
+        private const val TAG = "ShellyLockPrompt"
+        private val COLOR_BACKGROUND = Color.rgb(0, 12, 4)
+        private val COLOR_TEXT = Color.rgb(230, 255, 236)
+
+        /** Re-entrancy guard: only one ensureUnlocked() call (and therefore
+         *  one live LockPromptActivity) may be in flight at a time. A
+         *  second concurrent call fails fast (returns false) instead of
+         *  reassigning [pendingCall] out from under the first call's
+         *  already-launched Activity — mirrors ShellyAccessibilityService's
+         *  own `busy` AtomicBoolean guard on debugSendLineMessage/
+         *  debugPostToX. */
+        private val busy = AtomicBoolean(false)
+
+        /** Bundles the latch and its result holder so they are always
+         *  assigned/read as a single atomic unit — found as a theoretical
+         *  tear risk by independent review 2026-07-11 (two independently
+         *  @Volatile fields could in principle be observed as a mismatched
+         *  pair by onCreate() if it ran concurrently with a reassignment;
+         *  a single @Volatile reference makes that impossible). */
+        private data class PendingCall(val latch: CountDownLatch, val result: AtomicBoolean)
+
+        /** Set by [ensureUnlocked] immediately before launching the
+         *  Activity; read once by the new Activity's [onCreate] to capture
+         *  its own local copy — see that method's comment for why the
+         *  capture (rather than reading this field live from callbacks)
+         *  matters. */
+        @Volatile private var pendingCall: PendingCall? = null
+
+        /** The currently-live instance for the in-flight call, if any —
+         *  set in [onCreate], cleared by [completeOnce] once an outcome is
+         *  recorded (identity-guarded, mirrors ShellyAccessibilityService.
+         *  onDestroy's pattern). Lets [ensureUnlocked]'s timeout path
+         *  actively dismiss a prompt the user never responded to, instead
+         *  of leaving it sitting over the lock screen indefinitely (found
+         *  by independent review 2026-07-11). */
+        @Volatile private var currentInstance: LockPromptActivity? = null
+
+        /**
+         * Blocks the calling thread until the device is confirmed unlocked,
+         * [timeoutMs] elapses, or the user declines/cancels the unlock
+         * prompt. Safe to call from any background thread — deliberately
+         * NOT a suspend function (see the class doc comment for why).
+         * Returns true iff the device is unlocked by the time this
+         * returns: either it already was (cheap fast path, no Activity
+         * launched), or the user completed the OS's own unlock challenge in
+         * response to the prompt this method raises.
+         *
+         * Pre-API-26 devices: requestDismissKeyguard/setShowWhenLocked need
+         * API 26/27, so a locked pre-O device returns false immediately.
+         * This is an acceptable simplification — app.act's own
+         * minSdkVersion floor is 24, but this specific bridge only helps on
+         * 26+; on an older locked device app.act simply stays blocked
+         * while locked, exactly as it was before this feature existed.
+         */
+        fun ensureUnlocked(context: Context, timeoutMs: Long = 60_000L): Boolean {
+            val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+            if (keyguardManager == null || !keyguardManager.isKeyguardLocked) {
+                return true
+            }
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                Log.w(TAG, "ensureUnlocked: device is locked but SDK ${Build.VERSION.SDK_INT} < 26 (O), unsupported")
+                return false
+            }
+            if (!busy.compareAndSet(false, true)) {
+                Log.w(TAG, "ensureUnlocked: another unlock prompt is already in flight, failing fast")
+                return false
+            }
+            return try {
+                val newLatch = CountDownLatch(1)
+                val newResult = AtomicBoolean(false)
+                pendingCall = PendingCall(newLatch, newResult)
+
+                val intent = Intent(context, LockPromptActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+
+                val completed = try {
+                    newLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    false
+                }
+                val result = completed && newResult.get()
+                Log.i(TAG, "ensureUnlocked: completed=$completed result=$result")
+                if (!completed) {
+                    // The Activity never called completeOnce in time (no
+                    // KeyguardDismissCallback fired, and the OS never
+                    // destroyed it either) — actively dismiss it rather than
+                    // leaving a stale "unlock to proceed" prompt sitting
+                    // over the lock screen forever after this caller has
+                    // already given up (found by independent review
+                    // 2026-07-11). finish() is safe to call even if the
+                    // instance is already finishing/gone (currentInstance
+                    // may be null if a callback raced in right at the
+                    // timeout boundary).
+                    Log.w(TAG, "ensureUnlocked: timed out, finishing lingering prompt if still alive")
+                    currentInstance?.finish()
+                }
+                result
+            } finally {
+                // Release for the NEXT call. Note this does not affect an
+                // Activity instance that is still alive past a timeout —
+                // it already captured its own latch/result copies in
+                // onCreate and keeps writing to those, never to whatever
+                // this companion field gets reassigned to next.
+                pendingCall = null
+                busy.set(false)
+            }
+        }
+    }
+}

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/ShellyAccessibilityService.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/ShellyAccessibilityService.kt
@@ -1,0 +1,336 @@
+package expo.modules.terminalemulator
+
+import android.accessibilityservice.AccessibilityService
+import android.os.Bundle
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+
+/**
+ * UI-AUTOMATION-001 / app.act.
+ *
+ * Originally a throwaway observe-only diagnostic (dump the node tree, prove
+ * LINE's key elements carry stable resourceId/contentDescription values —
+ * see DEFERRED.md's continuation-25 entry, confirmed: `chat_ui_message_edit`
+ * for the input field, `chat_ui_send_button_image` for send), then grew a
+ * narrow hardcoded action capability (Milestone 0), then Track 1's
+ * hand-written search/navigate flow for LINE. As of the 2026-07-12
+ * implementation-detail plan (docs/superpowers/specs/2026-07-11-app-act
+ * -design.md, 2026-07-11-post-ui-automation-agent-architecture.md), the
+ * general recipe/step-walker engine (see [AppActExecutor] and
+ * [AppActRecipeStore]) now does the node-finding/polling/clicking work;
+ * this file keeps only what has no recipe equivalent:
+ * [debugSendLineMessage] (sends into whatever LINE conversation is already
+ * open — no search/navigate step, so it can't be expressed as one of the
+ * bundled recipes) plus the AccessibilityService lifecycle/diagnostics
+ * machinery every entry point (recipe-driven or not) depends on
+ * ([rootInActiveWindow] access, [diagnoseCurrentScreen],
+ * [summarizeClickableCandidates], [dumpNode], [activeInstance]).
+ * [debugSendLineMessageToContact] and [debugPostToX] are now thin wrappers
+ * around [AppActExecutor.execute] running the bundled `line.send-message`
+ * / `x.post` recipes.
+ *
+ * All three debug entry points remain deliberately NOT wired into the
+ * agent/PlanSpec pipeline — only reachable from temporary debug buttons
+ * (SettingsDropdown.tsx's AppActDebugSection) that a human taps directly.
+ *
+ * Scoped to an explicit package allowlist (see LINE_PACKAGE/X_PACKAGE
+ * below) — this is not a general screen-reader and should never receive
+ * events from arbitrary apps. Requires a MANUAL one-time grant in Android
+ * Settings -> Accessibility (or SHELL-001's `settings put secure
+ * enabled_accessibility_services`, verified working on-device 2026-07-11).
+ */
+class ShellyAccessibilityService : AccessibilityService() {
+
+    companion object {
+        private const val TAG = "ShellyA11yDump"
+
+        // LINE's real Android package name (well-established public fact,
+        // stable across LINE's own app history).
+        private const val LINE_PACKAGE = "jp.naver.line.android"
+
+        // X's (formerly Twitter's) Android package name — the app kept its
+        // original com.twitter.android package through the rebrand.
+        private const val X_PACKAGE = "com.twitter.android"
+
+        /** Live reference to the connected service instance, set/cleared in
+         *  [onServiceConnected]/[onDestroy] — same pattern as
+         *  ShellyNotificationListener.activeInstance. Null whenever the
+         *  service isn't currently bound (OS toggle off, or not yet
+         *  connected). Callers (TerminalEmulatorModule) must null-check. */
+        @Volatile
+        var activeInstance: ShellyAccessibilityService? = null
+
+        // findNodeByContentDescription / collectNodesByResourceId /
+        // findClickableAncestor / pollForNodeByResourceId /
+        // pollForNodeByContentDescription / pollForStableLineSearchResults /
+        // ensureForeground and the companion `busy` guard were ported into
+        // AppActExecutor.kt (Track 2's generic pollForCandidates +
+        // findClickableAncestor + ensureForeground + runGuarded) and removed
+        // from here — see docs/superpowers/specs/2026-07-11-app-act-design.md
+        // and the 2026-07-12 implementation-detail plan.
+
+        /** Recursively finds the first descendant (or the node itself)
+         *  whose viewIdResourceName exactly matches [resourceId]. Every
+         *  visited node that is NOT the match is recycled before returning;
+         *  the caller owns recycling the returned node. Kept (unlike its
+         *  former siblings above) because [sendLineMessageOnCurrentScreen]
+         *  — the one send-flow with no recipe equivalent — still needs a
+         *  single first-match node lookup and the plan requires that
+         *  function to stay "essentially unchanged" rather than routing
+         *  through AppActExecutor's generic (and slower, poll-based)
+         *  candidate collector for this simple case. */
+        private fun findNodeByResourceId(node: AccessibilityNodeInfo, resourceId: String): AccessibilityNodeInfo? {
+            if (node.viewIdResourceName == resourceId) return node
+            for (i in 0 until node.childCount) {
+                val child = node.getChild(i) ?: continue
+                val found = findNodeByResourceId(child, resourceId)
+                if (found != null) {
+                    if (found !== child) child.recycle()
+                    return found
+                }
+                child.recycle()
+            }
+            return null
+        }
+
+        /** Diagnostic-only, added 2026-07-12: walks [node] (a freshly-fetched
+         *  root) up to [maxDepth] levels and collects a terse one-line-per-node
+         *  summary of every CLICKABLE descendant that has non-blank text or
+         *  contentDescription, capped at [maxCount] entries. This exists to
+         *  enrich a fail-closed message with what's actually on screen right
+         *  now, in place of a real on-device uiautomator dump — remote
+         *  debugging sessions on this project have no adb/logcat access path,
+         *  so [dumpNode]'s always-on logcat trail (tag "ShellyA11yDump") isn't
+         *  reachable; this surfaces the same kind of data through the existing
+         *  AppActDebugResult.message -> Alert/Toast plumbing instead. Recycles
+         *  every node it visits except [node] itself (caller-owned, matching
+         *  this file's usual convention). Remove once the "検索" contentDescription
+         *  assumption this was added to investigate is confirmed/replaced. */
+        private fun summarizeClickableCandidates(node: AccessibilityNodeInfo, maxDepth: Int, maxCount: Int, out: MutableList<String> = mutableListOf()): List<String> {
+            if (out.size < maxCount) {
+                if (node.isClickable) {
+                    val resId = node.viewIdResourceName?.substringAfterLast('/')?.take(24) ?: ""
+                    val desc = node.contentDescription?.toString()?.take(18) ?: ""
+                    val text = node.text?.toString()?.take(18) ?: ""
+                    if (resId.isNotEmpty() || desc.isNotEmpty() || text.isNotEmpty()) {
+                        out.add("id=$resId desc=\"$desc\" text=\"$text\"")
+                    }
+                }
+                if (maxDepth > 0) {
+                    for (i in 0 until node.childCount) {
+                        if (out.size >= maxCount) break
+                        val child = node.getChild(i) ?: continue
+                        summarizeClickableCandidates(child, maxDepth - 1, maxCount, out)
+                        child.recycle()
+                    }
+                }
+            }
+            return out
+        }
+
+    }
+
+    /** Diagnostic-only, added 2026-07-12 (see [summarizeClickableCandidates]'s
+     *  doc comment for why this exists in place of a real uiautomator dump).
+     *  Fetches a fresh [rootInActiveWindow] snapshot and appends a compact
+     *  summary of its foreground package plus up to 10 clickable
+     *  candidates to a failure message. Safe to call with no active window
+     *  (returns a short "no active window" note instead). `internal` (not
+     *  private) so [AppActExecutor] can call it too, to enrich its own
+     *  zero/ambiguous-match failure messages the same way this file's
+     *  hand-written flows always have. */
+    internal fun diagnoseCurrentScreen(): String {
+        val root = rootInActiveWindow ?: return " (no active window right now)"
+        return try {
+            val pkg = root.packageName?.toString() ?: "?"
+            val candidates = summarizeClickableCandidates(root, 6, 10)
+            " Current foreground pkg=$pkg. Clickable candidates: " +
+                if (candidates.isEmpty()) "(none with text/desc)" else candidates.joinToString(" | ")
+        } finally {
+            root.recycle()
+        }
+    }
+
+    // pollForStableLineSearchResults was ported into AppActExecutor.kt as
+    // the generic pollForCandidates (see that file's doc comment for the
+    // exact "never treat an all-zero streak as stable" fix this preserves).
+
+    /** app.act Milestone 0's entire action surface: type [text] into LINE's
+     *  message field and tap send, against whatever conversation is
+     *  currently foregrounded. Has no recipe equivalent (both bundled
+     *  recipes always search/navigate first) — kept as a standalone
+     *  hand-written entry point, routed through
+     *  [AppActExecutor.runGuarded]/[AppActExecutor.ensureForeground] so it
+     *  shares the same single re-entrancy guard and foreground-bringing
+     *  logic every recipe-driven run uses, rather than duplicating either.
+     *  Fails closed with a specific reason at every step — including on an
+     *  unexpected exception (node traversal / performAction() on a stale/
+     *  disconnected node is not assumed exception-free, matching
+     *  ShellyNotificationListener's convention of never letting
+     *  AccessibilityService/NotificationListenerService calls throw past
+     *  this boundary) — rather than crashing or propagating an
+     *  uninformative rejection. */
+    fun debugSendLineMessage(text: String): AppActDebugResult = AppActExecutor.runGuarded {
+        if (!AppActExecutor.ensureForeground(this, LINE_PACKAGE)) {
+            AppActDebugResult(false, "Could not bring LINE to the foreground (not installed, or didn't respond in time)")
+        } else {
+            sendLineMessageOnCurrentScreen(text)
+        }
+    }
+
+    /** The post-navigation portion of Milestone 0's send flow — kept
+     *  essentially unchanged (per the app.act implementation-detail plan)
+     *  as the one piece of send logic with no recipe equivalent, since
+     *  [debugSendLineMessage] deliberately sends into whatever LINE
+     *  conversation is already open rather than searching/navigating
+     *  first. */
+    private fun sendLineMessageOnCurrentScreen(text: String): AppActDebugResult {
+        val root = rootInActiveWindow
+            ?: return AppActDebugResult(false, "No active window when attempting to send")
+        try {
+            if (root.packageName?.toString() != LINE_PACKAGE) {
+                return AppActDebugResult(false, "Foreground app is not LINE when attempting to send (found ${root.packageName})")
+            }
+            val inputNode = findNodeByResourceId(root, "$LINE_PACKAGE:id/chat_ui_message_edit")
+                ?: return AppActDebugResult(false, "Message input field not found — is a LINE conversation open?")
+            try {
+                val setTextArgs = Bundle()
+                setTextArgs.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
+                val setOk = inputNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, setTextArgs)
+                if (!setOk) return AppActDebugResult(false, "performAction(ACTION_SET_TEXT) failed")
+            } finally {
+                // inputNode may be identical to `root` itself (findNodeByResourceId
+                // returns the root unchanged if IT is the match) — the outer
+                // `finally` below recycles `root` unconditionally, so recycling
+                // here too would double-recycle the same object on API <33
+                // (minSdkVersion 24; recycle() only became a no-op around API 33).
+                if (inputNode !== root) inputNode.recycle()
+            }
+
+            // Re-fetch: the send button's contentDescription flips once text
+            // is present (continuation-25's finding), so the tree may have
+            // changed since `root` was captured.
+            val root2 = rootInActiveWindow
+                ?: return AppActDebugResult(false, "Window disappeared after setText")
+            try {
+                // LINE may have navigated internally between setText and here
+                // (share sheet, incoming-call overlay, a deep link reopening a
+                // different chat) — re-assert we're still looking at LINE
+                // before blindly tapping whatever now matches the send
+                // button's resourceId.
+                if (root2.packageName?.toString() != LINE_PACKAGE) {
+                    return AppActDebugResult(false, "Foreground app changed away from LINE mid-action (found ${root2.packageName})")
+                }
+                val sendNode = findNodeByResourceId(root2, "$LINE_PACKAGE:id/chat_ui_send_button_image")
+                    ?: return AppActDebugResult(false, "Send button not found after setText")
+                try {
+                    val clickOk = sendNode.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+                    return if (clickOk) {
+                        AppActDebugResult(true, "Sent")
+                    } else {
+                        AppActDebugResult(false, "performAction(ACTION_CLICK) failed")
+                    }
+                } finally {
+                    if (sendNode !== root2) sendNode.recycle()
+                }
+            } finally {
+                root2.recycle()
+            }
+        } finally {
+            root.recycle()
+        }
+    }
+
+    /** app.act Track 1 (navigation): types [message] into LINE's message
+     *  field and taps send, after first navigating to [targetName]'s
+     *  conversation via LINE's search screen. Now a thin wrapper around
+     *  [AppActExecutor.execute] running the bundled `line.send-message`
+     *  recipe — the hand-written search/match/click flow this used to
+     *  contain moved to that recipe + AppActExecutor.kt's generic walker.
+     *  Trims [targetName] and rejects an empty result up front (preserved
+     *  from the original hand-written flow) — this is call-specific input
+     *  validation, not something the generic recipe engine should own. */
+    fun debugSendLineMessageToContact(targetName: String, message: String): AppActDebugResult {
+        val trimmedTarget = targetName.trim()
+        if (trimmedTarget.isEmpty()) {
+            return AppActDebugResult(false, "Target contact/conversation name is empty")
+        }
+        return AppActExecutor.execute(this, applicationContext, "line.send-message", mapOf("contact" to trimmedTarget, "message" to message))
+    }
+
+    /** app.act Milestone 0's X (Twitter) action surface: type [text] into
+     *  the compose screen's body field and tap post. Now a thin wrapper
+     *  around [AppActExecutor.execute] running the bundled `x.post`
+     *  recipe. */
+    fun debugPostToX(text: String): AppActDebugResult =
+        AppActExecutor.execute(this, applicationContext, "x.post", mapOf("text" to text))
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        activeInstance = this
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Identity guard: if the OS ever creates a new instance (setting
+        // activeInstance = B) before this (old) instance's onDestroy fires
+        // — overlapping lifecycles during a service restart/rebind — this
+        // must not null out the live B reference.
+        if (activeInstance === this) {
+            activeInstance = null
+        }
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent) {
+        val pkg = event.packageName?.toString() ?: return
+        if (pkg != LINE_PACKAGE && pkg != X_PACKAGE) return
+
+        val eventTypeName = AccessibilityEvent.eventTypeToString(event.eventType)
+        Log.i(TAG, "==== event=$eventTypeName pkg=$pkg ====")
+
+        val root = rootInActiveWindow ?: run {
+            Log.i(TAG, "rootInActiveWindow is null, nothing to dump")
+            return
+        }
+        dumpNode(root, 0)
+        root.recycle()
+    }
+
+    /**
+     * Recursively logs each node's class name, resourceId, contentDescription,
+     * text, and clickable/editable flags. Deliberately verbose (one log line
+     * per node) — this is a short-lived manual diagnostic session, not
+     * something that runs continuously in production.
+     */
+    private fun dumpNode(node: AccessibilityNodeInfo, depth: Int) {
+        val indent = "  ".repeat(depth)
+        val resId = node.viewIdResourceName ?: "-"
+        val desc = node.contentDescription?.toString()?.take(60) ?: "-"
+        val text = node.text?.toString()?.take(60) ?: "-"
+        val cls = node.className?.toString() ?: "-"
+        val bounds = android.graphics.Rect()
+        node.getBoundsInScreen(bounds)
+        Log.i(
+            TAG,
+            "$indent[$cls] id=$resId desc=\"$desc\" text=\"$text\" " +
+                "clickable=${node.isClickable} editable=${node.isEditable} bounds=$bounds",
+        )
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            dumpNode(child, depth + 1)
+            child.recycle()
+        }
+    }
+
+    override fun onInterrupt() {
+        Log.i(TAG, "onInterrupt")
+    }
+}
+
+/** Result of [ShellyAccessibilityService.debugSendLineMessage] /
+ *  [ShellyAccessibilityService.debugSendLineMessageToContact] /
+ *  [ShellyAccessibilityService.debugPostToX] — [message] is always a
+ *  specific, human-readable reason (success or the exact precondition that
+ *  failed), never a generic "failed". */
+data class AppActDebugResult(val success: Boolean, val message: String)

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
@@ -938,6 +938,58 @@ class TerminalEmulatorModule : Module() {
             null
         }
 
+        // app.act Milestone 0 (docs/superpowers/specs/2026-07-11-app-act-design.md
+        // §6): the ENTIRE action surface is "type text into LINE's message
+        // field and tap send, against whatever conversation is already
+        // foregrounded". Deliberately not wired into the agent/PlanSpec
+        // pipeline — only reachable from SettingsDropdown.tsx's debug
+        // button, a human tapping directly. Returns a specific failure
+        // reason rather than throwing (activeInstance being null just means
+        // the Accessibility Service OS toggle is off).
+        AsyncFunction("debugAppActSendLineMessage") { text: String ->
+            val service = ShellyAccessibilityService.activeInstance
+                ?: return@AsyncFunction mapOf("success" to false, "message" to "Accessibility Service is not enabled/connected")
+            val result = service.debugSendLineMessage(text)
+            Log.i("TerminalEmulator", "debugAppActSendLineMessage: success=${result.success} message=${result.message}")
+            mapOf("success" to result.success, "message" to result.message)
+        }
+
+        // app.act Milestone 0, X (Twitter) variant — same shape as
+        // debugAppActSendLineMessage above, see ShellyAccessibilityService.debugPostToX.
+        AsyncFunction("debugAppActPostToX") { text: String ->
+            val service = ShellyAccessibilityService.activeInstance
+                ?: return@AsyncFunction mapOf("success" to false, "message" to "Accessibility Service is not enabled/connected")
+            val result = service.debugPostToX(text)
+            Log.i("TerminalEmulator", "debugAppActPostToX: success=${result.success} message=${result.message}")
+            mapOf("success" to result.success, "message" to result.message)
+        }
+
+        // app.act Track 1 (navigation, docs/superpowers/specs/2026-07-11-app
+        // -act-design.md §2.1/§6) — same shape as debugAppActSendLineMessage
+        // above, but navigates to targetName's LINE conversation via search
+        // first instead of requiring it already open. See
+        // ShellyAccessibilityService.debugSendLineMessageToContact.
+        AsyncFunction("debugAppActSendLineMessageToContact") { targetName: String, text: String ->
+            val service = ShellyAccessibilityService.activeInstance
+                ?: return@AsyncFunction mapOf("success" to false, "message" to "Accessibility Service is not enabled/connected")
+            val result = service.debugSendLineMessageToContact(targetName, text)
+            Log.i("TerminalEmulator", "debugAppActSendLineMessageToContact: success=${result.success} message=${result.message}")
+            mapOf("success" to result.success, "message" to result.message)
+        }
+
+        // Testable native primitive for LockPromptActivity's lock-screen
+        // bridge (docs/superpowers/specs/2026-07-11-app-act-design.md
+        // §0.1). Deliberately not wired into any RN UI/debug button in this
+        // pass — this exists so the ensureUnlocked() blocking path can be
+        // exercised on-device independent of the ensureForeground()
+        // production call site it also feeds.
+        AsyncFunction("debugTestLockPrompt") {
+            val context = appContext.reactContext ?: return@AsyncFunction false
+            val result = LockPromptActivity.ensureUnlocked(context)
+            Log.i("TerminalEmulator", "debugTestLockPrompt: result=$result")
+            result
+        }
+
         AsyncFunction("installApk") { apkPath: String ->
             val context = requireReactContext()
             try {

--- a/modules/terminal-emulator/android/src/main/res/values/styles.xml
+++ b/modules/terminal-emulator/android/src/main/res/values/styles.xml
@@ -9,4 +9,18 @@
     <item name="android:windowCloseOnTouchOutside">true</item>
     <item name="android:colorAccent">#30D5FF</item>
   </style>
+
+  <!-- LockPromptActivity's theme (docs/superpowers/specs/2026-07-11-app-act-design.md
+       §0.1's lock-screen bridge). Deliberately NOT ShellyScouterPromptTheme:
+       that one is translucent + undimmed, tuned for a small dialog-style
+       prompt over an already-foregrounded app. A lock-screen prompt needs
+       to be immediately, unmistakably visible over the keyguard, so this
+       stays fully opaque with a dark solid background instead. -->
+  <style name="ShellyLockPromptTheme" parent="@android:style/Theme.Material.NoActionBar">
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:windowActionBar">false</item>
+    <item name="android:windowIsTranslucent">false</item>
+    <item name="android:windowBackground">#000C04</item>
+    <item name="android:colorAccent">#30D5FF</item>
+  </style>
 </resources>

--- a/modules/terminal-emulator/src/TerminalEmulatorModule.ts
+++ b/modules/terminal-emulator/src/TerminalEmulatorModule.ts
@@ -227,6 +227,35 @@ declare class TerminalEmulatorModuleType extends NativeModule {
   ): Promise<void>;
   cancelAgentActionApproval?(runId: string): Promise<void>;
   fireAgentIntent?(mode: 'launch' | 'share', target: string, shareText?: string | null): Promise<void>;
+  /** app.act Milestone 0 (dev-only debug scaffold, docs/superpowers/specs/
+   *  2026-07-11-app-act-design.md §6): types `text` into LINE's message
+   *  field and taps send, against whatever conversation is currently
+   *  foregrounded via ShellyAccessibilityService. `message` is always a
+   *  specific reason (success or the exact precondition that failed). */
+  debugAppActSendLineMessage?(text: string): Promise<{ success: boolean; message: string }>;
+  /** app.act Milestone 0, X (Twitter) variant — same shape as
+   *  debugAppActSendLineMessage, targets X's compose screen instead. */
+  debugAppActPostToX?(text: string): Promise<{ success: boolean; message: string }>;
+  /** app.act Track 1 (navigation, dev-only debug scaffold, docs/superpowers/
+   *  specs/2026-07-11-app-act-design.md §2.1/§6): navigates to `targetName`'s
+   *  LINE conversation via LINE's search screen (requiring an EXACT,
+   *  non-fuzzy single text match — fails closed on zero or multiple
+   *  matches), then types `text` into the message field and taps send.
+   *  Unlike debugAppActSendLineMessage, does NOT require the conversation
+   *  to already be open. */
+  debugAppActSendLineMessageToContact?(
+    targetName: string,
+    text: string
+  ): Promise<{ success: boolean; message: string }>;
+  /** Native primitive for LockPromptActivity's lock-screen bridge
+   *  (docs/superpowers/specs/2026-07-11-app-act-design.md §0.1): if the
+   *  device is already unlocked, resolves true immediately with no UI. If
+   *  locked, wakes the screen and shows a prompt over the keyguard asking
+   *  the user to unlock via the OS's own PIN/pattern/biometric challenge
+   *  (Shelly never sees the credential), then resolves true iff they
+   *  succeed before the internal timeout. Not wired into any RN UI in this
+   *  pass — for on-device testing of the primitive itself. */
+  debugTestLockPrompt?(): Promise<boolean>;
   returnToHome?(): Promise<void>;
   addListener(eventName: string, listener: (event: any) => void): { remove(): void };
 }

--- a/plugins/with-accessibility-service.js
+++ b/plugins/with-accessibility-service.js
@@ -1,0 +1,110 @@
+/**
+ * Expo config plugin: register ShellyAccessibilityService.
+ *
+ * UI-AUTOMATION-001 / app.act Milestone 0 — see ShellyAccessibilityService.kt's
+ * doc comment and docs/superpowers/specs/2026-07-11-app-act-design.md.
+ * Originally observe-only; now also performs narrow, hardcoded
+ * performAction()-based actions (ShellyAccessibilityService.debugSendLineMessage
+ * / debugPostToX, each reachable only from a manual debug button — see that
+ * file). Note that `canPerformGestures` was never needed for this:
+ * performAction(ACTION_CLICK / ACTION_SET_TEXT) only requires
+ * canRetrieveWindowContent (set below) — gesture-dispatch capability gates a
+ * different, lower-level API (dispatchGesture()) that this service does not
+ * use. Scoped to an explicit package allowlist (LINE + X/Twitter) — never a
+ * general screen-reader.
+ *
+ * Like TerminalSessionService/ShellyNotificationListener, this must go
+ * through a config plugin — expo prebuild regenerates android/ and
+ * silently drops hand-edited manifest entries with no corresponding
+ * plugin (see with-terminal-service.js's doc comment for the confirmed
+ * BootCompletedReceiver incident this pattern avoids repeating).
+ *
+ * android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE" on
+ * the <service> element restricts BINDING to callers holding that
+ * system-signature permission (only the OS) — the same pattern already
+ * used for BIND_NOTIFICATION_LISTENER_SERVICE in with-terminal-service.js,
+ * not the receiver-level android:permission mistake that broke
+ * BootCompletedReceiver delivery.
+ */
+const { withAndroidManifest, withDangerousMod } = require("expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+const ACCESSIBILITY_SERVICE_CONFIG = `<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagReportViewIds"
+    android:canRetrieveWindowContent="true"
+    android:packageNames="jp.naver.line.android,com.twitter.android"
+    android:notificationTimeout="100" />
+`;
+
+function withAccessibilityService(config) {
+  // Step 1: write accessibility_service_config.xml
+  config = withDangerousMod(config, [
+    "android",
+    (config) => {
+      const xmlDir = path.join(
+        config.modRequest.platformProjectRoot,
+        "app/src/main/res/xml"
+      );
+      fs.mkdirSync(xmlDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(xmlDir, "accessibility_service_config.xml"),
+        ACCESSIBILITY_SERVICE_CONFIG
+      );
+      return config;
+    },
+  ]);
+
+  // Step 2: register the <service> in AndroidManifest.xml
+  config = withAndroidManifest(config, (config) => {
+    const manifest = config.modResults;
+    const application = manifest.manifest.application?.[0];
+    if (!application) return config;
+
+    if (!application.service) {
+      application.service = [];
+    }
+
+    const serviceName = "expo.modules.terminalemulator.ShellyAccessibilityService";
+    const existing = application.service.find(
+      (s) => s.$?.["android:name"] === serviceName
+    );
+    if (!existing) {
+      application.service.push({
+        $: {
+          "android:name": serviceName,
+          "android:exported": "true",
+          "android:permission": "android.permission.BIND_ACCESSIBILITY_SERVICE",
+        },
+        "intent-filter": [
+          {
+            action: [
+              {
+                $: {
+                  "android:name": "android.accessibilityservice.AccessibilityService",
+                },
+              },
+            ],
+          },
+        ],
+        "meta-data": [
+          {
+            $: {
+              "android:name": "android.accessibilityservice",
+              "android:resource": "@xml/accessibility_service_config",
+            },
+          },
+        ],
+      });
+    }
+
+    return config;
+  });
+
+  return config;
+}
+
+module.exports = withAccessibilityService;


### PR DESCRIPTION
## Summary
Ports the AccessibilityService automation engine for X/LINE posting from the stale, unmerged \`claude/work-handoff-2qb1xd\` branch (308 commits ahead of main / 43 behind, diverged before capability-broker/PlanSpec/INTENT-001/DM-pairing landed, but this native layer never depended on any of those — clean port):

- \`AppActExecutor.kt\` (723 lines) — the automation engine, resourceId-matched \`AccessibilityNodeInfo\` actions only, no gesture dispatch
- \`AppActRecipeStore.kt\`, \`LockPromptActivity.kt\` (ported from the branch's fixed commit \`85c4591d\`, after 2 real concurrency bugs were resolved there — verified this is the fixed version, not an earlier buggy one)
- \`ShellyAccessibilityService.kt\` — scoped to LINE+X package allowlist, \`canRetrieveWindowContent\` only
- \`line.send-message\`/\`x.post\` recipe JSONs, \`with-accessibility-service.js\` Expo config plugin

**No JS/RN caller is wired yet** — new declared service + dead debug bridge methods only, independently reviewable before dispatch wiring (a later phase) lands.

## Security review (self-reviewed, verified by me during merge)
- ✅ Per-action foreground re-check (not just entry) — TOCTOU-safe between multi-step actions
- ✅ \`canRetrieveWindowContent\` only — no gesture/key-filter capability, verified via grep for \`dispatchGesture\`/\`GestureDescription\`/\`canPerformGestures\`
- ✅ Fail-closed on missing/renamed resourceId matches — never guesses on ambiguous matches
- ✅ \`LockPromptActivity\` non-exported, no intent-filter
- ✅ No permission beyond \`BIND_ACCESSIBILITY_SERVICE\`

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Kotlin: no build environment available here — manual line-by-line read instead of a compile check
- [x] Confirmed via grep: zero RN/JS callers of the new bridge methods anywhere in \`components/\`, \`app/\`, \`store/\`, \`hooks/\`, \`lib/\`