### PR TITLE
feat(agent): wire app-act dispatch end-to-end (sh + PlanSpec + RN bridge)

### DIFF
--- a/__tests__/agent-action-app-act-schema.test.ts
+++ b/__tests__/agent-action-app-act-schema.test.ts
@@ -1,10 +1,12 @@
 jest.mock('@/lib/home-path', () => ({ getHomePath: () => '/home/shelly-test' }));
 
-// Phase 2 of the app-act rollout: schema + secret-scan coverage ONLY.
-// No dispatch/execution logic exists for 'app-act' yet — see
-// lib/agent-plan-spec.ts toPlanAction's default branch and
-// scripts/shelly-plan-executor.js's `action.type === 'unsupported'` refusal,
-// both asserted below as the inertness guarantee.
+// Phase 2 of the app-act rollout: schema + secret-scan coverage. Phase 4
+// (see __tests__/agent-executor-app-act-action.test.ts) added the real
+// dispatch path (lib/agent-executor.ts's app-act) case, agent-plan-spec.ts's
+// toPlanAction 'app-act' case, scripts/shelly-plan-executor.js's app-act
+// branch) — the former "PlanSpec builder refuses app-act as unsupported"
+// inertness assertion below was updated accordingly; it now asserts the
+// opposite (a real, non-'unsupported' PlanSpec action).
 
 import { generateRunScript } from '@/lib/agent-executor';
 import { resolveAgentRoute } from '@/lib/agent-tool-router';
@@ -86,15 +88,20 @@ describe('app-act action schema (Phase 2 — schema only, no dispatch)', () => {
     expect(script).toContain('Produce exactly the content needed for the requested app action.');
   });
 
-  it('is inert: PlanSpec builder refuses app-act as unsupported (fail closed, not a silent draft fallback)', () => {
+  // Phase 4: app-act is now a real PlanSpec action (see
+  // __tests__/agent-executor-app-act-action.test.ts for full dispatch
+  // coverage) — this supersedes the old "refuses as unsupported" inertness
+  // guarantee from Phase 2.
+  it('is real: PlanSpec builder threads app-act through to a genuine action, not the unsupported fallback', () => {
     const action: AgentAction = {
       type: 'app-act',
       appActRecipeId: 'x.post',
       appActParams: { text: '{{result}}' },
     };
     const spec = buildAgentPlanSpec(agent(action));
-    expect(spec.action.type).toBe('unsupported');
-    expect((spec.action as { unsupportedReason?: string }).unsupportedReason).toContain('app-act');
+    expect(spec.action.type).toBe('app-act');
+    expect((spec.action as { appActRecipeId?: string }).appActRecipeId).toBe('x.post');
+    expect((spec.action as { appActParams?: Record<string, string> }).appActParams).toEqual({ text: '{{result}}' });
   });
 });
 

--- a/__tests__/agent-executor-app-act-action.test.ts
+++ b/__tests__/agent-executor-app-act-action.test.ts
@@ -1,0 +1,173 @@
+jest.mock('@/lib/home-path', () => ({
+  getHomePath: () => '/home/shelly-test',
+}));
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { generateRunScript } from '@/lib/agent-executor';
+import { fireReviewedAgentAppAct, parseAppActParamsResolved } from '@/lib/agent-app-act-review';
+import { Agent } from '@/store/types';
+
+/** bash -n the script via a temp FILE (a full script exceeds the Windows argv limit for `-c`). */
+function bashParses(script: string): void {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'appact-parse-')), 'run.sh');
+  fs.writeFileSync(file, script);
+  execFileSync('bash', ['-n', file]);
+}
+
+const agent = (action: Agent['action']): Agent => ({
+  id: 't',
+  name: 'T',
+  description: '',
+  prompt: 'hi',
+  schedule: null,
+  tool: { type: 'local' },
+  outputPath: '~/out',
+  outputTemplate: null,
+  enabled: true,
+  lastRun: null,
+  lastResult: null,
+  createdAt: 0,
+  version: 1,
+  action,
+});
+
+// Phase 4: real .sh executor support for the 'app-act' agent action. The
+// actual side effect (AppActExecutor driving ShellyAccessibilityService)
+// happens natively in RN (fireAgentAppAct) at the moment the human taps
+// Allow -- BEFORE the accept reply is written. This case only requests
+// approval, waits, and reports; it must never call a broker/native function
+// after approval (mirrors intent/dm-reply's existing invariant).
+describe('generateRunScript — app-act action', () => {
+  const s = generateRunScript(agent({ type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } }));
+
+  it('threads ACTION_TYPE and the app-act variables through, correctly quoted', () => {
+    expect(s).toContain("ACTION_TYPE='app-act'");
+    expect(s).toContain("ACTION_APP_ACT_RECIPE_ID='x.post'");
+    expect(s).toContain('ACTION_APP_ACT_PARAMS_JSON=');
+    expect(s).toContain('{{result}}');
+  });
+
+  it('rejects autonomous/unattended execution before requesting attended Review approval', () => {
+    const appActCase = s.slice(s.indexOf('\n    app-act)'), s.indexOf('\n    *)', s.indexOf('\n    app-act)')));
+    expect(appActCase).toContain('[ "${AGENT_AUTONOMOUS:-0}" = "1" ]');
+    expect(appActCase).toContain('[ "${SHELLY_RUN_UNATTENDED:-0}" = "1" ]');
+    expect(appActCase).toContain('App-action actions require an attended Review.');
+    expect(appActCase).toContain('write_action_approval_request "app-act" "$preview" "$result_file"');
+    expect(appActCase).toContain('wait_action_approval "app-act" || return 1');
+    expect(appActCase.indexOf('AGENT_AUTONOMOUS')).toBeLessThan(appActCase.indexOf('write_action_approval_request'));
+    // No broker/native dispatch call after approval — the side effect already
+    // happens natively (fireAgentAppAct) before the accept reply is written.
+    expect(appActCase).not.toContain('cap_workspace_exec');
+    expect(appActCase).not.toContain('http_post_json');
+  });
+
+  it('validates recipe id and params before requesting approval', () => {
+    const missingRecipe = generateRunScript(agent({ type: 'app-act', appActParams: { text: 'hi' } }));
+    expect(missingRecipe).toContain('App-action is missing a recipe.');
+    const missingParams = generateRunScript(agent({ type: 'app-act', appActRecipeId: 'x.post' }));
+    expect(missingParams).toContain('App-action is missing its recipe parameters.');
+  });
+
+  it('emits parseable shell', () => {
+    expect(() => bashParses(s)).not.toThrow();
+  });
+});
+
+describe('generateRunScript — app-act redaction before {{result}} substitution', () => {
+  it('bakes resolve_app_act_params, which redacts a SECOND time after substituting {{result}}', () => {
+    const s = generateRunScript(agent({
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: 'Posting: {{result}}' },
+    }));
+    // The resolver function exists and is called from write_action_approval_request
+    // with the already-redacted $preview, then redacts the resolved JSON again
+    // (defense-in-depth) before it reaches the approval-request preview.
+    expect(s).toContain('resolve_app_act_params()');
+    expect(s).toContain('v.split(\'{{result}}\').join(preview)');
+    expect(s).toContain('redact_secrets_text "$tmp_resolved"');
+    expect(s).toContain('app_act_params_resolved=$(resolve_app_act_params "$ACTION_APP_ACT_PARAMS_JSON" "$preview")');
+    expect(s).toContain('app_act_params_resolved_json=$(json_escape_text "$app_act_params_resolved")');
+    expect(s).toContain('"appActRecipeId":"$app_act_recipe_id_json","appActParamsResolved":"$app_act_params_resolved_json"');
+  });
+
+  it('never bypasses redaction by inlining a raw {{result}} substitution outside resolve_app_act_params', () => {
+    const s = generateRunScript(agent({
+      type: 'app-act',
+      appActRecipeId: 'x.post',
+      appActParams: { text: 'leaking: {{result}}' },
+    }));
+    // Unlike ACTION_INTENT_SHARE_TEXT/ACTION_DM_REPLY_TEXT (which substitute
+    // {{result}} inline against the already-redacted $preview with no second
+    // pass), app-act's resolution always routes through resolve_app_act_params
+    // — this is the non-negotiable extra redaction pass for the first action
+    // type that can publish externally.
+    expect(s).not.toMatch(/ACTION_APP_ACT_PARAMS_JSON\/\/\\\{\\\{result\\\}\\\}/);
+  });
+});
+
+describe('fireReviewedAgentAppAct — mocked native bridge (accept/decline/throw paths)', () => {
+  it('fires the recipe with the resolved params during Review acceptance', async () => {
+    const request = {
+      appActRecipeId: 'x.post',
+      appActParamsResolved: JSON.stringify({ text: 'Hello world' }),
+    };
+    const events: string[] = [];
+    const fireAgentAppAct = jest.fn(async (recipeId: string, params: Record<string, string>) => {
+      events.push(`fire:${recipeId}:${JSON.stringify(params)}`);
+    });
+
+    await fireReviewedAgentAppAct(request, fireAgentAppAct);
+
+    expect(fireAgentAppAct).toHaveBeenCalledWith('x.post', { text: 'Hello world' });
+    expect(events).toEqual(['fire:x.post:{"text":"Hello world"}']);
+  });
+
+  it('propagates a native throw so the caller can resolve the approval as declined (fail-closed)', async () => {
+    const request = {
+      appActRecipeId: 'x.post',
+      appActParamsResolved: JSON.stringify({ text: 'Hello world' }),
+    };
+    const fireAgentAppAct = jest.fn(async () => {
+      throw new Error('Accessibility Service is not enabled/connected');
+    });
+
+    await expect(fireReviewedAgentAppAct(request, fireAgentAppAct)).rejects.toThrow(
+      'Accessibility Service is not enabled/connected',
+    );
+  });
+
+  it('fails closed to an empty param map on malformed appActParamsResolved JSON, never throwing itself', async () => {
+    const request = { appActRecipeId: 'x.post', appActParamsResolved: 'not json{{{' };
+    const fireAgentAppAct = jest.fn(async () => undefined);
+
+    await fireReviewedAgentAppAct(request, fireAgentAppAct);
+
+    expect(fireAgentAppAct).toHaveBeenCalledWith('x.post', {});
+  });
+});
+
+describe('parseAppActParamsResolved', () => {
+  it('parses a valid resolved-params JSON object', () => {
+    expect(parseAppActParamsResolved('{"text":"hi","other":"x"}')).toEqual({ text: 'hi', other: 'x' });
+  });
+
+  it('returns {} for null/undefined/empty input', () => {
+    expect(parseAppActParamsResolved(null)).toEqual({});
+    expect(parseAppActParamsResolved(undefined)).toEqual({});
+    expect(parseAppActParamsResolved('')).toEqual({});
+  });
+
+  it('returns {} for a JSON array or a JSON primitive (not a plain object)', () => {
+    expect(parseAppActParamsResolved('["a","b"]')).toEqual({});
+    expect(parseAppActParamsResolved('"just a string"')).toEqual({});
+    expect(parseAppActParamsResolved('42')).toEqual({});
+  });
+
+  it('drops non-string values from an otherwise valid object', () => {
+    expect(parseAppActParamsResolved('{"text":"hi","count":3,"nested":{"a":1}}')).toEqual({ text: 'hi' });
+  });
+});

