### PR TITLE
feat(agent-nl): wire NL detection for app-act X-posting + tool-pinned steps

### DIFF
--- a/__tests__/agent-nl-parser.test.ts
+++ b/__tests__/agent-nl-parser.test.ts
@@ -419,39 +419,44 @@ describe('parseAgentNL — action layer (capability boundary)', () => {
   });
 });
 
-describe('parseAgentNL — action caveat (X-posting not yet supported)', () => {
-  // X-posting delivery doesn't exist on `main` yet (a later phase). Until then,
-  // detectAction() must keep returning 'draft' for this phrasing, but the user
-  // should be told why they got a file instead of a post.
-  it('"Xに投稿して" stays draft and sets a user-facing caveat', () => {
+describe('parseAgentNL — X-posting resolves to a real app-act action (Phase 6)', () => {
+  // X-posting used to fall back to 'draft' + a caveat (Phase 0) because there was
+  // no `app-act` action type to target. Phase 2 added the schema; this parser
+  // now targets it for real. LINE-posting still hits the old fallback — see the
+  // next describe block — so these two phrasings must NOT be confused.
+  it('"Xに投稿して" resolves to app-act x.post with no caveat', () => {
     const d = parseAgentNL('毎日8時にXに投稿して');
-    expect(d.action.type).toBe('draft');
-    expect(typeof d.actionCaveat).toBe('string');
-    expect(d.actionCaveat!.length).toBeGreaterThan(0);
+    expect(d.action.type).toBe('app-act');
+    if (d.action.type === 'app-act') {
+      expect(d.action.appActRecipeId).toBe('x.post');
+      expect(d.action.appActParams).toEqual({ text: '{{result}}' });
+    }
+    expect(d.actionCaveat).toBeUndefined();
   });
 
-  it('"post to X" (EN phrasing) also stays draft with a caveat', () => {
+  it('"post to X" (EN phrasing) also resolves to app-act x.post', () => {
     const d = parseAgentNL('every day at 8 post to X');
-    expect(d.action.type).toBe('draft');
-    expect(d.actionCaveat).toBeTruthy();
+    expect(d.action.type).toBe('app-act');
+    if (d.action.type === 'app-act') expect(d.action.appActRecipeId).toBe('x.post');
+    expect(d.actionCaveat).toBeUndefined();
   });
 
-  it('"tweet this" also stays draft with a caveat', () => {
+  it('"tweet this" also resolves to app-act x.post', () => {
     const d = parseAgentNL('毎朝ニュースをまとめてtweet this');
-    expect(d.action.type).toBe('draft');
-    expect(d.actionCaveat).toBeTruthy();
+    expect(d.action.type).toBe('app-act');
+    if (d.action.type === 'app-act') expect(d.action.appActRecipeId).toBe('x.post');
   });
 
-  it('a たら-conditional scopes the caveat to the delivery clause, not the condition', () => {
+  it('a たら-conditional scopes app-act detection to the delivery clause, not the condition', () => {
     // "記事が完成したらXに投稿して" — condition = "記事が完成", action = "Xに投稿して".
     // Mirrors detectAction's own たら-scoping (see its comment above) so a
-    // trigger-condition clause never falsely fires the caveat.
+    // trigger-condition clause never falsely fires the X-post detector.
     const d = parseAgentNL('記事が完成したらXに投稿して');
-    expect(d.action.type).toBe('draft');
-    expect(d.actionCaveat).toBeTruthy();
+    expect(d.action.type).toBe('app-act');
+    if (d.action.type === 'app-act') expect(d.action.appActRecipeId).toBe('x.post');
   });
 
-  it('no caveat when X-posting phrasing is absent', () => {
+  it('stays draft (not app-act) when X-posting phrasing is absent', () => {
     const d = parseAgentNL('毎日8時にブログ記事を書いて');
     expect(d.action.type).toBe('draft');
     expect(d.actionCaveat).toBeUndefined();
@@ -460,6 +465,33 @@ describe('parseAgentNL — action caveat (X-posting not yet supported)', () => {
   it('no caveat when the action resolves to something other than draft', () => {
     const d = parseAgentNL('毎日9時にコマンド実行して結果を保存');
     expect(d.action.type).toBe('cli');
+    expect(d.actionCaveat).toBeUndefined();
+  });
+});
+
+describe('parseAgentNL — LINE-posting caveat (still not supported, unlike X)', () => {
+  // LINE-posting deliberately keeps the OLD Phase-0-style fallback: `draft` +
+  // a user-facing caveat. Only X graduated to a real app-act action this phase
+  // (see the describe block above) — LINE NL detection/dispatch is out of scope
+  // here even though a `line.send-message` recipe is scaffolded natively.
+  it('"LINEに投稿して" stays draft and sets a user-facing caveat', () => {
+    const d = parseAgentNL('毎日8時にLINEに投稿して');
+    expect(d.action.type).toBe('draft');
+    expect(typeof d.actionCaveat).toBe('string');
+    expect(d.actionCaveat!.length).toBeGreaterThan(0);
+  });
+
+  it('"send this to LINE" (EN phrasing) also stays draft with a caveat', () => {
+    const d = parseAgentNL('every day at 8 send this to LINE');
+    expect(d.action.type).toBe('draft');
+    expect(d.actionCaveat).toBeTruthy();
+  });
+
+  it('a bare "LINEで知らせて" (notify, not post) is unaffected — resolves to notify, no caveat', () => {
+    // Regression guard: LINE_POST_RE must not collide with the pre-existing
+    // notify-keyword branch ("知らせ") that already handles this phrasing.
+    const d = parseAgentNL('毎日8時にLINEで知らせて');
+    expect(d.action.type).toBe('notify');
     expect(d.actionCaveat).toBeUndefined();
   });
 });
@@ -593,5 +625,83 @@ describe('parseAgentNL — memory (Phase 1)', () => {
   it('still fires on "don\'t forget" (affirmative keep-this)', () => {
     const d = parseAgentNL("don't forget to water the plants");
     expect(d.memory?.remember).toBe(true);
+  });
+});
+
+describe('parseAgentNL — Phase 6 target scenario: tool-pinned て-form chain → app-act', () => {
+  // The literal Japanese utterance from the Phase 6 brief: a weekly schedule +
+  // a plain て-form conjunctive chain naming Perplexity then the local LLM, that
+  // ends in an X-post. No explicit sequence marker (まず/次に/…) appears anywhere,
+  // so this MUST come from detectToolPinnedSteps, not parseStepsFromText.
+  const JP_UTTERANCE =
+    '毎週月曜9時に、パープレでSTEAM教育×AIの最新論文を集めて、ローカルLLMで日本語要約と自分の見解とリンクを付けて、Xに自動投稿して';
+
+  it('produces a confident weekly Monday 9:00 schedule', () => {
+    const d = parseAgentNL(JP_UTTERANCE);
+    expect(d.scheduleConfident).toBe(true);
+    expect(d.schedule).toBe('0 9 * * 1');
+  });
+
+  it('produces >= 2 orchestration steps with the correct per-step tool pins', () => {
+    const d = parseAgentNL(JP_UTTERANCE);
+    expect(d.orchestrationSteps).toBeDefined();
+    expect(d.orchestrationSteps!.length).toBeGreaterThanOrEqual(2);
+
+    const steps = d.orchestrationSteps!;
+    const first = steps[0];
+    const second = steps[1];
+    expect(typeof first).not.toBe('string');
+    expect(typeof second).not.toBe('string');
+    if (typeof first !== 'string') {
+      expect(first.tool).toEqual({ type: 'perplexity', model: 'sonar-deep-research' });
+      expect(first.instruction).toContain('パープレ');
+    }
+    if (typeof second !== 'string') {
+      expect(second.tool).toEqual({ type: 'local' });
+      expect(second.instruction).toContain('ローカルLLM');
+    }
+  });
+
+  it('resolves action to a real app-act x.post (not draft + caveat)', () => {
+    const d = parseAgentNL(JP_UTTERANCE);
+    expect(d.action.type).toBe('app-act');
+    if (d.action.type === 'app-act') {
+      expect(d.action.appActRecipeId).toBe('x.post');
+      expect(d.action.appActParams).toEqual({ text: '{{result}}' });
+    }
+    expect(d.actionCaveat).toBeUndefined();
+  });
+
+  // English paraphrase of the same scenario (kept schedule-free — derivePrompt's
+  // EN weekday-clause stripping only handles a LEADING "on Monday at 9" shape,
+  // not "Every Monday at 9,"; that pre-existing limitation is orthogonal to what
+  // this phase is testing, so the schedule clause is left out of this variant to
+  // isolate the orchestration + action assertions).
+  const EN_UTTERANCE =
+    'Collect the latest STEAM x AI papers with Perplexity, summarize them in Japanese with the local LLM and add my take with links, then post to X automatically.';
+
+  it('EN paraphrase: produces the same tool-pinned steps and app-act action', () => {
+    const d = parseAgentNL(EN_UTTERANCE);
+    expect(d.orchestrationSteps).toBeDefined();
+    expect(d.orchestrationSteps!.length).toBeGreaterThanOrEqual(2);
+    const [first, second] = d.orchestrationSteps!;
+    if (typeof first !== 'string') expect(first.tool).toEqual({ type: 'perplexity', model: 'sonar-deep-research' });
+    if (typeof second !== 'string') expect(second.tool).toEqual({ type: 'local' });
+
+    expect(d.action.type).toBe('app-act');
+    if (d.action.type === 'app-act') expect(d.action.appActRecipeId).toBe('x.post');
+  });
+
+  it('REGRESSION: ordinary て、-containing prose with no tool mention stays single-step', () => {
+    // Same clause-boundary shape (て-form + 、) as the target scenario, but no
+    // tool name anywhere — must NOT spuriously produce pinned steps. This is
+    // the guard for "don't widen the generic splitter" from the Phase 6 brief.
+    const d = parseAgentNL('毎朝8時にニュースを集めて、要約して、保存して');
+    expect(d.orchestrationSteps).toBeUndefined();
+  });
+
+  it('REGRESSION: a plain single-tool mention with no clause chain stays single-step', () => {
+    const d = parseAgentNL('パープレで論文を集めて');
+    expect(d.orchestrationSteps).toBeUndefined();
   });
 });

--- a/__tests__/agent-orchestration.test.ts
+++ b/__tests__/agent-orchestration.test.ts
@@ -2,6 +2,7 @@ import {
   buildStepPrompt,
   combineFinalPreview,
   DEFAULT_MAX_STEPS,
+  detectToolPinnedSteps,
   HARD_MAX_STEPS,
   HARD_TOTAL_TIMEOUT_MS,
   isOrchestrated,
@@ -184,6 +185,52 @@ describe('parseStepsFromText — conservative multi-step detection', () => {
   it('caps at the hard step max', () => {
     const many = Array.from({ length: 30 }, (_, i) => `${i + 1}. step`).join('\n');
     expect(parseStepsFromText(many).length).toBeLessThanOrEqual(HARD_MAX_STEPS);
+  });
+});
+
+describe('detectToolPinnedSteps — Phase 6 tool-mention chain detection', () => {
+  it('pins パープレ/ローカルLLM per clause on a plain て-form/、-delimited chain, leaves the last clause unpinned', () => {
+    const steps = detectToolPinnedSteps(
+      'パープレでSTEAM教育×AIの最新論文を集めて、ローカルLLMで日本語要約と自分の見解とリンクを付けて、Xに自動投稿して',
+    );
+    expect(steps).not.toBeNull();
+    expect(steps!.length).toBe(3);
+    expect(steps![0].tool).toEqual({ type: 'perplexity', model: 'sonar-deep-research' });
+    expect(steps![0].instruction).toContain('パープレ');
+    expect(steps![1].tool).toEqual({ type: 'local' });
+    expect(steps![2].tool).toBeUndefined();
+    expect(steps![2].instruction).toContain('X');
+  });
+
+  it('pins Codex and Gemini mentions to their ToolChoice shapes', () => {
+    const steps = detectToolPinnedSteps('Codexでコードを直して、Geminiでレビューコメントを書いて');
+    expect(steps).not.toBeNull();
+    expect(steps![0].tool).toEqual({ type: 'cli', cli: 'codex' });
+    expect(steps![1].tool).toEqual({ type: 'gemini-api' });
+  });
+
+  it('recognizes an EN comma-delimited chain with tool mentions', () => {
+    const steps = detectToolPinnedSteps(
+      'Collect the latest STEAM x AI papers with Perplexity, summarize them in Japanese with the local LLM and add my take with links, then post to X automatically.',
+    );
+    expect(steps).not.toBeNull();
+    expect(steps!.length).toBe(3);
+    expect(steps![0].tool).toEqual({ type: 'perplexity', model: 'sonar-deep-research' });
+    expect(steps![1].tool).toEqual({ type: 'local' });
+    expect(steps![2].tool).toBeUndefined();
+  });
+
+  it('returns null for a single clause (no boundary at all)', () => {
+    expect(detectToolPinnedSteps('パープレで論文を集めて')).toBeNull();
+  });
+
+  it('REGRESSION: returns null for ordinary て、-containing prose with no tool mention (does not widen the generic splitter)', () => {
+    expect(detectToolPinnedSteps('毎朝ニュースをまとめて、保存して')).toBeNull();
+    expect(detectToolPinnedSteps('資料を確認して、問題なければ承認して、担当者に共有して')).toBeNull();
+  });
+
+  it('returns null for fewer than 2 usable clauses even with a tool mention', () => {
+    expect(detectToolPinnedSteps('ローカルLLMで要約')).toBeNull();
   });
 });
 

--- a/components/panes/AgentConfirmCard.tsx
+++ b/components/panes/AgentConfirmCard.tsx
@@ -21,9 +21,9 @@ import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-nativ
 import { useTheme } from '@/hooks/use-theme';
 import { useTranslation } from '@/lib/i18n';
 import { ParsedAgentDraft } from '@/lib/agent-nl-parser';
-import { AgentAction, AgentActionType, AgentMemoryConfig, ToolChoice } from '@/store/types';
+import { AgentAction, AgentActionType, AgentMemoryConfig, AgentOrchestrationStep, ToolChoice } from '@/store/types';
 import { useSettingsStore } from '@/store/settings-store';
-import { resolveAutonomousFinalTool } from '@/lib/agent-tool-router';
+import { resolveAutonomousFinalTool, toolChoiceToLabel } from '@/lib/agent-tool-router';
 import { detectRouteSignals } from '@/lib/agent-router-scoring';
 import { decodeCron, buildCron, resolveInitialFrequency, type Frequency } from '@/lib/agent-card-cron';
 import { parseNotificationTriggerPackages } from '@/lib/notification-trigger';
@@ -45,8 +45,10 @@ export interface ConfirmedAgentDraft {
   memory?: AgentMemoryConfig;
   /** Phase 2a: id of a reused skill recipe the user kept on in the card. */
   skillId?: string;
-  /** Phase 4: ordered step instructions for a multi-step (orchestrated) agent. */
-  orchestrationSteps?: string[];
+  /** Phase 4/6: ordered step instructions for a multi-step (orchestrated) agent.
+   *  Each entry is either a plain string (auto-routed) or a { instruction, tool }
+   *  object pinning a concrete tool for that step (Phase 6). */
+  orchestrationSteps?: Array<string | AgentOrchestrationStep>;
   /** NOTIFY-001 Increment 2: notification-package allowlist that triggers this agent. */
   notificationTrigger?: { packageNames: string[] } | null;
 }
@@ -295,6 +297,16 @@ export default function AgentConfirmCard({ draft, onConfirm, onCancel }: Props) 
     if (actionType === 'dm-reply') {
       action.dmPairingId = dmPairingId;
       action.dmReplyText = dmReplyText.trim();
+    }
+    // app-act has no dedicated editor UI yet (Phase 6 is NL-parser-only) — when
+    // the user leaves the card's action picker on 'app-act' unchanged, carry the
+    // recipe/params the parser already resolved through verbatim. Without this,
+    // rebuilding `action` from `{ type: actionType }` alone would silently drop
+    // appActRecipeId/appActParams, registering an app-act action with no recipe.
+    if (actionType === 'app-act' && draft.action.type === 'app-act') {
+      action.appActRecipeId = draft.action.appActRecipeId;
+      action.appActParams = draft.action.appActParams;
+      action.appActMethod = draft.action.appActMethod;
     }
     // Autonomous keeps the scored web tool when consent allows (P1 Gemini path);
     // otherwise the gated Codex driver. Non-autonomous keeps the scored tool.
@@ -622,6 +634,13 @@ export default function AgentConfirmCard({ draft, onConfirm, onCancel }: Props) 
           <Text style={[styles.warn, { color: colors.muted }]}>{t('agentcard.dmreply_text_hint')}</Text>
         </>
       )}
+      {actionType === 'app-act' && (
+        <Text style={[styles.warn, { color: colors.warning }]}>
+          {draft.action.type === 'app-act' && draft.action.appActRecipeId === 'x.post'
+            ? t('agentcard.appact_x_warning')
+            : t('agentcard.appact_generic_warning')}
+        </Text>
+      )}
 
       {/* Notification trigger (NOTIFY-001 Increment 2) */}
       <Text style={[styles.label, { color: colors.muted }]}>{t('agentcard.notification_trigger_label')}</Text>
@@ -721,17 +740,27 @@ export default function AgentConfirmCard({ draft, onConfirm, onCancel }: Props) 
         </View>
       )}
 
-      {/* Phase 4: when the utterance was multi-step, show the planned chain. */}
+      {/* Phase 4/6: when the utterance was multi-step, show the planned chain —
+          including, for a Phase 6 tool-pinned step, WHICH tool it will use. This
+          is a security-relevant disclosure: a step can pin `cli`/Codex (see
+          AgentOrchestrationStep in store/types.ts), and the user should see that
+          in the same reviewable-before-Confirm surface as every other action. */}
       {draft.orchestrationSteps && draft.orchestrationSteps.length >= 2 && (
         <View style={{ marginTop: 4 }}>
           <Text style={[styles.label, { color: colors.muted, marginTop: 0 }]}>
             {t('agentcard.orchestration', { count: draft.orchestrationSteps.length })}
           </Text>
-          {draft.orchestrationSteps.map((s, i) => (
-            <Text key={`step-${i}`} style={[styles.warn, { color: colors.muted }]} numberOfLines={2}>
-              {`${i + 1}. ${s}`}
-            </Text>
-          ))}
+          {draft.orchestrationSteps.map((s, i) => {
+            const instruction = typeof s === 'string' ? s : s.instruction;
+            const pinnedTool = typeof s === 'string' ? undefined : s.tool;
+            return (
+              <Text key={`step-${i}`} style={[styles.warn, { color: colors.muted }]} numberOfLines={2}>
+                {pinnedTool
+                  ? `${i + 1}. [${toolChoiceToLabel(pinnedTool)}] ${instruction}`
+                  : `${i + 1}. ${instruction}`}
+              </Text>
+            );
+          })}
         </View>
       )}
 

--- a/lib/agent-nl-parser.ts
+++ b/lib/agent-nl-parser.ts
@@ -16,9 +16,9 @@
  *
  * The result is a PREVIEW draft, not a live agent. The caller shows it in the confirm card.
  */
-import { AgentAction, AgentMemoryConfig, ToolChoice } from '@/store/types';
+import { AgentAction, AgentMemoryConfig, AgentOrchestrationStep, ToolChoice } from '@/store/types';
 import { suggestTool, toolChoiceToLabel } from './agent-tool-router';
-import { parseStepsFromText, normalizeSteps } from './agent-orchestration';
+import { parseStepsFromText, normalizeSteps, detectToolPinnedSteps } from './agent-orchestration';
 import { buildSteamPipeline, type PipelinePreset } from './agent-pipeline-presets';
 
 export interface ParsedAgentDraft {
@@ -56,13 +56,19 @@ export interface ParsedAgentDraft {
    *  card. Set by the dispatcher (async skill match), not the pure parser. */
   matchedSkill?: { id: string; name: string; successCount: number };
   /** Phase 4: ordered step instructions when the utterance is multi-step
-   *  ("まず…次に…最後に" / numbered). Absent/<2 = single-run. */
-  orchestrationSteps?: string[];
+   *  ("まず…次に…最後に" / numbered), OR (Phase 6) a plain て-form/comma-delimited
+   *  chain naming a tool per clause ("パープレで集めて、ローカルLLMで要約して…") —
+   *  see detectToolPinnedSteps. Each entry is either a plain string (auto-routed,
+   *  same as before) or a { instruction, tool } object pinning a concrete tool for
+   *  just that step. Absent/<2 = single-run. */
+  orchestrationSteps?: Array<string | AgentOrchestrationStep>;
   /** Set when the utterance asked for a delivery action that isn't backed by a
-   *  real `action.type` yet (e.g. "Xに投稿して" — X-posting delivery doesn't
-   *  exist on `main`), so `action` stayed `draft` instead of reflecting what
-   *  the user actually asked for. The confirm card should surface this as a
-   *  visible warning; absent = no caveat. */
+   *  real `action.type` yet (currently: LINE-posting — "LINEに投稿して" has a
+   *  scaffolded `line.send-message` app-act recipe but no wired detection here
+   *  yet), so `action` stayed `draft` instead of reflecting what the user
+   *  actually asked for. X-posting used to hit this same fallback but is now a
+   *  real `app-act` action (Phase 6) — see X_POST_RE / detectAction. The confirm
+   *  card should surface this as a visible warning; absent = no caveat. */
   actionCaveat?: string;
   /** The original utterance, preserved for the card / fallback editing. */
   rawText: string;
@@ -436,20 +442,39 @@ function actionDetectionScope(text: string): string {
   return talaIndex >= 0 ? text.slice(talaIndex + 2) : text;
 }
 
-// X-posting phrasing ("Xに投稿して" / "post to X" / "tweet this"). X-posting
-// delivery doesn't exist yet on `main` (a later phase), so detectAction()
-// deliberately keeps returning `{ type: 'draft' }` when this fires — this is
-// only used to surface a user-facing caveat, never to change the action type.
+// X-posting phrasing ("Xに投稿して" / "post to X" / "tweet this"). Phase 0 kept
+// this as a `draft` fallback + caveat because there was no `app-act` action type
+// on `main` yet to target. Phase 2 added the `app-act` schema (appActRecipeId /
+// appActParams on AgentAction — see store/types.ts), so detectAction() below now
+// returns a REAL `{ type: 'app-act', appActRecipeId: 'x.post', … }` action for
+// this phrasing instead of falling through to draft. (Real on-device dispatch of
+// `app-act` is separate, in-progress work — this parser change is what lets NL
+// text reach that action type at all; the recipe/params are fixed and reviewed
+// once at registration time, per the AgentActionType doc comment.) Kept as its
+// own named const (not inlined) since it's still reused verbatim by the tests
+// and by the "no caveat when X-posting is absent" invariant.
 const X_POST_RE = /Xに(?:自動)?投稿|Xに上げて|Xでポスト|Xにポスト|post(?:ing)?\s+to\s+x\b|tweet\s+this|\bxポスト/i;
 
+// LINE-posting phrasing ("LINEに投稿して" / "send this to LINE"). Phase 3
+// scaffolded a `line.send-message` app-act recipe on the native layer, but
+// wiring NL detection + dispatch for it is OUT OF SCOPE for this phase (only
+// X was asked for) — so, unlike X above, this still falls through to `draft`
+// with a caveat, exactly like X used to. Deliberately narrow (a literal
+// 投稿/送信 verb, or "send ... to line") so it never collides with
+// "LINEで知らせて/LINEで教えて", which already resolves to a real `notify`
+// action via the notify-keyword branch in detectAction below.
+const LINE_POST_RE = /LINEに(?:自動)?投稿|LINEに(?:メッセージを)?送(?:って|信)|send\s+(?:this|a\s+message)?\s*to\s+line\b|post(?:ing)?\s+to\s+line\b/i;
+
 /** Detect a delivery request for a not-yet-supported action (currently just
- *  X-posting). Returns a user-facing warning string, or undefined when none
- *  applies. Callers should only surface this when `detectAction()` actually
- *  fell back to `draft` for the same text (see parseAgentNL). */
+ *  LINE-posting — see LINE_POST_RE above; X-posting graduated to a real
+ *  app-act action in Phase 6 and no longer needs this fallback). Returns a
+ *  user-facing warning string, or undefined when none applies. Callers should
+ *  only surface this when `detectAction()` actually fell back to `draft` for
+ *  the same text (see parseAgentNL). */
 function detectActionCaveat(text: string): string | undefined {
   const actionScope = actionDetectionScope(text);
-  if (X_POST_RE.test(actionScope)) {
-    return 'Xへの投稿にはまだ対応していないため、下書き（ファイル保存）として登録します';
+  if (LINE_POST_RE.test(actionScope)) {
+    return 'LINEへの投稿にはまだ対応していないため、下書き（ファイル保存）として登録します';
   }
   return undefined;
 }
@@ -490,6 +515,16 @@ function detectAction(text: string): AgentAction {
   // practice (needs two chained conditionals in one utterance); not fixed
   // here, no known simple fix without deeper clause parsing.
   const actionScope = actionDetectionScope(text);
+
+  // app-act: X-posting (Phase 6). Checked before the draft/notify keyword scans
+  // so "Xに自動投稿して" resolves to the real recipe even if the same clause
+  // happens to also contain a draft/notify word elsewhere. {{result}} is the
+  // agreed placeholder convention (same as intentShareText/dmReplyText) —
+  // string-replaced with the run's output preview at request-build time,
+  // BEFORE the approval request is written.
+  if (X_POST_RE.test(actionScope)) {
+    return { type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } };
+  }
 
   if (/ドラフト|下書き|\bdraft\b/i.test(actionScope)) {
     return { type: 'draft' };
@@ -684,9 +719,12 @@ export function parseAgentNL(utterance: string): ParsedAgentDraft {
     return {
       name: deriveName(preset.name),
       prompt: preset.prompt,
-      // ParsedAgentDraft.orchestrationSteps is plain strings (Phase 5 tool-pin
-      // detection from NL text is a later phase) — normalize + extract the
-      // instruction so a future object-shaped step entry can't leak through.
+      // The G6 preset's own steps stay plain strings here (its fixed
+      // search→primary-source→summarize→re-summarize shape has no per-clause
+      // tool mentions to detect) — normalize + extract the instruction so an
+      // object-shaped preset step entry can't leak through un-normalized. The
+      // Phase 6 tool-pin detector (detectToolPinnedSteps) only runs in the
+      // non-preset branch below, on the user's own utterance text.
       orchestrationSteps: normalizeSteps(preset.orchestration).map((s) => s.instruction),
       schedule,
       scheduleConfident: presetSched.confident || usePresetDefault,
@@ -714,13 +752,23 @@ export function parseAgentNL(utterance: string): ParsedAgentDraft {
   const prompt = derivePrompt(rawText, sched);
   const suggestion = suggestTool(prompt || rawText);
   const memory = detectMemory(rawText);
-  // Phase 4: detect an explicit multi-step instruction (≥ 2 ordered parts).
-  const orchestrationSteps = parseStepsFromText(prompt || rawText);
+  // Phase 4: detect an explicit multi-step instruction (≥ 2 ordered parts) via
+  // an explicit sequence marker (まず/次に/… , first/then/…, numbered list).
+  const explicitSteps = parseStepsFromText(prompt || rawText);
+  // Phase 6: when there's no EXPLICIT marker, fall back to the narrower
+  // tool-mention detector (plain て-form/comma chain naming a tool per clause,
+  // e.g. "パープレで集めて、ローカルLLMで要約して、Xに投稿して"). Checked only when
+  // explicitSteps didn't already find a confident split, so a marker-based
+  // utterance is never double-processed by both detectors.
+  const orchestrationSteps: Array<string | AgentOrchestrationStep> | undefined =
+    explicitSteps.length >= 2
+      ? explicitSteps
+      : detectToolPinnedSteps(prompt || rawText) ?? undefined;
 
   return {
     name: deriveName(rawText),
     prompt,
-    orchestrationSteps: orchestrationSteps.length >= 2 ? orchestrationSteps : undefined,
+    orchestrationSteps,
     schedule: sched.schedule,
     scheduleConfident: sched.confident,
     scheduleLabel: sched.label,

--- a/lib/agent-orchestration.ts
+++ b/lib/agent-orchestration.ts
@@ -16,6 +16,7 @@
  * All functions are pure (no IO) for deterministic unit tests.
  */
 import type { AgentOrchestrationConfig, AgentOrchestrationStep, AgentRunStep, ToolChoice } from '@/store/types';
+import { GEMINI_WEB, PERPLEXITY_WEB } from './agent-router-scoring';
 
 /** Sensible default; the hard cap protects the phantom-process ceiling. */
 export const DEFAULT_MAX_STEPS = 6;
@@ -193,4 +194,77 @@ export function parseStepsFromText(text: string): string[] {
     }
   }
   return [];
+}
+
+// ── Tool-pinned step detection (Phase 6) ─────────────────────────────────────
+//
+// A plain て-form conjunctive chain ("集めて、…付けて、…投稿して") carries none of
+// the explicit sequence markers JP_SEQUENCE_SPLIT/EN_SEQUENCE_SPLIT/NUMBERED_SPLIT
+// look for (まず/次に/… , first/then/next/…, numbered lists), so parseStepsFromText
+// never fires for it. We deliberately do NOT widen JP_SEQUENCE_SPLIT itself to
+// catch plain "て、" — that risks false-positiving on ordinary prose that merely
+// happens to contain "て、" with no multi-step intent. Instead this is a NARROWER,
+// SEPARATE detector: it only turns a clause-boundary-delimited chain into pinned
+// orchestration steps when at least one clause explicitly NAMES a tool/provider
+// (パープレ/Perplexity, ローカルLLM/ローカル, Codex, Gemini). The tool mention is the
+// actual "this is deliberately multi-step" signal, not the punctuation — a clause
+// chain with boundaries but NO tool mention returns null and the normal
+// single-run / other-detector path is used instead (regression-tested).
+
+// Clause boundaries: JP 、/。 runs, EN ", " / "; ", and the EN conjunctions
+// "then" / "and then" (which, unlike EN_SEQUENCE_SPLIT above, are recognised
+// mid-sentence, not just at a clause's leading edge — this detector's own tool-
+// mention gate is what keeps it narrow, so it doesn't need EN_SEQUENCE_SPLIT's
+// stricter start-of-clause anchoring).
+const CLAUSE_BOUNDARY = /[、。]+|,\s+|;\s+|\s*\band then\b\s*|\s*\bthen\b\s*/gi;
+
+interface ToolMention {
+  re: RegExp;
+  tool: ToolChoice;
+}
+
+// Ordered; the FIRST pattern that matches a clause wins (a clause naming two
+// tools is not a supported phrasing — pick the earliest/most specific). JP
+// tokens match as a plain substring (no word boundary — CJK has none); Latin
+// tokens use \b so e.g. "codex" doesn't fire inside an unrelated longer word.
+const TOOL_MENTIONS: ToolMention[] = [
+  { re: /パープレ(?:キシティ)?|perplexity/i, tool: PERPLEXITY_WEB },
+  { re: /ローカル\s*llm|local\s*llm|ローカル/i, tool: { type: 'local' } },
+  { re: /\bcodex\b/i, tool: { type: 'cli', cli: 'codex' } },
+  { re: /\bgemini\b/i, tool: GEMINI_WEB },
+];
+
+function matchToolMention(clause: string): ToolChoice | undefined {
+  for (const { re, tool } of TOOL_MENTIONS) {
+    if (re.test(clause)) return tool;
+  }
+  return undefined;
+}
+
+/**
+ * Detect a tool-pinned multi-step chain in plain conjunctive text — e.g.
+ * "パープレで論文を集めて、ローカルLLMで要約して、Xに投稿して". Returns null when
+ * fewer than 2 usable clauses result, OR when none of them names a tool (the
+ * narrow trigger condition — see the file comment above). `tool` is set on a
+ * NormalizedStep ONLY when that specific clause matched a mention; the other
+ * clauses stay auto-routed (Phase 1's additive contract: absent tool = today's
+ * exact auto-routing behavior for that step).
+ */
+export function detectToolPinnedSteps(text: string): NormalizedStep[] | null {
+  const clauses = text
+    .split(CLAUSE_BOUNDARY)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 1);
+  if (clauses.length < 2) return null;
+
+  const steps: NormalizedStep[] = clauses.slice(0, HARD_MAX_STEPS).map((instruction) => {
+    const tool = matchToolMention(instruction);
+    const trimmedInstruction = instruction.slice(0, MAX_STEP_INSTRUCTION_CHARS);
+    return tool ? { instruction: trimmedInstruction, tool } : { instruction: trimmedInstruction };
+  });
+
+  const anyToolMatched = steps.some((s) => s.tool !== undefined);
+  if (!anyToolMatched) return null;
+
+  return steps;
 }

--- a/lib/agent-router-scoring.ts
+++ b/lib/agent-router-scoring.ts
@@ -219,9 +219,11 @@ const LABELS: Record<ToolChoice['type'], string> = {
  * confidence (top-two gap), and the full candidate score list for the audit log.
  * Deterministic + offline.
  */
-// Web-capable primaries (the only backends that can fetch live info).
-const GEMINI_WEB: ToolChoice = { type: 'gemini-api' };
-const PERPLEXITY_WEB: ToolChoice = { type: 'perplexity', model: 'sonar-deep-research' };
+// Web-capable primaries (the only backends that can fetch live info). Exported
+// so other NL-facing detectors (e.g. agent-orchestration's tool-mention step
+// detector) reuse the exact same tool literals instead of re-inventing them.
+export const GEMINI_WEB: ToolChoice = { type: 'gemini-api' };
+export const PERPLEXITY_WEB: ToolChoice = { type: 'perplexity', model: 'sonar-deep-research' };
 
 export function scoreRoutes(prompt: string): ScoredRoute {
   const signals = detectRouteSignals(prompt);

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -214,6 +214,8 @@ const en: Record<string, string> = {
   'agentcard.action_intent': 'App / Share',
   'agentcard.action_dm-reply': 'DM reply',
   'agentcard.action_app-act': 'App action',
+  'agentcard.appact_x_warning': 'This will auto-post the run result to X (Twitter) every time this agent runs — there is no separate approval prompt at run time, so review carefully before confirming.',
+  'agentcard.appact_generic_warning': 'This will drive another app automatically every time this agent runs — there is no separate approval prompt at run time, so review carefully before confirming.',
   'agentcard.dmreply_pairing_label': 'Paired conversation',
   'agentcard.dmreply_no_pairings': 'Pair a conversation in Settings first.',
   'agentcard.dmreply_text_label': 'Reply text',

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -214,6 +214,8 @@ const ja: Record<string, string> = {
   'agentcard.action_intent': 'アプリ起動・共有',
   'agentcard.action_dm-reply': 'DM返信',
   'agentcard.action_app-act': 'アプリ操作',
+  'agentcard.appact_x_warning': 'このエージェントは実行のたびに結果をXへ自動投稿します。実行時に個別の確認は挟まれないため、登録前によく確認してください。',
+  'agentcard.appact_generic_warning': 'このエージェントは実行のたびに他のアプリを自動操作します。実行時に個別の確認は挟まれないため、登録前によく確認してください。',
   'agentcard.dmreply_pairing_label': 'ペアリング済みの会話',
   'agentcard.dmreply_no_pairings': '先に設定から会話をペアリングしてください。',
   'agentcard.dmreply_text_label': '返信テキスト',


### PR DESCRIPTION
## Summary
Phase 6 of the app-act (X-posting) delivery series. Wires the natural-language parsing side so a prompt like "パープレでSTEAM教育×AIの最新論文を集めて、ローカルLLMで日本語要約と自分の見解とリンクを付けて、Xに自動投稿して" produces a real scheduled multi-step agent:

- \`detectAction()\` now returns a real \`{ type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } }\` for X-posting phrasing, closing the gap Phase 0's caveat covered. LINE-posting keeps the draft+caveat fallback (scaffolded native recipe, but NL detection/dispatch for LINE is out of scope this phase) — narrowed so it doesn't collide with the existing \`LINEで知らせて\` → \`notify\` path.
- New \`detectToolPinnedSteps()\` in \`lib/agent-orchestration.ts\`: splits a plain て-form/comma-delimited chain into steps and pins a step's tool ONLY when its own clause names a provider (Perplexity/ローカルLLM/Codex/Gemini) — deliberately narrower than widening the existing sequence-marker splitter, to avoid false-positiving on ordinary prose.
- **Real bug fix found along the way**: \`AgentConfirmCard.tsx\`'s \`handleConfirm\` rebuilt \`action\` from only \`actionType\`, silently dropping \`appActRecipeId\`/\`appActParams\` for app-act agents. Fixed, plus the card now discloses each step's pinned tool before Confirm (security-relevant transparency, since a step can pin \`cli\`/Codex).

## Security self-review
Traced whether NL text pinning a step to \`cli\`/Codex could dodge approval-tiering: no new escalation surface — it routes through the exact same \`resolveAgentRoute\` \`'configured-tool'\` path and \`codexDriverCommand\`'s unconditional \`--approval-policy untrusted --policy-json\` gate that a top-level tool pin already uses (and top-level NL-driven \`cli\` pinning is already reachable today via \`suggestTool\`'s keyword matching). Phase 6 extends the same identically-gated mechanism to per-step granularity.

## Test plan
- [x] 159/159 relevant tests pass (\`agent-nl-parser\`, \`agent-orchestration\`, \`AgentConfirmCard\`, \`agent-router-scoring\`), including the literal target scenario (JP + EN) and regression guards for ordinary て-form prose with no tool mention
- [x] \`npx tsc --noEmit\` clean
- [x] Confirmed no forbidden files touched (\`lib/agent-executor.ts\`, \`scripts/shelly-plan-executor.js\`, \`app/_layout.tsx\`, \`lib/agent-plan-spec.ts\` — Phase 4's territory)