### PR TITLE
fix(agent-nl): warn instead of silently misrouting X-post requests to draft

### DIFF
--- a/__tests__/agent-nl-parser.test.ts
+++ b/__tests__/agent-nl-parser.test.ts
@@ -419,6 +419,51 @@ describe('parseAgentNL — action layer (capability boundary)', () => {
   });
 });
 
+describe('parseAgentNL — action caveat (X-posting not yet supported)', () => {
+  // X-posting delivery doesn't exist on `main` yet (a later phase). Until then,
+  // detectAction() must keep returning 'draft' for this phrasing, but the user
+  // should be told why they got a file instead of a post.
+  it('"Xに投稿して" stays draft and sets a user-facing caveat', () => {
+    const d = parseAgentNL('毎日8時にXに投稿して');
+    expect(d.action.type).toBe('draft');
+    expect(typeof d.actionCaveat).toBe('string');
+    expect(d.actionCaveat!.length).toBeGreaterThan(0);
+  });
+
+  it('"post to X" (EN phrasing) also stays draft with a caveat', () => {
+    const d = parseAgentNL('every day at 8 post to X');
+    expect(d.action.type).toBe('draft');
+    expect(d.actionCaveat).toBeTruthy();
+  });
+
+  it('"tweet this" also stays draft with a caveat', () => {
+    const d = parseAgentNL('毎朝ニュースをまとめてtweet this');
+    expect(d.action.type).toBe('draft');
+    expect(d.actionCaveat).toBeTruthy();
+  });
+
+  it('a たら-conditional scopes the caveat to the delivery clause, not the condition', () => {
+    // "記事が完成したらXに投稿して" — condition = "記事が完成", action = "Xに投稿して".
+    // Mirrors detectAction's own たら-scoping (see its comment above) so a
+    // trigger-condition clause never falsely fires the caveat.
+    const d = parseAgentNL('記事が完成したらXに投稿して');
+    expect(d.action.type).toBe('draft');
+    expect(d.actionCaveat).toBeTruthy();
+  });
+
+  it('no caveat when X-posting phrasing is absent', () => {
+    const d = parseAgentNL('毎日8時にブログ記事を書いて');
+    expect(d.action.type).toBe('draft');
+    expect(d.actionCaveat).toBeUndefined();
+  });
+
+  it('no caveat when the action resolves to something other than draft', () => {
+    const d = parseAgentNL('毎日9時にコマンド実行して結果を保存');
+    expect(d.action.type).toBe('cli');
+    expect(d.actionCaveat).toBeUndefined();
+  });
+});
+
 describe('parseAgentNL — invariants', () => {
   const samples = [
     '毎日8時にXの下書きを作って',

--- a/components/panes/AgentConfirmCard.tsx
+++ b/components/panes/AgentConfirmCard.tsx
@@ -346,6 +346,13 @@ export default function AgentConfirmCard({ draft, onConfirm, onCancel }: Props) 
         })}
       </Text>
 
+      {/* Requested-but-unsupported delivery action (e.g. X-posting): the parser
+          already fell back to `draft`, but the user should be told why rather
+          than silently getting a file instead of what they asked for. */}
+      {draft.actionCaveat && (
+        <Text style={[styles.warn, { color: colors.warning }]}>{draft.actionCaveat}</Text>
+      )}
+
       {/* Name */}
       <Text style={[styles.label, { color: colors.muted }]}>{t('agentcard.name')}</Text>
       <TextInput

--- a/lib/agent-nl-parser.ts
+++ b/lib/agent-nl-parser.ts
@@ -58,6 +58,12 @@ export interface ParsedAgentDraft {
   /** Phase 4: ordered step instructions when the utterance is multi-step
    *  ("まず…次に…最後に" / numbered). Absent/<2 = single-run. */
   orchestrationSteps?: string[];
+  /** Set when the utterance asked for a delivery action that isn't backed by a
+   *  real `action.type` yet (e.g. "Xに投稿して" — X-posting delivery doesn't
+   *  exist on `main`), so `action` stayed `draft` instead of reflecting what
+   *  the user actually asked for. The confirm card should surface this as a
+   *  visible warning; absent = no caveat. */
+  actionCaveat?: string;
   /** The original utterance, preserved for the card / fallback editing. */
   rawText: string;
 }
@@ -419,6 +425,35 @@ function parseSchedule(text: string): ScheduleResult {
 
 const URL_RE = /https?:\/\/[^\s、。)）]+/i;
 
