### PR TITLE
feat(agent): support per-step tool pinning in multi-step orchestration

### DIFF
--- a/__tests__/agent-manager-step-tool-pin.test.ts
+++ b/__tests__/agent-manager-step-tool-pin.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Phase 5: an orchestration step may optionally pin a concrete tool, skipping
+ * the keyword-based auto-routing for that step only (lib/agent-orchestration.ts
+ * normalizeStep + lib/agent-manager.ts runAgentOrchestrated).
+ *
+ * Two layers are covered:
+ *  - `resolveAgentRoute` (pure): proves the GUARD distinction at the layer
+ *    where it's actually decided — an unpinned step's tool stays 'auto' and
+ *    resolves via 'keyword'/'scorer', a pinned step's tool is concrete and
+ *    resolves via 'configured-tool' (the SAME path a top-level non-auto
+ *    Agent.tool already uses — no new mechanism).
+ *  - `runAgentNow` → runAgentOrchestrated (end-to-end): proves the pin
+ *    actually reaches the materialized run-script that TerminalEmulator
+ *    executes on-device. NOTE: the escalation ladder (agent-manager.ts
+ *    runLadderAttempts) always re-materializes each attempt with a FORCED
+ *    concrete `tool` + `runOn: 'auto'` (see its "force the configured-tool
+ *    branch" comment) — so the materialized script's OWN route decision is
+ *    'configured-tool' for EVERY successful attempt, pinned or not. The
+ *    meaningful, distinguishing signal at this layer is which TOOL got
+ *    materialized, not the guard label — asserted below via TOOL_LABEL /
+ *    ROUTE_DECISION_JSON embedded in the generated script.
+ *
+ * Only the shell boundary (runCommand) and the native TerminalEmulator bridge
+ * are mocked, following the pattern in __tests__/agent-delete-tombstone.test.ts.
+ */
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+const mockTerminalEmulator = {
+  cancelAgent: jest.fn(async () => undefined),
+  execCommand: jest.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+  runAgent: jest.fn(async () => undefined),
+};
+
+jest.mock('@/modules/terminal-emulator/src/TerminalEmulatorModule', () => ({
+  __esModule: true,
+  default: mockTerminalEmulator,
+}));
+jest.mock('expo-notifications', () => ({}));
+jest.mock('expo-file-system/legacy', () => ({}));
+
+import { runAgentNow } from '@/lib/agent-manager';
+import { useAgentStore } from '@/store/agent-store';
+import { Agent, AgentRouteDecision } from '@/store/types';
+import { resolveAgentRoute } from '@/lib/agent-tool-router';
+import { buildStepPrompt, normalizeSteps } from '@/lib/agent-orchestration';
+
+const AGENT_ID = 'chain-agent';
+
+const baseAgent: Agent = {
+  id: AGENT_ID,
+  name: AGENT_ID,
+  description: '',
+  prompt: '', // empty — keeps step-instruction keyword signals unambiguous
+  schedule: null,
+  tool: { type: 'auto' },
+  outputPath: '~/out',
+  outputTemplate: null,
+  enabled: true,
+  lastRun: null,
+  lastResult: null,
+  createdAt: 0,
+  version: 1,
+};
+
+// ── Layer 1: resolveAgentRoute — the guard is decided here, pure & offline ──
+describe('resolveAgentRoute — orchestration step tool pin (guard layer)', () => {
+  // Mirrors EXACTLY how runAgentOrchestrated builds a stepAgent
+  // (lib/agent-manager.ts): tool defaults to agent.tool when the step has no
+  // pin, prompt is buildStepPrompt(agent.prompt, step.instruction, prior).
+  function stepAgentFor(agent: Agent, instruction: string, tool: Agent['tool'] | undefined) {
+    return {
+      ...agent,
+      prompt: buildStepPrompt(agent.prompt, instruction, []),
+      orchestration: undefined,
+      tool: tool ?? agent.tool,
+    };
+  }
+
+  it('(a) regression: an unpinned step (tool undefined) resolves via keyword/scorer, exactly like today', () => {
+    const step = stepAgentFor(baseAgent, 'review this github pull request and merge it', undefined);
+    const { decision, tool } = resolveAgentRoute(step);
+    expect(decision.guard).not.toBe('configured-tool');
+    expect(['keyword', 'scorer']).toContain(decision.guard);
+    expect(tool.type).toBe('cli'); // code-keyword task → Codex CLI, same as a single-run agent
+  });
+
+  it('(b) a pinned step resolves via configured-tool and returns EXACTLY the pinned tool, ignoring its own keywords', () => {
+    // Misleading on purpose: strong CODE keywords that would normally score to
+    // Codex CLI — the pin must win regardless of instruction content.
+    const pinned = { type: 'perplexity' as const, model: 'sonar-deep-research' };
+    const step = stepAgentFor(baseAgent, 'review this github pull request and merge it', pinned);
+    const { decision, tool } = resolveAgentRoute(step);
+    expect(decision.guard).toBe('configured-tool');
+    expect(tool).toEqual(pinned);
+  });
+
+  it('(c) mixed array: each step in the SAME chain resolves independently — pin does not leak to the unpinned sibling', () => {
+    const steps = normalizeSteps({ steps: [
+      'review this github pull request and merge it',
+      { instruction: 'review this github pull request and merge it', tool: { type: 'local' as const } },
+    ] });
+    const results = steps.map((s) => resolveAgentRoute(stepAgentFor(baseAgent, s.instruction, s.tool)));
+    expect(results[0].decision.guard).not.toBe('configured-tool');
+    expect(results[0].tool.type).toBe('cli');
+    expect(results[1].decision.guard).toBe('configured-tool');
+    expect(results[1].tool.type).toBe('local');
+  });
+});
+
+// ── Layer 2: runAgentNow → runAgentOrchestrated — the pin reaches the shell ──
+interface CapturedStep {
+  toolLabel: string;
+  routeDecision: AgentRouteDecision;
+}
+
+/** Extract TOOL_LABEL= / ROUTE_DECISION_JSON= from a materialize command's
+ * embedded generateRunScript() output (each is a single shellQuote()'d line). */
+function captureFromMaterializeCommand(cmd: string): CapturedStep {
+  const lines = cmd.split('\n');
+  const toolLabelLine = lines.find((l) => l.startsWith('TOOL_LABEL='));
+  const routeLine = lines.find((l) => l.startsWith('ROUTE_DECISION_JSON='));
+  const unquote = (line: string, prefix: string) => line.slice(prefix.length + 1, -1);
+  const toolLabel = toolLabelLine ? unquote(toolLabelLine, 'TOOL_LABEL=') : '';
+  const routeJson = routeLine ? unquote(routeLine, 'ROUTE_DECISION_JSON=') : '{}';
+  return { toolLabel, routeDecision: JSON.parse(routeJson) as AgentRouteDecision };
+}
+
+/**
+ * Build a mocked runCommand that drives runAgentOrchestrated end to end:
+ *  - answers the ladderEnv probe with "no free-cloud keys",
+ *  - captures every materialize call's resolved tool (via TOOL_LABEL /
+ *    ROUTE_DECISION_JSON) into `captured`, in step order,
+ *  - and — the moment a materialize call is captured — immediately "commits"
+ *    a successful run-log entry for it, so the very next log read (the
+ *    escalation ladder's wait-for-completion + after-snapshot) sees a
+ *    success and the ladder does NOT climb past the first candidate.
+ */
+function makeRunCommand(captured: CapturedStep[]) {
+  const logs: Array<Record<string, unknown>> = [];
+  return jest.fn(async (cmd: string) => {
+    // NOTE: check the materialize marker BEFORE the ladderEnv ('CEREBRAS_API_KEY')
+    // marker — the generated run script itself embeds a line that unsets
+    // CEREBRAS_API_KEY (apiKeyEnvScrub) when the resolved tool doesn't need an
+    // API key env var, so a materialize command can ALSO contain that substring.
+    if (cmd.includes(`# run-agent-${AGENT_ID}`)) {
+      const step = captureFromMaterializeCommand(cmd);
+      captured.push(step);
+      logs.push({
+        agentId: AGENT_ID,
+        timestamp: Date.now() + logs.length,
+        status: 'success',
+        durationMs: 5,
+        toolUsed: step.toolLabel,
+        outputPreview: `ok via ${step.toolLabel}`,
+        routeDecision: step.routeDecision,
+      });
+      return '';
+    }
+    if (cmd.includes('CEREBRAS_API_KEY')) return ''; // ladderEnv: no free-cloud keys, no consent
+    if (cmd.includes('---SHELLY_AGENT_LOG---')) {
+      return logs.map((l) => `${JSON.stringify(l)}\n---SHELLY_AGENT_LOG---\n`).join('');
+    }
+    return ''; // listAgentLogFiles / aggregate write / memory / skills / misc
+  });
+}
+
+describe('orchestration step tool pin — end-to-end (agent-manager)', () => {
+  beforeEach(() => {
+    mockTerminalEmulator.cancelAgent.mockClear();
+    mockTerminalEmulator.execCommand.mockClear();
+    mockTerminalEmulator.runAgent.mockClear();
+    mockTerminalEmulator.execCommand.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    mockTerminalEmulator.runAgent.mockResolvedValue(undefined);
+    useAgentStore.getState().setAgents([]);
+    useAgentStore.getState().setRunHistory({});
+  });
+
+  it('(a) regression: plain-string-only steps still reach the shell with the auto-scored tool', async () => {
+    const agent: Agent = {
+      ...baseAgent,
+      orchestration: {
+        steps: [
+          'review this github pull request and merge it',
+          'write a short two sentence conclusion',
+        ],
+      },
+    };
+    useAgentStore.getState().setAgents([agent]);
+    const captured: CapturedStep[] = [];
+    const runCommand = makeRunCommand(captured);
+
+    await runAgentNow(AGENT_ID, runCommand, { waitTimeoutMs: 2000, pollMs: 1 });
+
+    expect(captured.length).toBeGreaterThanOrEqual(2);
+    // The strong code-keyword step routes to Codex CLI, exactly as a single-run
+    // agent with the same prompt would (no orchestration-specific behavior change).
+    expect(captured[0].routeDecision.toolType).toBe('cli');
+    expect(captured[0].toolLabel).toBe('Codex CLI');
+  });
+
+  it('(b) a step with an explicit tool pin reaches the shell with EXACTLY that tool, not an auto-routed one', async () => {
+    const agent: Agent = {
+      ...baseAgent,
+      orchestration: {
+        // >= 2 steps so this takes the orchestration codepath (isOrchestrated
+        // requires >= 2); the second step is unrelated so the pinned first
+        // step is isolated cleanly.
+        steps: [
+          // Misleading on purpose: strong CODE keywords that would normally
+          // score to Codex CLI — the pin must win over them regardless.
+          { instruction: 'review this github pull request and merge it', tool: { type: 'perplexity', model: 'sonar-deep-research' } },
+          'write a short two sentence conclusion',
+        ],
+      },
+    };
+    useAgentStore.getState().setAgents([agent]);
+    const captured: CapturedStep[] = [];
+    const runCommand = makeRunCommand(captured);
+
+    await runAgentNow(AGENT_ID, runCommand, { waitTimeoutMs: 2000, pollMs: 1 });
+
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    expect(captured[0].routeDecision.toolType).toBe('perplexity');
+    expect(captured[0].toolLabel).toBe('Perplexity API (sonar-deep-research)');
+  });
+
+  it('(c) mixed array: an unpinned step auto-routes while a pinned step in the SAME chain ignores its own keywords', async () => {
+    const agent: Agent = {
+      ...baseAgent,
+      orchestration: {
+        steps: [
+          'review this github pull request and merge it', // plain string → auto (Codex CLI expected)
+          {
+            instruction: 'review this github pull request and merge it', // same misleading text
+            tool: { type: 'local', model: 'Qwen3.5-0.8B-Q4_K_M' },
+          },
+        ],
+      },
+    };
+    useAgentStore.getState().setAgents([agent]);
+    const captured: CapturedStep[] = [];
+    const runCommand = makeRunCommand(captured);
+
+    await runAgentNow(AGENT_ID, runCommand, { waitTimeoutMs: 2000, pollMs: 1 });
+
+    expect(captured.length).toBeGreaterThanOrEqual(2);
+    // Step 1: unpinned, code-keyword instruction → Codex CLI (auto-routed).
+    expect(captured[0].routeDecision.toolType).toBe('cli');
+    // Step 2: pinned to local — ignoring the IDENTICAL code-keyword instruction
+    // that drove step 1 to Codex. Proves the pin is per-step, not chain-wide.
+    expect(captured[1].routeDecision.toolType).toBe('local');
+    expect(captured[1].toolLabel).toBe('Local LLM');
+  });
+});

--- a/__tests__/agent-orchestration.test.ts
+++ b/__tests__/agent-orchestration.test.ts
@@ -6,6 +6,7 @@ import {
   HARD_TOTAL_TIMEOUT_MS,
   isOrchestrated,
   nextStepGate,
+  normalizeStep,
   normalizeSteps,
   parseStepsFromText,
   reduceStatus,
@@ -35,14 +36,60 @@ describe('resolveBudget — clamps to hard caps', () => {
   });
 });
 