--- a/__tests__/agent-executor-autonomous.test.ts
+++ b/__tests__/agent-executor-autonomous.test.ts
@@ -465,7 +465,7 @@ describe('generateRunScript — orchestration suppressAction (Phase 4)', () => {
 describe('generateRunScript — autonomous tool resolution (Spec A §4/§5)', () => {
   it('resolves autonomous auto → codex (OAuth), key-free env', () => {
     const s = generateRunScript(agent({ type: 'auto' }, true));
-    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=10');
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=11');
     expect(s).toContain('.shelly-agent-driver.js'); // resolved to cli/codex via the approval driver
     expect(s).toContain('--prompt-file "$PROMPT_FILE"');
     expect(s).toContain('if node_usable && [ -f "$HOME/.shelly-agent-driver.js" ]; then');

--- a/__tests__/agent-executor-cap-broker.test.ts
+++ b/__tests__/agent-executor-cap-broker.test.ts
@@ -63,7 +63,7 @@ describe('capability broker wiring — http_post_json seam (CAP/HTTP/SECRET-001)
   });
 
   it('bumps the script version in lockstep with the native gate', () => {
-    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=10');
+    expect(s).toContain('SHELLY_AGENT_SCRIPT_VERSION=11');
   });
 });
 

--- a/__tests__/plan-executor-parity.test.ts
+++ b/__tests__/plan-executor-parity.test.ts
@@ -137,4 +137,25 @@ describe('shelly-plan-executor.js parity', () => {
     expect(executorSrc).toContain("tainted: process.env.SHELLY_CAP_TAINTED === '1'");
     expect(executorSrc).toContain("if (opts.tainted) args.push('--tainted', '1');");
   });
+
+  it('wires app-act into the PlanSpec executor path (Phase 4), not just the legacy .sh path', () => {
+    const executorSrc = fs.readFileSync(scriptCopy, 'utf8');
+    // Native gate: AgentRuntime.kt must allow 'app-act' through
+    // PLAN_EXECUTOR_ACTIONS or every PlanSpec-routed app-act run is refused
+    // before the executor ever launches.
+    expect(agentRuntime).toContain('PLAN_EXECUTOR_ACTIONS = setOf("draft", "notify", "webhook", "cli", "intent", "dm-reply", "app-act", "__suppressed__")');
+    // Executor: dispatchActionTrusted must accept 'app-act' and resolve+redact
+    // its params (mirrors the legacy .sh's resolve_app_act_params) before they
+    // reach the approval-request preview shown to the human.
+    expect(executorSrc).toContain("actionType !== 'app-act'");
+    expect(executorSrc).toContain('function resolveAppActParams(params, preview)');
+    expect(executorSrc).toContain("v.split('{{result}}').join(preview)");
+    expect(executorSrc).toContain('appActRecipeId: extra.appActRecipeId');
+    expect(executorSrc).toContain('appActParamsResolved: extra.appActParamsResolved');
+    // unattendedPreflightFailure only allowlists draft/notify for unattended
+    // runs, so app-act (not added there) is refused-when-unattended by
+    // construction — assert that allowlist stayed narrow rather than widening
+    // to accidentally include app-act.
+    expect(executorSrc).toMatch(/if \(actionType !== 'draft' && actionType !== 'notify'\) \{/);
+  });
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -40,6 +40,7 @@ import { execCommand } from '@/hooks/use-native-exec';
 import { useTelegramInbound } from '@/hooks/use-telegram-inbound';
 import TerminalEmulator from '@/modules/terminal-emulator/src/TerminalEmulatorModule';
 import { fireReviewedAgentIntent } from '@/lib/agent-intent-review';
+import { fireReviewedAgentAppAct, parseAppActParamsResolved } from '@/lib/agent-app-act-review';
 
 export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   logError('ErrorBoundary', 'Uncaught error', error);
@@ -106,7 +107,7 @@ type AgentActionApprovalRequest = {
   agentId: string;
   agentName?: string | null;
   toolLabel?: string | null;
-  actionType: 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply';
+  actionType: 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply' | 'app-act';
   preview?: string | null;
   destinationHost?: string | null;
   command?: string | null;
@@ -123,8 +124,25 @@ type AgentActionApprovalRequest = {
   dmPairingId?: string | null;
   dmPairingLabel?: string | null;
   dmReplyText?: string | null;
+  appActRecipeId?: string | null;
+  appActParamsResolved?: string | null;
   actionNonce?: string | null;
 };
+
+/** Renders the FULLY resolved (post-{{result}}-substitution, post-redaction)
+ *  app-act params for the Review card -- same bar as intentShareText. Prefers
+ *  a `text` param (the shape every bundled recipe's primary content field
+ *  uses, e.g. x.post) so the common case shows just the post body; falls back
+ *  to a compact "key: value" listing for a multi-param recipe (e.g.
+ *  line.send-message's contact + message) so nothing resolved is hidden from
+ *  the user before they can Accept. */
+function appActParamsPreviewText(paramsResolved: string | null | undefined): string {
+  const params = parseAppActParamsResolved(paramsResolved);
+  const keys = Object.keys(params);
+  if (keys.length === 0) return '';
+  if (typeof params.text === 'string') return params.text;
+  return keys.map((key) => `${key}: ${params[key]}`).join('\n');
+}
 
 export default function RootLayout() {
   const [fontsLoaded] = useFonts({
@@ -181,6 +199,29 @@ export default function RootLayout() {
         setPendingAgentActionApproval(null);
         setAgentActionResolving(false);
         Alert.alert(t('agent_action_confirm_intent_failed'));
+        return;
+      }
+    }
+    if (decision === 'accept' && request.actionType === 'app-act') {
+      if (!TerminalEmulator.fireAgentAppAct) {
+        Alert.alert(t('agent_action_confirm_not_ready'));
+        setAgentActionResolving(false);
+        return;
+      }
+      try {
+        await fireReviewedAgentAppAct(request, TerminalEmulator.fireAgentAppAct);
+      } catch (e) {
+        // Mirrors fireAgentIntent's catch above: a native AppActExecutor
+        // failure message can echo on-screen UI text (diagnoseCurrentScreen)
+        // -- log only the error class/type, never e.message/e itself.
+        const errorKind = (e as { constructor?: { name?: string } } | undefined)?.constructor?.name ?? 'UnknownError';
+        logError('AgentActionApproval', `fireAgentAppAct failed: ${errorKind}`);
+        // Fail closed: tell the waiting executor "declined" rather than
+        // leaving it to time out after a failed/partial post attempt.
+        await TerminalEmulator.resolveAgentActionApproval?.(request.runId, 'decline', requestSha256, actionNonce).catch(() => undefined);
+        setPendingAgentActionApproval(null);
+        setAgentActionResolving(false);
+        Alert.alert(t('agent_action_confirm_appact_failed'));
         return;
       }
     }
@@ -789,7 +830,8 @@ export default function RootLayout() {
         actionType !== 'webhook' &&
         actionType !== 'cli' &&
         actionType !== 'intent' &&
-        actionType !== 'dm-reply'
+        actionType !== 'dm-reply' &&
+        actionType !== 'app-act'
       ) {
         return null;
       }
@@ -821,6 +863,8 @@ export default function RootLayout() {
         dmPairingId: str('dmPairingId') || null,
         dmPairingLabel: str('dmPairingLabel') || null,
         dmReplyText: typeof value.dmReplyText === 'string' ? value.dmReplyText : null,
+        appActRecipeId: str('appActRecipeId') || null,
+        appActParamsResolved: typeof value.appActParamsResolved === 'string' ? value.appActParamsResolved : null,
         // Only ever populated by the native readAgentActionApprovalRequest
         // round trip (freshly minted per read). The raw-JSON fallback path
         // and the notify-only poll loop below never set it, and must not --
@@ -850,6 +894,8 @@ export default function RootLayout() {
       dmPairingId: request.dmPairingId,
       dmPairingLabel: request.dmPairingLabel,
       dmReplyText: request.dmReplyText,
+      appActRecipeId: request.appActRecipeId,
+      appActParamsResolved: request.appActParamsResolved,
     });
 
     const getActionApprovalRequestDirUri = async () => {
@@ -1538,6 +1584,8 @@ export default function RootLayout() {
                   ? t('agent_action_confirm_title_intent')
                   : pendingAgentActionApproval.actionType === 'dm-reply'
                     ? t('agent_action_confirm_title_dmreply')
+                  : pendingAgentActionApproval.actionType === 'app-act'
+                    ? t('agent_action_confirm_title_appact')
                   : t('agent_action_confirm_title')}
               </Text>
               <Text style={actionApprovalStyles.body}>
@@ -1545,6 +1593,8 @@ export default function RootLayout() {
                   ? t('agent_action_confirm_body_intent')
                   : pendingAgentActionApproval.actionType === 'dm-reply'
                     ? t('agent_action_confirm_body_dmreply')
+                  : pendingAgentActionApproval.actionType === 'app-act'
+                    ? t('agent_action_confirm_body_appact')
                   : t('agent_action_confirm_body')}
               </Text>
               {pendingAgentActionApproval.actionType === 'intent' ? (
@@ -1584,6 +1634,23 @@ export default function RootLayout() {
                   <ScrollView style={actionApprovalStyles.commandBox}>
                     <Text selectable style={actionApprovalStyles.commandText}>
                       {pendingAgentActionApproval.dmReplyText || ''}
+                    </Text>
+                  </ScrollView>
+                </>
+              ) : pendingAgentActionApproval.actionType === 'app-act' ? (
+                <>
+                  <Text style={actionApprovalStyles.label}>
+                    {t('agent_action_confirm_appact_recipe')}
+                  </Text>
+                  <Text style={actionApprovalStyles.meta}>
+                    {pendingAgentActionApproval.appActRecipeId || ''}
+                  </Text>
+                  <Text style={actionApprovalStyles.label}>
+                    {t('agent_action_confirm_appact_preview')}
+                  </Text>
+                  <ScrollView style={actionApprovalStyles.commandBox}>
+                    <Text selectable style={actionApprovalStyles.commandText}>
+                      {appActParamsPreviewText(pendingAgentActionApproval.appActParamsResolved)}
                     </Text>
                   </ScrollView>
                 </>

--- a/docs/superpowers/DEFERRED.md
+++ b/docs/superpowers/DEFERRED.md
@@ -1140,6 +1140,44 @@ coreutils: /sdcard/Download/patch-codex.sh: Permission denied
 
 ## P1 — v0.1.1 で対応推奨
 
+### app-act (Phase 5) — Tier-B unattended dispatch がまだ実装されていない
+
+**発見**: 2026-07-14 Phase 4 (app-act delivery wiring) 実装中。
+
+**状態**: `store/types.ts` の `AgentActionType`/`AgentAction` doc comment は
+app-act を「Tier-B・unattended/autonomous 実行可能」（recipe+target+params が
+登録時に一度だけ fix され、intent/dm-reply のような実行時ターゲット解決が
+ない）と明記しているが、これは最終形の設計意図であり、Phase 4 時点の実装は
+まだそこに到達していない。`lib/agent-executor.ts` の `app-act)` ケースと
+`scripts/shelly-plan-executor.js`（および APK asset mirror）の app-act
+分岐は、`AGENT_AUTONOMOUS=1` / `SHELLY_RUN_UNATTENDED=1` を intent/dm-reply
+と同じ形で拒否している（`unattendedPreflightFailure` も draft/notify のみを
+許可、app-act は追加していない）。つまり app-act は現状 **attended Review
+必須**で、無人（スケジュール）実行では常に拒否される。
+
+**戻す条件**:
+1. `AGENT_AUTONOMOUS`/`SHELLY_RUN_UNATTENDED` ゲートを外し、Tier-B の
+   unattended 実行パスを設計する（native 側で recipe+params が登録時の
+   ものと変わっていないことを検証する仕組みを含む）。
+2. `write_action_approval_request`/`requestActionApproval` の
+   unattended 経路（`trustedNativeLowRiskAction` 相当）に app-act 用の
+   trust 判定を追加する。
+3. native 側 `fireAgentAppAct` を accept 前に呼ぶ現行の「RN が承認後に
+   native を叩く」不変条件を、unattended 経路でも同等に安全な形（例:
+   native 側で直接 AppActExecutor を呼ぶが、登録時に固定された
+   recipe/params のみを許可する）に置き換える。
+
+**Why not now**: このリリースは「app-act を初めて実際に発火させる」段階の
+配線タスクであり、スコープを配線のみに絞るために意図的に Tier-B unattended
+bypass を除外した。既存 (`store/types.ts`) の doc comment を読んだ将来の
+開発者が「intent/dm-reply と同じ拒否ゲートがあるのは矛盾/バグでは」と
+誤読しないよう、ここに正式に記録する。
+
+**優先度**: P1（Phase 5 で対応予定。attended Review のみでも app-act 自体は
+機能するため release blocker ではない）
+
+---
+
 ### MEMORY-001 — 保存時暗号化・一般 PII/taint 分類がない
 
 **発見**: 2026-07-13 Batch 11 の MEMORY-001 移植時に、source design の既知制限を再確認。
@@ -2136,6 +2174,7 @@ claude() {
 
 ## History
 
+- **2026-07-14（app-act Phase 4 配線）**: `lib/agent-executor.ts`/`scripts/shelly-plan-executor.js`（+APK asset mirror）/`lib/agent-plan-spec.ts` に app-act の実 dispatch を実装し、native `fireAgentAppAct`（`TerminalEmulatorModule.kt`、`AppActExecutor.execute` を汎用 recipe id + param map で包む）と `app/_layout.tsx` の Review カード（「投稿内容プレビュー」表示、accept 時 native 呼び出し→native throw で decline に fail-closed）を配線した。Tier-B unattended dispatch は意図的に今回のスコープ外とし、上記 P1 entry「app-act (Phase 5) — Tier-B unattended dispatch がまだ実装されていない」に記録。実装中に `NotificationDispatcher.kt` の system 通知 one-tap Allow ボタンが（cli/intent/dm-reply 同様に除外していなければ）native `fireAgentAppAct` を経由せず `AgentActionApprovalBridge.writeHumanReply` を直接叩いてしまい、投稿内容を人間がレビューする前に承認が成立してしまう既存構造上のリスクを発見・修正（app-act を review-required バケットに追加）。
 - **2026-07-14（PR #125 実機検証）**: approval-bridge nonce 硬化（PR #125）の実機検証中、`cli` action の単発実行で自動的にエスカレーションラダー（`runLadderAttempts`）が2回目の承認リクエストを人間に出す挙動を発見。ソース追跡で今夜のマージが原因ではない既存の意図された仕様と切り分け（`### 自律エージェント制御面レビュー` に追記）。nonce 硬化自体は2回の独立した承認サイクルで Allow が正しく通ったことで検証成立と判断。
 - **2026-07-13 (agent action system prompts)**: 実機の通知トリガー agent（`action: draft`）が、要求された短文そのものではなく解釈のメタ説明を生成した不具合を修正。`draft` / `notify` / `webhook` / `cli` / `intent` / `dm-reply` ごとの出力契約を `lib/agent-executor.ts` に追加し、local・Perplexity・Cerebras・Groq・Gemini（native `systemInstruction`）・A/B article eval の全 JSON request に配線した。明示された長さ・形式・トーンを常に優先し、未指定時だけ直接的・簡潔にする。生成スクリプト assertion、provider shell parse、TypeScript、Expo lint、`git diff --check` を確認。`agent-executor.ts` はスクリプトを inline 生成し、対応する Android asset mirror は存在しないため mirror 更新なし。→ sync: なし（内部生成品質の修正）。
 

--- a/lib/agent-app-act-review.ts
+++ b/lib/agent-app-act-review.ts
@@ -1,0 +1,43 @@
+export type ReviewedAgentAppAct = {
+  appActRecipeId?: string | null;
+  /** JSON-encoded Record<string, string> — already {{result}}-resolved and
+   *  redacted by the executor (write_action_approval_request /
+   *  requestActionApproval) before this request ever reached RN. */
+  appActParamsResolved?: string | null;
+};
+
+export type FireAgentAppAct = (
+  recipeId: string,
+  params: Record<string, string>,
+) => Promise<void>;
+
+/** Parses the JSON-encoded resolved params carried on the approval request.
+ *  Returns {} (never throws) on malformed/absent JSON — fireReviewedAgentAppAct
+ *  then calls fireAgentAppAct with an empty param map, which the native side
+ *  and/or the recipe's own required-param check fails closed on, rather than
+ *  this helper silently swallowing a parse failure into "nothing to post". */
+export function parseAppActParamsResolved(raw: string | null | undefined): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === 'string') out[key] = value;
+    }
+    return out;
+  } catch (_e) {
+    return {};
+  }
+}
+
+/** Fires the native side effect only from the human Review accept path
+ *  (mirrors lib/agent-intent-review.ts's fireReviewedAgentIntent exactly). */
+export async function fireReviewedAgentAppAct(
+  request: ReviewedAgentAppAct,
+  fireAgentAppAct: FireAgentAppAct,
+): Promise<void> {
+  const recipeId = (request.appActRecipeId ?? '').trim();
+  const params = parseAppActParamsResolved(request.appActParamsResolved);
+  await fireAgentAppAct(recipeId, params);
+}

--- a/lib/agent-executor.ts
+++ b/lib/agent-executor.ts
@@ -13,7 +13,7 @@ import { buildAgentPolicy } from './agent-policy';
 const MAX_CONCURRENT = 2;
 
 const DEFAULT_TIMEOUT_SEC = 600; // 10 minutes
-const AGENT_SCRIPT_VERSION = 10;
+const AGENT_SCRIPT_VERSION = 11;
 const LOCAL_MODEL_LIGHT = 'Qwen3.5-0.8B-Q4_K_M';
 const LOCAL_MODEL_BALANCED = 'Qwen3.5-2B-Q4_K_M';
 const LOCAL_MODEL_QUALITY = 'Qwen3.5-4B-Q4_K_M';
@@ -33,8 +33,8 @@ const ACTION_OUTPUT_INSTRUCTIONS: Record<AgentActionType, string> = {
   cli: 'Produce exactly the content needed by the requested command or command workflow.',
   intent: 'Produce exactly the text or content needed for the requested app or share action.',
   'dm-reply': 'Write the reply message itself as a natural, short conversational response unless explicit user instructions request otherwise.',
-  // Schema only (Phase 2 of the app-act rollout) — no dispatch path reads this
-  // yet; see agent-plan-spec.ts toPlanAction's default 'unsupported' branch.
+  // Phase 4: real dispatch path, see dispatch_agent_action's app-act) case
+  // below and agent-plan-spec.ts toPlanAction's 'app-act' case.
   'app-act': 'Produce exactly the content needed for the requested app action.',
 };
 const ACTION_OUTPUT_RULES = 'Follow explicit user instructions for content, format, length, and tone. When they are not specified, be direct and concise. Output only the requested deliverable. Never add meta-commentary about your reasoning or interpretation of the request.';
@@ -230,6 +230,15 @@ export function generateRunScript(agent: Agent, opts: { suppressAction?: boolean
   const actionIntentShareText = actionType === 'intent' ? (agent.action?.intentShareText ?? '') : '';
   const actionDmPairingId = actionType === 'dm-reply' ? agent.action?.dmPairingId ?? '' : '';
   const actionDmReplyText = actionType === 'dm-reply' ? agent.action?.dmReplyText ?? '' : '';
+  const actionAppActRecipeId = actionType === 'app-act' ? (agent.action?.appActRecipeId ?? '') : '';
+  // Baked as a JSON string constant (params may carry the literal "{{result}}"
+  // placeholder in any value, same convention as intentShareText/dmReplyText).
+  // Resolved against the redacted run preview, and redacted a second time as
+  // defense-in-depth, entirely at RUNTIME in the shell (resolve_app_act_params) —
+  // this is the first agent action type that reaches a real external-posting
+  // surface, so it gets an extra redaction pass beyond relying solely on the
+  // preview already being clean.
+  const actionAppActParamsJson = actionType === 'app-act' ? JSON.stringify(agent.action?.appActParams ?? {}) : '{}';
   const actionCommandSafety = evaluateAgentActionCommand(actionCommand);
 
   // North Star fix: a web-research / collection agent otherwise receives the bare
@@ -347,6 +356,8 @@ ACTION_INTENT_SHARE_TEXT=${shellQuote(actionIntentShareText)}
 ACTION_DM_PAIRING_ID=${shellQuote(actionDmPairingId)}
 ACTION_DM_REPLY_TEXT=${shellQuote(actionDmReplyText)}
 ACTION_DM_PAIRING_LABEL=""
+ACTION_APP_ACT_RECIPE_ID=${shellQuote(actionAppActRecipeId)}
+ACTION_APP_ACT_PARAMS_JSON=${shellQuote(actionAppActParamsJson)}
 ACTION_COMMAND_SAFETY_LEVEL=${shellQuote(actionCommandSafety.level)}
 ACTION_COMMAND_SAFETY_REASON=${shellQuote(actionCommandSafety.reason)}
 ACTION_COMMAND_AUTO_APPROVABLE=${actionCommandSafety.autoApprovable ? '1' : '0'}
@@ -584,6 +595,48 @@ NODEEOF
     "$file" 2>/dev/null || cat "$file" 2>/dev/null || true
 }
 
+# app-act (Phase 4): resolves the literal "{{result}}" placeholder in every
+# value of $1 (a JSON object string, e.g. '{"text":"Check this: {{result}}"}')
+# against $2 (the already-redacted run preview — see clean_result_preview),
+# then runs redact_secrets_text over the resolved JSON a SECOND time as
+# defense-in-depth. $preview is already redacted by the time it reaches here,
+# so this second pass is a deliberate belt-and-suspenders for the first agent
+# action type that can publish content externally (a leaked secret in a
+# public X post is categorically worse than one in a private draft/notify) —
+# not evidence the first pass is believed to be insufficient. Falls back to
+# an empty object on any parse/exec failure (fail-closed: an app-act with no
+# resolvable params fails its own presence check in dispatch_agent_action
+# rather than firing with stale/unresolved "{{result}}" text).
+resolve_app_act_params() {
+  params_json="$1"
+  preview="$2"
+  tmp_in="$TMP_DIR/app-act-params-$AGENT_ID-$$.json"
+  tmp_resolved="$TMP_DIR/app-act-params-resolved-$AGENT_ID-$$.json"
+  printf '%s' "$params_json" > "$tmp_in"
+  : > "$tmp_resolved"
+  if node_usable; then
+    SHELLY_APP_ACT_PREVIEW="$preview" shelly_node - "$tmp_in" <<'NODEEOF' > "$tmp_resolved" 2>/dev/null
+const fs = require('fs');
+const file = process.argv[2];
+const preview = process.env.SHELLY_APP_ACT_PREVIEW || '';
+let params = {};
+try { params = JSON.parse(fs.readFileSync(file, 'utf8')); } catch (_) { params = {}; }
+const out = {};
+if (params && typeof params === 'object' && !Array.isArray(params)) {
+  for (const [k, v] of Object.entries(params)) {
+    out[k] = typeof v === 'string' ? v.split('{{result}}').join(preview) : '';
+  }
+}
+process.stdout.write(JSON.stringify(out));
+NODEEOF
+  fi
+  if [ ! -s "$tmp_resolved" ]; then
+    printf '{}' > "$tmp_resolved"
+  fi
+  redact_secrets_text "$tmp_resolved"
+  rm -f "$tmp_in" "$tmp_resolved"
+}
+
 # Strip the autonomous driver's structured telemetry (AUDIT/GATE/protocol/STDERR/
 # escalation) from a result file so the user-facing preview shows real content,
 # never the internal driver_start JSON. Backends that write a plain answer
@@ -816,11 +869,24 @@ write_action_approval_request() {
   dm_pairing_id_json=$(json_escape_text "$ACTION_DM_PAIRING_ID")
   dm_pairing_label_json=$(json_escape_text "\${ACTION_DM_PAIRING_LABEL:-}")
   dm_reply_text_json=$(json_escape_text "$dm_reply_text_resolved")
+  # app-act (Phase 4): resolve_app_act_params substitutes {{result}} in every
+  # param value against $preview (already redacted) and redacts the resolved
+  # JSON a second time (defense-in-depth for the first agent action type that
+  # can publish externally). The resolved JSON is embedded as a plain STRING
+  # field (json_escape_text), same shape as intentShareText/dmReplyText, not
+  # a nested object — the approval-request record is a flat string map.
+  app_act_recipe_id_json=$(json_escape_text "$ACTION_APP_ACT_RECIPE_ID")
+  # ACTION_APP_ACT_PARAMS_JSON defaults to '{}' for every non-app-act action
+  # (see actionAppActParamsJson in generateRunScript), so resolving it
+  # unconditionally here is a harmless no-op for those calls -- no need to
+  # branch on $approval_type.
+  app_act_params_resolved=$(resolve_app_act_params "$ACTION_APP_ACT_PARAMS_JSON" "$preview")
+  app_act_params_resolved_json=$(json_escape_text "$app_act_params_resolved")
   ts_seconds=$(date +%s)
   expires_at=$(( (ts_seconds + ACTION_APPROVAL_TIMEOUT_SECONDS) * 1000 ))
   tmp="$ACTION_APPROVAL_REQUEST_FILE.tmp"
   cat > "$tmp" << APPROVALEOF
-{"runId":"$ACTION_RUN_ID","agentId":"$agent_json","agentName":"$agent_name_json","toolLabel":"$tool_label_json","actionType":"$approval_type_json","preview":"$preview_json","destinationHost":"$destination_json","command":"$command_json","safetyLevel":"$safety_level_json","safetyReason":"$safety_reason_json","payloadPath":"$payload_path_json","resultPath":"$result_path_json","intentMode":"$intent_mode_json","intentTarget":"$intent_target_json","intentShareText":"$intent_share_text_json","dmPairingId":"$dm_pairing_id_json","dmPairingLabel":"$dm_pairing_label_json","dmReplyText":"$dm_reply_text_json","ts":"$(date -Iseconds)","expiresAt":$expires_at}
+{"runId":"$ACTION_RUN_ID","agentId":"$agent_json","agentName":"$agent_name_json","toolLabel":"$tool_label_json","actionType":"$approval_type_json","preview":"$preview_json","destinationHost":"$destination_json","command":"$command_json","safetyLevel":"$safety_level_json","safetyReason":"$safety_reason_json","payloadPath":"$payload_path_json","resultPath":"$result_path_json","intentMode":"$intent_mode_json","intentTarget":"$intent_target_json","intentShareText":"$intent_share_text_json","dmPairingId":"$dm_pairing_id_json","dmPairingLabel":"$dm_pairing_label_json","dmReplyText":"$dm_reply_text_json","appActRecipeId":"$app_act_recipe_id_json","appActParamsResolved":"$app_act_params_resolved_json","ts":"$(date -Iseconds)","expiresAt":$expires_at}
 APPROVALEOF
   mv "$tmp" "$ACTION_APPROVAL_REQUEST_FILE"
   ACTION_APPROVAL_REQUEST_SHA256="$(sha256_file "$ACTION_APPROVAL_REQUEST_FILE" || true)"
@@ -1156,6 +1222,45 @@ dispatch_agent_action() {
       # RN sends natively before publishing the accept reply. There is no
       # post-approval broker or shell side effect here.
       ACTION_DISPATCH_MESSAGE="DM reply sent."
+      return 0
+      ;;
+    app-act)
+      # Phase 4: app-act is the first agent action that can publish content to
+      # an external, human-facing surface (e.g. a public X post) rather than a
+      # private draft/notification. store/types.ts documents app-act as
+      # ultimately Tier-B/unattended-capable (its recipe+target+params are
+      # fixed and consented to once at registration time, unlike intent/
+      # dm-reply's runtime-resolved targets) -- but THIS phase deliberately
+      # keeps it behind an attended Review, matching intent/dm-reply's refusal
+      # shape exactly, as an interim conservative default. Do not read this as
+      # an oversight to "fix" by widening it; a later phase revisits the
+      # unattended case explicitly (see docs/superpowers/DEFERRED.md).
+      if [ "\${AGENT_AUTONOMOUS:-0}" = "1" ] || [ "\${SHELLY_RUN_UNATTENDED:-0}" = "1" ]; then
+        ACTION_DISPATCH_STATUS="skipped"
+        ACTION_DISPATCH_MESSAGE="App-action actions require an attended Review."
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
+      if [ -z "$ACTION_APP_ACT_RECIPE_ID" ]; then
+        ACTION_DISPATCH_STATUS="error"
+        ACTION_DISPATCH_MESSAGE="App-action is missing a recipe."
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
+      app_act_params_check=$(resolve_app_act_params "$ACTION_APP_ACT_PARAMS_JSON" "$preview")
+      if [ -z "$app_act_params_check" ] || [ "$app_act_params_check" = "{}" ]; then
+        ACTION_DISPATCH_STATUS="error"
+        ACTION_DISPATCH_MESSAGE="App-action is missing its recipe parameters."
+        write_native_notification_request "error" "$ACTION_DISPATCH_MESSAGE" || true
+        return 1
+      fi
+      write_action_approval_request "app-act" "$preview" "$result_file"
+      wait_action_approval "app-act" || return 1
+      # No broker/native call here (mirrors intent/dm-reply): RN already fired
+      # the recipe NATIVELY (fireAgentAppAct, driving ShellyAccessibilityService
+      # via AppActExecutor) BEFORE writing the accept reply that
+      # wait_action_approval just observed. Nothing left to execute.
+      ACTION_DISPATCH_MESSAGE="App action fired: $ACTION_APP_ACT_RECIPE_ID"
       return 0
       ;;
     *)

--- a/lib/agent-plan-spec.ts
+++ b/lib/agent-plan-spec.ts
@@ -23,7 +23,7 @@ export type PlanToolType =
   | 'groq'
   | 'unsupported';
 
-export type PlanActionType = 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply' | '__suppressed__' | 'unsupported';
+export type PlanActionType = 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply' | 'app-act' | '__suppressed__' | 'unsupported';
 
 export interface AgentPlanSpecV1 {
   kind: typeof PLAN_SPEC_KIND;
@@ -52,6 +52,8 @@ export interface AgentPlanSpecV1 {
     intentShareText?: string;
     dmPairingId?: string;
     dmReplyText?: string;
+    appActRecipeId?: string;
+    appActParams?: Record<string, string>;
     safety?: ReturnType<typeof evaluateAgentActionCommand>;
     unsupportedReason?: string;
   };
@@ -232,6 +234,12 @@ function toPlanAction(
         type: 'dm-reply',
         dmPairingId: action?.dmPairingId,
         dmReplyText: action?.dmReplyText,
+      };
+    case 'app-act':
+      return {
+        type: 'app-act',
+        appActRecipeId: action?.appActRecipeId,
+        appActParams: action?.appActParams,
       };
     default:
       return {

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -1711,6 +1711,11 @@ const en: Record<string, string> = {
   'agent_action_confirm_intent_target': 'Target',
   'agent_action_confirm_intent_share_text': 'Share text',
   'agent_action_confirm_intent_failed': 'Failed to fire the app action. The request was declined.',
+  'agent_action_confirm_title_appact': 'Confirm app action',
+  'agent_action_confirm_body_appact': 'This autonomous agent is requesting to run an app action (e.g. post to another app). Review the exact content before allowing it.',
+  'agent_action_confirm_appact_recipe': 'App action',
+  'agent_action_confirm_appact_preview': 'Content preview',
+  'agent_action_confirm_appact_failed': 'Failed to run the app action. The request was declined.',
 };
 
 export default en;

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -1710,6 +1710,11 @@ const ja: Record<string, string> = {
   'agent_action_confirm_intent_target': '対象',
   'agent_action_confirm_intent_share_text': '共有テキスト',
   'agent_action_confirm_intent_failed': 'アプリ操作の実行に失敗しました。リクエストは拒否されました。',
+  'agent_action_confirm_title_appact': 'アプリ操作の確認',
+  'agent_action_confirm_body_appact': '自律エージェントがアプリ操作（例: 他アプリへの投稿）の実行を要求しています。許可する前に投稿内容プレビューを確認してください。',
+  'agent_action_confirm_appact_recipe': 'アプリ操作',
+  'agent_action_confirm_appact_preview': '投稿内容プレビュー',
+  'agent_action_confirm_appact_failed': 'アプリ操作の実行に失敗しました。リクエストは拒否されました。',
 };
 
 export default ja;

--- a/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
+++ b/modules/terminal-emulator/android/src/main/assets/shelly-plan-executor.js
@@ -89,6 +89,23 @@ function redact(text) {
   return out;
 }
 
+// app-act (Phase 4): resolves the literal "{{result}}" placeholder in every
+// value of `params` against `preview` (already redact()-ed by previewText),
+// then redact()s the resolved values a SECOND time as defense-in-depth --
+// mirrors lib/agent-executor.ts's resolve_app_act_params exactly. This is the
+// first agent action type that can publish content externally (a public X
+// post), so it gets an extra redaction pass beyond relying solely on preview
+// already being clean.
+function resolveAppActParams(params, preview) {
+  const out = {};
+  if (params && typeof params === 'object' && !Array.isArray(params)) {
+    for (const [k, v] of Object.entries(params)) {
+      out[k] = typeof v === 'string' ? redact(v.split('{{result}}').join(preview)) : '';
+    }
+  }
+  return out;
+}
+
 function parseArgs(argv) {
   const args = {};
   for (let i = 0; i < argv.length; i += 1) {
@@ -771,6 +788,8 @@ function requestActionApproval(paths, plan, actionType, preview, resultFile, con
     dmPairingId: extra.dmPairingId || '',
     dmPairingLabel: extra.dmPairingLabel || '',
     dmReplyText: extra.dmReplyText || '',
+    appActRecipeId: extra.appActRecipeId || '',
+    appActParamsResolved: extra.appActParamsResolved || '',
     resultPath: resultFile,
     ts: new Date().toISOString(),
     expiresAt: Date.now() + Math.max(1, timeoutSeconds) * 1000,
@@ -1216,7 +1235,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     writeDraftOutputs(paths, opts, plan, config, roots, true);
     return { status: 'success', preview };
   }
-  if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli' && actionType !== 'intent' && actionType !== 'dm-reply') {
+  if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli' && actionType !== 'intent' && actionType !== 'dm-reply' && actionType !== 'app-act') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
   if (trustedNativeLowRiskAction(args, plan, actionType)) {
@@ -1352,6 +1371,31 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
         dmPairingLabel: pairing.label,
         dmReplyText,
       });
+      return { status: 'success', preview };
+    }
+    if (actionType === 'app-act') {
+      // Phase 4: refused-when-unattended is already enforced upstream by
+      // unattendedPreflightFailure() (dispatchActionTrusted is never reached
+      // for an unattended app-act run) -- see that function and
+      // lib/agent-executor.ts's app-act) case for the matching rationale.
+      const recipeId = String(plan.action.appActRecipeId || '').trim();
+      if (!recipeId) {
+        const message = 'App-action is missing a recipe.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      const resolvedParams = resolveAppActParams(plan.action.appActParams, preview);
+      if (Object.keys(resolvedParams).length === 0) {
+        const message = 'App-action is missing its recipe parameters.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
+        appActRecipeId: recipeId,
+        appActParamsResolved: JSON.stringify(resolvedParams),
+      });
+      // Side effect already happened in RN before the accept reply appeared —
+      // no broker/native call here, unlike webhook/cli (mirrors intent/dm-reply).
       return { status: 'success', preview };
     }
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/AgentRuntime.kt
@@ -28,9 +28,9 @@ data class AgentRunResult(
 object AgentRuntime {
     private const val TAG = "AgentRuntime"
     private const val DEFAULT_TIMEOUT_MS = 30 * 60 * 1000
-    private const val CURRENT_SCRIPT_VERSION = 10
+    private const val CURRENT_SCRIPT_VERSION = 11
     private const val CURRENT_PLAN_SPEC_VERSION = 1
-    private val PLAN_EXECUTOR_ACTIONS = setOf("draft", "notify", "webhook", "cli", "intent", "dm-reply", "__suppressed__")
+    private val PLAN_EXECUTOR_ACTIONS = setOf("draft", "notify", "webhook", "cli", "intent", "dm-reply", "app-act", "__suppressed__")
 
     private data class TrustedPlanLaunch(
         val actionType: String,

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/TerminalEmulatorModule.kt
@@ -1074,6 +1074,38 @@ class TerminalEmulatorModule : Module() {
             null
         }
 
+        // Agent action executor (Track D dependency, app-act phase): fires a
+        // registered app-action recipe on behalf of an approved agent action (see
+        // AgentAction.appActRecipeId/appActParams in store/types.ts). Never called
+        // with an un-reviewed request — the approval tier for "app-act" requires
+        // in-app Review before Accept (same shape as fireAgentIntent above),
+        // enforced upstream. Unlike the debugAppAct* wrappers above (fixed
+        // recipe/param names, reachable only from a dev-only debug button), this
+        // takes a recipe id + a generic param map so it can drive ANY registered
+        // recipe — the real dispatch path this phase wires up. Throws on any
+        // failure (service not connected, or the recipe run itself failing) so
+        // RN's accept handler can resolve the pending approval as 'decline'
+        // (fail-closed) instead of silently treating a failed post as accepted.
+        AsyncFunction("fireAgentAppAct") { recipeId: String, params: Map<String, String> ->
+            val trimmedRecipeId = recipeId.trim()
+            if (trimmedRecipeId.isEmpty()) {
+                throw IllegalArgumentException("app-act recipe id is empty")
+            }
+            val service = ShellyAccessibilityService.activeInstance
+                ?: throw IllegalStateException("Accessibility Service is not enabled/connected")
+            val result = AppActExecutor.execute(service, service.applicationContext, trimmedRecipeId, params)
+            // Never log param VALUES (agent/user free text — could be a post body,
+            // a contact name, message content) or the failure message (which may
+            // echo on-screen text via diagnoseCurrentScreen) — recipeId + success +
+            // param count only, matching fireAgentIntent's "mode + lengths only"
+            // convention above.
+            Log.i("TerminalEmulator", "fireAgentAppAct: recipeId=$trimmedRecipeId success=${result.success} paramCount=${params.size}")
+            if (!result.success) {
+                throw IllegalStateException("app-act recipe failed: $trimmedRecipeId")
+            }
+            null
+        }
+
         AsyncFunction("enqueueApkDownload") { url: String, downloadSubdir: String, fileName: String ->
             val context = requireReactContext()
             val target = validateDownloadPath(context, downloadSubdir, fileName)

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/AgentActionApprovalBridge.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/AgentActionApprovalBridge.kt
@@ -32,7 +32,9 @@ data class AgentActionApprovalRequest(
     val intentShareText: String? = null,
     val dmPairingId: String? = null,
     val dmPairingLabel: String? = null,
-    val dmReplyText: String? = null
+    val dmReplyText: String? = null,
+    val appActRecipeId: String? = null,
+    val appActParamsResolved: String? = null
 ) {
     val key: String get() = listOf(
         runId,
@@ -132,12 +134,14 @@ object AgentActionApprovalBridge {
         "dmPairingId" to request.dmPairingId,
         "dmPairingLabel" to request.dmPairingLabel,
         "dmReplyText" to request.dmReplyText,
+        "appActRecipeId" to request.appActRecipeId,
+        "appActParamsResolved" to request.appActParamsResolved,
     )
 
     private fun fromJson(raw: JSONObject, requestSha256: String?): AgentActionApprovalRequest? {
         val runId = raw.optString("runId").trim().takeIf { it.isNotBlank() } ?: return null
         val actionType = raw.optString("actionType").trim().takeIf {
-            it == "draft" || it == "notify" || it == "webhook" || it == "cli" || it == "intent" || it == "dm-reply"
+            it == "draft" || it == "notify" || it == "webhook" || it == "cli" || it == "intent" || it == "dm-reply" || it == "app-act"
         } ?: return null
         return AgentActionApprovalRequest(
             runId = runId,
@@ -160,7 +164,9 @@ object AgentActionApprovalBridge {
             intentShareText = raw.optString("intentShareText").takeIf { it.isNotBlank() },
             dmPairingId = raw.optString("dmPairingId").trim().takeIf { it.isNotBlank() },
             dmPairingLabel = raw.optString("dmPairingLabel").trim().takeIf { it.isNotBlank() },
-            dmReplyText = raw.optString("dmReplyText").takeIf { it.isNotBlank() }
+            dmReplyText = raw.optString("dmReplyText").takeIf { it.isNotBlank() },
+            appActRecipeId = raw.optString("appActRecipeId").trim().takeIf { it.isNotBlank() },
+            appActParamsResolved = raw.optString("appActParamsResolved").takeIf { it.isNotBlank() }
         )
     }
 

--- a/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/NotificationDispatcher.kt
+++ b/modules/terminal-emulator/android/src/main/java/expo/modules/terminalemulator/scouter/NotificationDispatcher.kt
@@ -148,6 +148,7 @@ class NotificationDispatcher(private val context: Context) {
                 "cli" -> context.getString(R.string.scouter_notification_agent_action_what_cli)
                 "intent" -> context.getString(R.string.scouter_notification_agent_action_what_intent)
                 "dm-reply" -> context.getString(R.string.scouter_notification_agent_action_what_dm_reply)
+                "app-act" -> context.getString(R.string.scouter_notification_agent_action_what_appact)
                 else -> request.actionType
             }
             val previewText = request.preview.takeIf { it.isNotBlank() }?.redactForScouter()
@@ -186,6 +187,14 @@ class NotificationDispatcher(private val context: Context) {
                     },
                     context.getString(R.string.scouter_notification_agent_action_dm_reply_review_required),
                 ).joinToString("\n")
+                "app-act" -> listOfNotNull(
+                    engineLine,
+                    actionPhrase,
+                    request.appActRecipeId?.takeIf { it.isNotBlank() }?.let {
+                        context.getString(R.string.scouter_notification_agent_action_appact_recipe, it)
+                    },
+                    context.getString(R.string.scouter_notification_agent_action_appact_review_required),
+                ).joinToString("\n")
                 else -> listOfNotNull(
                     engineLine,
                     actionPhrase,
@@ -193,7 +202,15 @@ class NotificationDispatcher(private val context: Context) {
                 ).joinToString("\n")
             }
             val actionNonce = AgentActionApprovalBridge.registerActionNonce(request.runId)
-            val actions = if (request.actionType == "cli" || request.actionType == "intent" || request.actionType == "dm-reply") {
+            // app-act MUST stay in this "Review" bucket (never one-tap Allow),
+            // same as cli/intent/dm-reply: the ALLOW pending intent below calls
+            // AgentActionApprovalBridge.writeHumanReply directly with no RN
+            // round trip (see ScouterWidgetPromptActivity.handleAgentActionApprovalAction),
+            // so it never invokes fireAgentAppAct -- a one-tap Allow here would
+            // resolve the approval as accepted while the recipe never actually
+            // ran, AND would let a real external post go out (or silently not
+            // go out) without the user ever seeing the resolved post text.
+            val actions = if (request.actionType == "cli" || request.actionType == "intent" || request.actionType == "dm-reply" || request.actionType == "app-act") {
                 listOf(
                     action(context.getString(R.string.scouter_notification_action_review), agentActionReviewPendingIntent(request, requestSha256)),
                     action(context.getString(R.string.scouter_notification_action_deny), agentActionApprovalPendingIntent(false, request, actionNonce, requestSha256)),

--- a/modules/terminal-emulator/android/src/main/res/values-ja/scouter_strings.xml
+++ b/modules/terminal-emulator/android/src/main/res/values-ja/scouter_strings.xml
@@ -59,6 +59,9 @@
   <string name="scouter_notification_agent_action_cli_review_required">CLI アクションはアプリ内でコマンド全文の確認が必要です。</string>
   <string name="scouter_notification_agent_action_intent_target">対象: %1$s</string>
   <string name="scouter_notification_agent_action_intent_review_required">Intent アクションはアプリ内での確認が必要です。</string>
+  <string name="scouter_notification_agent_action_what_appact">アプリ操作を実行します（例: 他アプリへの投稿）</string>
+  <string name="scouter_notification_agent_action_appact_recipe">操作: %1$s</string>
+  <string name="scouter_notification_agent_action_appact_review_required">アプリ操作は実行前にアプリ内で内容の確認が必要です。</string>
   <string name="scouter_notification_agent_escalation_title">エージェント %1$s: 境界操作を許可しますか？</string>
   <string name="scouter_notification_agent_escalation_truncated">長いコマンドです: %1$d 文字。許可前に Shelly で全文を確認してください。</string>
   <string name="scouter_notification_agent_escalation_reason">理由: %1$s</string>

--- a/modules/terminal-emulator/android/src/main/res/values/scouter_strings.xml
+++ b/modules/terminal-emulator/android/src/main/res/values/scouter_strings.xml
@@ -69,6 +69,9 @@
   <string name="scouter_notification_agent_action_cli_review_required">CLI actions require in-app command review.</string>
   <string name="scouter_notification_agent_action_intent_target">Target: %1$s</string>
   <string name="scouter_notification_agent_action_intent_review_required">Intent actions require in-app review.</string>
+  <string name="scouter_notification_agent_action_what_appact">Will run an app action (e.g. post to another app)</string>
+  <string name="scouter_notification_agent_action_appact_recipe">Recipe: %1$s</string>
+  <string name="scouter_notification_agent_action_appact_review_required">App actions require in-app review of the exact content before running.</string>
   <string name="scouter_notification_agent_escalation_title">Agent %1$s: approve boundary op?</string>
   <string name="scouter_notification_agent_escalation_truncated">Long command: %1$d characters; review the full request in Shelly before allowing.</string>
   <string name="scouter_notification_agent_escalation_reason">Reason: %1$s</string>

--- a/modules/terminal-emulator/src/TerminalEmulatorModule.ts
+++ b/modules/terminal-emulator/src/TerminalEmulatorModule.ts
@@ -180,7 +180,7 @@ declare class TerminalEmulatorModuleType extends NativeModule {
   readAgentActionApprovalRequest?(runId: string): Promise<{
     runId: string;
     agentId: string;
-    actionType: 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply';
+    actionType: 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply' | 'app-act';
     preview?: string | null;
     destinationHost?: string | null;
     command?: string | null;
@@ -197,12 +197,14 @@ declare class TerminalEmulatorModuleType extends NativeModule {
     dmPairingId?: string | null;
     dmPairingLabel?: string | null;
     dmReplyText?: string | null;
+    appActRecipeId?: string | null;
+    appActParamsResolved?: string | null;
     actionNonce?: string | null;
   }>;
   notifyAgentActionApprovalNeeded?(request: {
     runId: string;
     agentId?: string | null;
-    actionType: 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply';
+    actionType: 'draft' | 'notify' | 'webhook' | 'cli' | 'intent' | 'dm-reply' | 'app-act';
     preview?: string | null;
     destinationHost?: string | null;
     command?: string | null;
@@ -218,6 +220,8 @@ declare class TerminalEmulatorModuleType extends NativeModule {
     dmPairingId?: string | null;
     dmPairingLabel?: string | null;
     dmReplyText?: string | null;
+    appActRecipeId?: string | null;
+    appActParamsResolved?: string | null;
   }): Promise<void>;
   resolveAgentActionApproval?(
     runId: string,
@@ -227,6 +231,15 @@ declare class TerminalEmulatorModuleType extends NativeModule {
   ): Promise<void>;
   cancelAgentActionApproval?(runId: string): Promise<void>;
   fireAgentIntent?(mode: 'launch' | 'share', target: string, shareText?: string | null): Promise<void>;
+  /** Agent action executor (app-act phase): fires a registered app-action
+   *  recipe (e.g. 'x.post', 'line.send-message') with `params` resolved
+   *  against the run result, via ShellyAccessibilityService/AppActExecutor.
+   *  Never called with an un-reviewed request -- the approval tier for
+   *  "app-act" requires in-app Review before Accept, same as
+   *  fireAgentIntent. Throws if the Accessibility Service isn't connected or
+   *  the recipe run fails, so the caller can resolve the pending approval as
+   *  'decline' on any throw (fail-closed). */
+  fireAgentAppAct?(recipeId: string, params: Record<string, string>): Promise<void>;
   /** app.act Milestone 0 (dev-only debug scaffold, docs/superpowers/specs/
    *  2026-07-11-app-act-design.md §6): types `text` into LINE's message
    *  field and taps send, against whatever conversation is currently

--- a/scripts/shelly-plan-executor.js
+++ b/scripts/shelly-plan-executor.js
@@ -89,6 +89,23 @@ function redact(text) {
   return out;
 }
 
+// app-act (Phase 4): resolves the literal "{{result}}" placeholder in every
+// value of `params` against `preview` (already redact()-ed by previewText),
+// then redact()s the resolved values a SECOND time as defense-in-depth --
+// mirrors lib/agent-executor.ts's resolve_app_act_params exactly. This is the
+// first agent action type that can publish content externally (a public X
+// post), so it gets an extra redaction pass beyond relying solely on preview
+// already being clean.
+function resolveAppActParams(params, preview) {
+  const out = {};
+  if (params && typeof params === 'object' && !Array.isArray(params)) {
+    for (const [k, v] of Object.entries(params)) {
+      out[k] = typeof v === 'string' ? redact(v.split('{{result}}').join(preview)) : '';
+    }
+  }
+  return out;
+}
+
 function parseArgs(argv) {
   const args = {};
   for (let i = 0; i < argv.length; i += 1) {
@@ -771,6 +788,8 @@ function requestActionApproval(paths, plan, actionType, preview, resultFile, con
     dmPairingId: extra.dmPairingId || '',
     dmPairingLabel: extra.dmPairingLabel || '',
     dmReplyText: extra.dmReplyText || '',
+    appActRecipeId: extra.appActRecipeId || '',
+    appActParamsResolved: extra.appActParamsResolved || '',
     resultPath: resultFile,
     ts: new Date().toISOString(),
     expiresAt: Date.now() + Math.max(1, timeoutSeconds) * 1000,
@@ -1216,7 +1235,7 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
     writeDraftOutputs(paths, opts, plan, config, roots, true);
     return { status: 'success', preview };
   }
-  if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli' && actionType !== 'intent' && actionType !== 'dm-reply') {
+  if (actionType !== 'draft' && actionType !== 'notify' && actionType !== 'webhook' && actionType !== 'cli' && actionType !== 'intent' && actionType !== 'dm-reply' && actionType !== 'app-act') {
     throw new PlanFailure(`unsupported PlanSpec action: ${actionType}`, { exitCode: EXIT.TOOL_DENY });
   }
   if (trustedNativeLowRiskAction(args, plan, actionType)) {
@@ -1352,6 +1371,31 @@ function dispatchActionTrusted(paths, opts, plan, config, roots, resultText, arg
         dmPairingLabel: pairing.label,
         dmReplyText,
       });
+      return { status: 'success', preview };
+    }
+    if (actionType === 'app-act') {
+      // Phase 4: refused-when-unattended is already enforced upstream by
+      // unattendedPreflightFailure() (dispatchActionTrusted is never reached
+      // for an unattended app-act run) -- see that function and
+      // lib/agent-executor.ts's app-act) case for the matching rationale.
+      const recipeId = String(plan.action.appActRecipeId || '').trim();
+      if (!recipeId) {
+        const message = 'App-action is missing a recipe.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      const resolvedParams = resolveAppActParams(plan.action.appActParams, preview);
+      if (Object.keys(resolvedParams).length === 0) {
+        const message = 'App-action is missing its recipe parameters.';
+        writeNotification(paths, plan, 'error', message);
+        return { status: 'error', preview: message, errorMessage: message };
+      }
+      requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config, {
+        appActRecipeId: recipeId,
+        appActParamsResolved: JSON.stringify(resolvedParams),
+      });
+      // Side effect already happened in RN before the accept reply appeared —
+      // no broker/native call here, unlike webhook/cli (mirrors intent/dm-reply).
       return { status: 'success', preview };
     }
     requestActionApproval(paths, plan, actionType, preview, paths.resultFile, config);


### PR DESCRIPTION
## Summary
Phase 4 of the app-act (X-posting) delivery series — makes \`app-act\` actually dispatch, end to end, for the first time.

- **\`lib/agent-executor.ts\` (.sh generator)**: real \`app-act)\` dispatch case. Refuses when autonomous/unattended (matching \`intent\`/\`dm-reply\`'s shape — this is a deliberate interim conservative default; \`store/types.ts\` documents app-act as ultimately Tier-B/unattended-capable, but that's Phase 5's scope, tracked as P1 in DEFERRED.md). Resolves \`{{result}}\` against the already-redacted preview, then redacts a **second time** as defense-in-depth (first agent action type that can publish externally). Never calls native itself — mirrors \`intent\`/\`dm-reply\`'s invariant that RN fires the real effect before the accept reply appears. \`AGENT_SCRIPT_VERSION\` bumped 10→11 so any already-persisted app-act agent regenerates instead of permanently hitting "Unknown agent action."
- **\`scripts/shelly-plan-executor.js\`** (+ byte-identical APK asset mirror) + **\`lib/agent-plan-spec.ts\`**: parallel PlanSpec-side dispatch, was previously falling to \`unsupported\`.
- **Native**: new \`fireAgentAppAct(recipeId, params)\` bridge method (not a debug stub) wrapping \`AppActExecutor.execute\` generically, fail-closed on any failure.
- **\`app/_layout.tsx\`**: Review card handles \`app-act\` — fires native *before* resolving accept, catches failures and resolves as decline (never leaves the shell script to time out), shows a "投稿内容プレビュー" of the fully-resolved, redacted post text.
- **Real bug found and fixed**: \`NotificationDispatcher.kt\`'s system-notification one-tap "Allow" button called \`AgentActionApprovalBridge.writeHumanReply\` directly with no RN round trip — without excluding \`app-act\` from that bucket (same as \`cli\`/\`intent\`/\`dm-reply\`), a user could accept an X-post from the notification shade without ever seeing the resolved text, and \`fireAgentAppAct\` would never fire while the approval still resolved as accepted.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] New \`agent-executor-app-act-action.test.ts\`, extended \`plan-executor-parity.test.ts\`, fixed the now-stale Phase 2 "inertness" assertion in \`agent-action-app-act-schema.test.ts\`
- [x] 129 relevant tests pass (app-act + intent/dm-reply regression + NL parser + confirm card), post-rebase onto Phase 6 (#133) with zero merge conflicts
- [x] Could not compile/run native Kotlin in this environment (no Android SDK) — the \`Map<String, String>\` AsyncFunction param shape should be smoke-tested on-device before the underlying capability goes live for real users