+/** Slice `text` down to the clause that actually names the delivery action —
+ *  the part after the LAST "たら" marker when a conditional ("Xたら、Y") is
+ *  present, else the whole text. Shared by detectAction's own keyword scans
+ *  and by detectActionCaveat() below, so every action-phrase detector agrees
+ *  on what counts as "the action" vs. "the condition". See the comment on
+ *  detectAction's たら handling for the full rationale / known limitation. */
+function actionDetectionScope(text: string): string {
+  const talaIndex = text.lastIndexOf('たら');
+  return talaIndex >= 0 ? text.slice(talaIndex + 2) : text;
+}
+
+// X-posting phrasing ("Xに投稿して" / "post to X" / "tweet this"). X-posting
+// delivery doesn't exist yet on `main` (a later phase), so detectAction()
+// deliberately keeps returning `{ type: 'draft' }` when this fires — this is
+// only used to surface a user-facing caveat, never to change the action type.
+const X_POST_RE = /Xに(?:自動)?投稿|Xに上げて|Xでポスト|Xにポスト|post(?:ing)?\s+to\s+x\b|tweet\s+this|\bxポスト/i;
+
+/** Detect a delivery request for a not-yet-supported action (currently just
+ *  X-posting). Returns a user-facing warning string, or undefined when none
+ *  applies. Callers should only surface this when `detectAction()` actually
+ *  fell back to `draft` for the same text (see parseAgentNL). */
+function detectActionCaveat(text: string): string | undefined {
+  const actionScope = actionDetectionScope(text);
+  if (X_POST_RE.test(actionScope)) {
+    return 'Xへの投稿にはまだ対応していないため、下書き（ファイル保存）として登録します';
+  }
+  return undefined;
+}
+
 /** Detect the delivery action. Default = draft. Never returns 'publish'. */
 function detectAction(text: string): AgentAction {
   // webhook — an explicit URL is the strongest signal.
@@ -454,8 +489,7 @@ function detectAction(text: string): AgentAction {
   // notify, because slicing after the LAST "たら" drops "通知して". Rare in
   // practice (needs two chained conditionals in one utterance); not fixed
   // here, no known simple fix without deeper clause parsing.
-  const talaIndex = text.lastIndexOf('たら');
-  const actionScope = talaIndex >= 0 ? text.slice(talaIndex + 2) : text;
+  const actionScope = actionDetectionScope(text);
 
   if (/ドラフト|下書き|\bdraft\b/i.test(actionScope)) {
     return { type: 'draft' };
@@ -635,6 +669,8 @@ export function parseAgentNL(utterance: string): ParsedAgentDraft {
   if (preset) {
     const presetSched = parseSchedule(rawText);
     const presetSuggestion = suggestTool(preset.prompt);
+    const presetAction = detectAction(rawText);
+    const presetActionCaveat = presetAction.type === 'draft' ? detectActionCaveat(rawText) : undefined;
     // Use the preset's Mon/Fri default ONLY when the user gave no schedule cue at
     // all. If they stated one that we couldn't confidently parse (e.g. "90分ごと"),
     // fall to manual selection rather than silently rewriting it to Mon/Fri.
@@ -662,17 +698,19 @@ export function parseAgentNL(utterance: string): ParsedAgentDraft {
       suggestedTime: presetSched.suggestedTime
         ? { hour: presetSched.suggestedTime.hour, minute: presetSched.suggestedTime.minute }
         : undefined,
-      action: detectAction(rawText),
+      action: presetAction,
       tool: presetSuggestion.tool,
       toolLabel: presetSuggestion.label ?? toolChoiceToLabel(presetSuggestion.tool),
       autonomous: true,
       memory: detectMemory(rawText),
+      actionCaveat: presetActionCaveat,
       rawText,
     };
   }
 
   const sched = parseSchedule(rawText);
   const action = detectAction(rawText);
+  const actionCaveat = action.type === 'draft' ? detectActionCaveat(rawText) : undefined;
   const prompt = derivePrompt(rawText, sched);
   const suggestion = suggestTool(prompt || rawText);
   const memory = detectMemory(rawText);
@@ -695,6 +733,7 @@ export function parseAgentNL(utterance: string): ParsedAgentDraft {
     tool: suggestion.tool,
     toolLabel: suggestion.label ?? toolChoiceToLabel(suggestion.tool),
     memory,
+    actionCaveat,
     rawText,
   };
 }


### PR DESCRIPTION
## Summary
- \`detectAction()\` didn't recognize "Xに投稿して"/"post to X" phrasing and silently fell through to the \`draft\` default (writes a file instead of posting), with no indication to the user this happened.
- Adds \`detectActionCaveat()\`, scoped through the same たら-clause-aware slicing \`detectAction\` already uses, setting a new \`ParsedAgentDraft.actionCaveat\` message when X-posting phrasing is detected but the action still resolves to \`draft\` (X-posting delivery doesn't exist as live dispatch yet — later phases in this same series).
- \`AgentConfirmCard\` surfaces the caveat as a visible warning.

## Test plan
- [x] 6 new test cases: JP/EN phrasing, a たら-conditional utterance verifying the condition clause doesn't falsely trigger it, negative cases (no caveat when no X-posting phrasing, or when action resolves to \`cli\` instead of \`draft\`)
- [x] \`npx tsc --noEmit\` clean
- [x] 87/87 relevant tests pass