+describe('normalizeStep — single-entry normalization (Phase 5 tool pin)', () => {
+  it('a plain string becomes {instruction} with no tool — byte-identical to legacy behavior', () => {
+    expect(normalizeStep('  do the thing  ')).toEqual({ instruction: 'do the thing' });
+  });
+  it('an object with no tool becomes {instruction} — same as a plain string', () => {
+    expect(normalizeStep({ instruction: '  do the thing  ' })).toEqual({ instruction: 'do the thing' });
+  });
+  it('an object with a tool pin keeps it — this is the auto-routing skip', () => {
+    expect(normalizeStep({ instruction: 'draft a summary', tool: { type: 'perplexity', model: 'sonar-deep-research' } }))
+      .toEqual({ instruction: 'draft a summary', tool: { type: 'perplexity', model: 'sonar-deep-research' } });
+  });
+  it('truncates a long instruction the same way for both shapes', () => {
+    const long = 'x'.repeat(900);
+    expect(normalizeStep(long).instruction.length).toBeLessThanOrEqual(500);
+    expect(normalizeStep({ instruction: long, tool: { type: 'local' } }).instruction.length).toBeLessThanOrEqual(500);
+  });
+});
+
 describe('normalizeSteps / isOrchestrated', () => {
-  it('trims, drops empties, caps at hard max', () => {
-    expect(normalizeSteps(cfg({ steps: ['  x ', '', '  ', 'y'] }))).toEqual(['x', 'y']);
+  it('regression: plain-string-only steps normalize to {instruction} with no tool (unchanged auto-routing shape)', () => {
+    expect(normalizeSteps(cfg({ steps: ['  x ', '', '  ', 'y'] }))).toEqual([
+      { instruction: 'x' },
+      { instruction: 'y' },
+    ]);
     expect(normalizeSteps(cfg({ steps: Array(50).fill('s') })).length).toBe(HARD_MAX_STEPS);
+  });
+  it('a pinned-tool step surfaces its tool; an unpinned step in the SAME array does not', () => {
+    const steps = normalizeSteps(cfg({
+      steps: [
+        'collect the news',
+        { instruction: 'draft the digest', tool: { type: 'local', model: 'Qwen3.5-0.8B-Q4_K_M' } },
+      ],
+    }));
+    expect(steps).toEqual([
+      { instruction: 'collect the news' },
+      { instruction: 'draft the digest', tool: { type: 'local', model: 'Qwen3.5-0.8B-Q4_K_M' } },
+    ]);
+  });
+  it('mixed array: plain strings and pinned objects interleave correctly, empties still dropped', () => {
+    const steps = normalizeSteps(cfg({
+      steps: [
+        'step one',
+        { instruction: '' }, // empty instruction — dropped like an empty string
+        { instruction: 'step three', tool: { type: 'cli', cli: 'codex' } },
+        'step four',
+      ],
+    }));
+    expect(steps.map((s) => s.instruction)).toEqual(['step one', 'step three', 'step four']);
+    expect(steps.map((s) => s.tool)).toEqual([undefined, { type: 'cli', cli: 'codex' }, undefined]);
   });
   it('is orchestrated only with >= 2 steps', () => {
     expect(isOrchestrated(cfg({ steps: ['only one'] }))).toBe(false);
     expect(isOrchestrated(cfg({ steps: ['a', 'b'] }))).toBe(true);
+    expect(isOrchestrated(cfg({ steps: ['a', { instruction: 'b', tool: { type: 'groq' } }] }))).toBe(true);
     expect(isOrchestrated(undefined)).toBe(false);
   });
 });

--- a/__tests__/agent-pipeline-presets.test.ts
+++ b/__tests__/agent-pipeline-presets.test.ts
@@ -6,6 +6,15 @@ import {
   X_CHAR_LIMIT,
 } from '@/lib/agent-pipeline-presets';
 import { detectRouteSignals } from '@/lib/agent-router-scoring';
+import { normalizeSteps } from '@/lib/agent-orchestration';
+import type { AgentOrchestrationConfig } from '@/store/types';
+
+// buildSteamPipeline only ever produces plain-string steps (no tool pins) —
+// this preset predates and is untouched by the Phase 5 step-tool-pin schema
+// change, so narrow AgentOrchestrationConfig.steps (now string | {instruction,
+// tool?}) back down to plain instruction strings for these existing assertions.
+const stepInstructions = (orchestration: AgentOrchestrationConfig) =>
+  normalizeSteps(orchestration).map((s) => s.instruction);
 
 describe('buildSteamPipeline — North Star collection pipeline', () => {
   it('produces a 4-step autonomous Mon/Fri pipeline with a char limit', () => {
@@ -18,7 +27,7 @@ describe('buildSteamPipeline — North Star collection pipeline', () => {
 
   it('routes each step correctly via the existing scorer (collect=web, summarize=on-device)', () => {
     const p = buildSteamPipeline();
-    const [collect, primary, summarize, resummarize] = p.orchestration.steps;
+    const [collect, primary, summarize, resummarize] = stepInstructions(p.orchestration);
     // The base prompt is prepended to every step at runtime (buildStepPrompt), so
     // it MUST be neutral — no collection verb / freshness — or it would force
     // needsWeb on the transform steps too.
@@ -36,15 +45,15 @@ describe('buildSteamPipeline — North Star collection pipeline', () => {
   it('honours topic / count / charLimit / schedule overrides (clamped)', () => {
     const p = buildSteamPipeline({ topic: '宇宙生物学', count: 99, charLimit: 5, schedule: null });
     expect(p.name).toContain('宇宙生物学');
-    expect(p.orchestration.steps[0]).toContain('宇宙生物学');
-    expect(p.orchestration.steps[0]).toContain('10件'); // count clamped to 10
+    expect(stepInstructions(p.orchestration)[0]).toContain('宇宙生物学');
+    expect(stepInstructions(p.orchestration)[0]).toContain('10件'); // count clamped to 10
     expect(p.orchestration.charLimit).toBe(40); // 5 clamped up to the floor
     expect(p.schedule).toBeNull();
   });
 
   it('bakes the char limit into the final re-summarize instruction', () => {
     const p = buildSteamPipeline({ charLimit: 200 });
-    expect(p.orchestration.steps[3]).toContain('200文字以内');
+    expect(stepInstructions(p.orchestration)[3]).toContain('200文字以内');
   });
 });
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ import { useAgentStore } from '@/store/agent-store';
 import type { Agent, ToolChoice } from '@/store/types';
 import { deleteAgent, installAgent, runAgentNow, syncAgentRunLogsFromDisk, setAgentEnabled, haltAllAgents, resumeAllAgents } from '@/lib/agent-manager';
 import { toolChoiceToLabel } from '@/lib/agent-tool-router';
+import { normalizeSteps } from '@/lib/agent-orchestration';
 import { readMemoryNotes, type MemoryNote } from '@/lib/agent-memory';
 import { parseNotificationTriggerPackages } from '@/lib/notification-trigger';
 import {
@@ -601,15 +602,20 @@ export function Sidebar() {
       agent.enabled ? null : t('sidebar.agent_paused'),
     ].filter(Boolean).join(' · ');
     // Phase 4: when the agent is multi-step, show the planned chain; and if the
-    // last run was orchestrated, show each step's status.
-    const plannedSteps = agent.orchestration?.steps ?? [];
+    // last run was orchestrated, show each step's status. Phase 5: a step may
+    // pin a concrete tool — normalizeSteps handles both the legacy plain-string
+    // shape and the { instruction, tool? } shape, and surfacing the pinned
+    // tool's label here is the transparency a later "no per-run approval by
+    // default" policy needs (the user can see up front which steps skip
+    // auto-routing and which backend they'll actually use).
+    const plannedSteps = normalizeSteps(agent.orchestration);
     const stepDetail = lastLog?.steps?.length
       ? `${t('sidebar.agent_steps', { count: lastLog.steps.length })}\n${lastLog.steps
           .map((s) => `  ${s.index + 1}. [${s.status}] ${s.instruction.slice(0, 60)}`)
           .join('\n')}`
       : plannedSteps.length >= 2
       ? `${t('sidebar.agent_steps', { count: plannedSteps.length })}\n${plannedSteps
-          .map((s, i) => `  ${i + 1}. ${s.slice(0, 60)}`)
+          .map((s, i) => `  ${i + 1}. ${s.instruction.slice(0, 60)}${s.tool ? ` (${toolChoiceToLabel(s.tool)})` : ''}`)
           .join('\n')}`
       : '';
     // Reliability block (proof-of-execution): next scheduled run, last run (time ·

--- a/lib/agent-manager.ts
+++ b/lib/agent-manager.ts
@@ -626,11 +626,18 @@ async function runAgentOrchestrated(
     if (!gate.proceed) break;
 
     // Each step is a normal single run with a step-specific prompt; orchestration
-    // is cleared so the step itself doesn't recurse.
+    // is cleared so the step itself doesn't recurse. Phase 5: a step may pin a
+    // concrete tool (steps[i].tool) — when present it REPLACES agent.tool for
+    // this attempt, which routes it through resolveAgentRoute's existing
+    // 'configured-tool' path (same one a top-level non-auto Agent.tool already
+    // uses) and skips keyword-based auto-selection for this step only. Absent
+    // tool = agent.tool unchanged = today's exact auto-routing behavior.
+    const step = steps[i];
     const stepAgent: Agent = {
       ...agent,
-      prompt: buildStepPrompt(agent.prompt, steps[i], priorResults),
+      prompt: buildStepPrompt(agent.prompt, step.instruction, priorResults),
       orchestration: undefined,
+      tool: step.tool ?? agent.tool,
     };
     const stepStart = Date.now();
     // Only the FINAL step performs the agent action (draft/notify/webhook/cli) —
@@ -653,7 +660,7 @@ async function runAgentOrchestrated(
     } catch (error) {
       records.push({
         index: i,
-        instruction: steps[i],
+        instruction: step.instruction,
         status: 'error',
         durationMs: Date.now() - stepStart,
         outputPreview: error instanceof Error ? error.message.slice(0, 200) : 'step failed',
@@ -668,7 +675,7 @@ async function runAgentOrchestrated(
     const status: AgentRunStep['status'] = log?.status ?? 'error';
     records.push({
       index: i,
-      instruction: steps[i],
+      instruction: step.instruction,
       status,
       durationMs: Date.now() - stepStart,
       outputPreview: log?.outputPreview ?? '',

--- a/lib/agent-nl-parser.ts
+++ b/lib/agent-nl-parser.ts
@@ -18,7 +18,7 @@
  */
 import { AgentAction, AgentMemoryConfig, ToolChoice } from '@/store/types';
 import { suggestTool, toolChoiceToLabel } from './agent-tool-router';
-import { parseStepsFromText } from './agent-orchestration';
+import { parseStepsFromText, normalizeSteps } from './agent-orchestration';
 import { buildSteamPipeline, type PipelinePreset } from './agent-pipeline-presets';
 
 export interface ParsedAgentDraft {
@@ -648,7 +648,10 @@ export function parseAgentNL(utterance: string): ParsedAgentDraft {
     return {
       name: deriveName(preset.name),
       prompt: preset.prompt,
-      orchestrationSteps: preset.orchestration.steps,
+      // ParsedAgentDraft.orchestrationSteps is plain strings (Phase 5 tool-pin
+      // detection from NL text is a later phase) — normalize + extract the
+      // instruction so a future object-shaped step entry can't leak through.
+      orchestrationSteps: normalizeSteps(preset.orchestration).map((s) => s.instruction),
       schedule,
       scheduleConfident: presetSched.confident || usePresetDefault,
       scheduleLabel: presetSched.confident

--- a/lib/agent-orchestration.ts
+++ b/lib/agent-orchestration.ts
@@ -15,7 +15,7 @@
  *
  * All functions are pure (no IO) for deterministic unit tests.
  */
-import type { AgentOrchestrationConfig, AgentRunStep } from '@/store/types';
+import type { AgentOrchestrationConfig, AgentOrchestrationStep, AgentRunStep, ToolChoice } from '@/store/types';
 
 /** Sensible default; the hard cap protects the phantom-process ceiling. */
 export const DEFAULT_MAX_STEPS = 6;
@@ -51,12 +51,32 @@ export function resolveBudget(cfg: AgentOrchestrationConfig | undefined): Resolv
   };
 }
 
-/** Return the ordered, bounded, non-empty step instructions for an agent. */
-export function normalizeSteps(cfg: AgentOrchestrationConfig | undefined): string[] {
+export interface NormalizedStep {
+  instruction: string;
+  /** Present only when this step pins a concrete tool (Phase 5). Absent =
+   *  today's exact auto-routing behavior. */
+  tool?: ToolChoice;
+}
+
+/**
+ * Normalize a single step entry — either the legacy plain-string shape or the
+ * Phase 5 { instruction, tool? } object — into one canonical shape. Pure,
+ * trims/truncates the instruction the same way for both input shapes.
+ */
+export function normalizeStep(step: string | AgentOrchestrationStep): NormalizedStep {
+  if (typeof step === 'string') {
+    return { instruction: step.trim().slice(0, MAX_STEP_INSTRUCTION_CHARS) };
+  }
+  const instruction = (step.instruction ?? '').trim().slice(0, MAX_STEP_INSTRUCTION_CHARS);
+  return step.tool ? { instruction, tool: step.tool } : { instruction };
+}
+
+/** Return the ordered, bounded, non-empty steps for an agent (normalized). */
+export function normalizeSteps(cfg: AgentOrchestrationConfig | undefined): NormalizedStep[] {
   if (!cfg?.steps) return [];
   return cfg.steps
-    .map((s) => s.trim().slice(0, MAX_STEP_INSTRUCTION_CHARS))
-    .filter((s) => s.length > 0)
+    .map(normalizeStep)
+    .filter((s) => s.instruction.length > 0)
     .slice(0, HARD_MAX_STEPS);
 }
 

--- a/store/types.ts
+++ b/store/types.ts
@@ -679,10 +679,28 @@ export interface AgentRunStep {
   routeDecision?: AgentRouteDecision;
 }
 
+/**
+ * Phase 5: a step can optionally pin a concrete tool/provider, skipping the
+ * keyword-based auto-routing for that step only. A plain string step (below)
+ * is the original shape and keeps today's exact auto-routing behavior — no
+ * migration needed for existing on-disk agents.
+ */
+export interface AgentOrchestrationStep {
+  instruction: string;
+  /** Absent/omitted = auto-routed exactly like a plain-string step. A concrete
+   *  (non-'auto') tool here is resolved via the SAME 'configured-tool' path a
+   *  top-level pinned `Agent.tool` already uses — it does not widen privilege:
+   *  autonomous unattended runs still force local/Codex via resolveForAutonomous,
+   *  and a top-level `Agent.runOn` on-device/cloud pin still outranks it. */
+  tool?: ToolChoice;
+}
+
 /** Phase 4 orchestration config on an agent. Absent = single-run (today). */
 export interface AgentOrchestrationConfig {
-  /** Ordered step instructions; ≥ 2 → runs as a linear chain. */
-  steps: string[];
+  /** Ordered step instructions; ≥ 2 → runs as a linear chain. Each entry is
+   *  EITHER a plain string (legacy shape, always auto-routed) OR an object with
+   *  an optional tool pin (Phase 5). */
+  steps: Array<string | AgentOrchestrationStep>;
   /** Max steps to launch (clamped to a hard cap for the phantom-process ceiling). */
   maxSteps?: number;
   /** Total wall-clock budget in ms (clamped to a hard ceiling). */


### PR DESCRIPTION
## Summary
- Extends \`AgentOrchestrationConfig.steps\` from \`string[]\` to \`Array<string | { instruction: string; tool?: ToolChoice }>\` so a step can pin a specific provider ("collect via Perplexity, then summarize via local LLM") instead of always auto-routing off the step's instruction text.
- Additive: an absent pin keeps today's exact auto-routing behavior byte-for-byte, no migration needed for stored agent JSON.
- Sidebar now shows the pinned tool label next to a step's preview text — the transparency this project's "no per-run approval by default" policy needs.
- No NL-parser tool-pin detection yet (a later phase) — this is schema + execution-respects-the-pin only.

## Security self-review
Traced whether a step pin could bypass \`cli\`/\`codex\` approval-tiering: it routes through the exact same pre-existing \`'configured-tool'\` guard a top-level \`Agent.tool\` pin already uses — no new mechanism. Autonomous/unattended runs ignore any pin entirely (\`resolveEscalationLadder\` always rebuilds from the fixed local/codex set), so a step pin can never smuggle an unauthorized backend into an autonomous run. No privilege-escalation gap found.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 48/48 relevant tests pass (\`agent-orchestration\`, \`agent-manager-step-tool-pin\`, \`agent-pipeline-presets\`), including a regression guard that plain-string steps still auto-route exactly as before