### PR TITLE
feat(agent): chat-native confirm for app-act / tool-pinned orchestration drafts

### DIFF
--- a/__tests__/AgentChatConfirm.test.tsx
+++ b/__tests__/AgentChatConfirm.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import AgentChatConfirm from '@/components/panes/AgentChatConfirm';
+import type { ParsedAgentDraft } from '@/lib/agent-nl-parser';
+
+// Same mocking pattern as __tests__/AgentConfirmCard.test.tsx (this component
+// shares the theme/i18n dependency surface, and that card had two real bugs
+// in this exact area recently: c3f4ddd7a — infinite render loop from an
+// unstable Zustand selector — and 387ca7135 which added its render-regression
+// test in the first place). AgentChatConfirm has no store selector of its own,
+// but it is rendered from the same MessageBubble list AgentConfirmCard is, so
+// a render-time crash here would be just as disruptive.
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+jest.mock('@/hooks/use-theme', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#000000',
+      border: '#333333',
+      foreground: '#ffffff',
+      muted: '#999999',
+      success: '#00cc66',
+    },
+  }),
+}));
+
+jest.mock('@/lib/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const scheduledDraft: ParsedAgentDraft = {
+  name: 'X digest',
+  prompt: 'Summarize today and post it',
+  schedule: '0 8 * * *',
+  scheduleConfident: true,
+  scheduleLabel: 'Daily at 08:00',
+  action: { type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } },
+  tool: { type: 'local' },
+  toolLabel: 'Local LLM',
+  rawText: 'Every day at 8, summarize today and post it to X',
+};
+
+const unfireableDraft: ParsedAgentDraft = {
+  ...scheduledDraft,
+  schedule: null,
+  scheduleConfident: false,
+  suggestedFrequency: 'daily',
+};
+
+describe('AgentChatConfirm', () => {
+  it('renders without throwing for a draft with a fireable schedule', () => {
+    expect(() =>
+      render(<AgentChatConfirm draft={scheduledDraft} onConfirm={jest.fn()} onCancel={jest.fn()} />),
+    ).not.toThrow();
+  });
+
+  it('shows a Confirm affordance and calls onConfirm with the draft carried through verbatim', () => {
+    const onConfirm = jest.fn();
+    const { getByText } = render(
+      <AgentChatConfirm draft={scheduledDraft} onConfirm={onConfirm} onCancel={jest.fn()} />,
+    );
+    fireEvent.press(getByText('agentcard.confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const confirmed = onConfirm.mock.calls[0][0];
+    expect(confirmed.name).toBe(scheduledDraft.name);
+    expect(confirmed.schedule).toBe(scheduledDraft.schedule);
+    expect(confirmed.action).toEqual(scheduledDraft.action);
+  });
+
+  it('calls onCancel when Cancel is pressed', () => {
+    const onCancel = jest.fn();
+    const { getByText } = render(
+      <AgentChatConfirm draft={scheduledDraft} onConfirm={jest.fn()} onCancel={onCancel} />,
+    );
+    fireEvent.press(getByText('agentcard.cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // HARD REQUIREMENT parity with AgentConfirmCard: never register an agent that
+  // will never fire. When the schedule still needs restating (a recurrence was
+  // named but no confirmable time), Confirm must not be offered at all.
+  it('withholds the Confirm affordance when the schedule still needs restating', () => {
+    const { queryByText, getByText } = render(
+      <AgentChatConfirm draft={unfireableDraft} onConfirm={jest.fn()} onCancel={jest.fn()} />,
+    );
+    expect(queryByText('agentcard.confirm')).toBeNull();
+    expect(getByText('agentcard.cancel')).toBeTruthy();
+  });
+});

--- a/__tests__/agent-plan-summary.test.ts
+++ b/__tests__/agent-plan-summary.test.ts
@@ -1,0 +1,189 @@
+// lib/i18n imports expo-localization (ESM-only) which the plain "unit" ts-jest
+// project (no RN/babel transform) cannot parse — mock it exactly like
+// __tests__/AgentConfirmCard.test.tsx does, but with real {{param}}
+// interpolation so assertions below can check the actually-composed strings
+// rather than just raw keys.
+// Mirrors AgentConfirmCard.test.tsx's `t: (key) => key` mock, extended to also
+// surface the params object in the output (JSON-appended) so assertions below
+// can check that the RIGHT interpolated values (times, labels, previews) were
+// actually passed through, not just that a key was looked up.
+jest.mock('@/lib/i18n', () => ({
+  t: (key: string, params?: Record<string, string | number>) =>
+    params ? `${key}|${JSON.stringify(params)}` : key,
+}));
+
+import {
+  hasFireableSchedule,
+  shouldUseChatConfirm,
+  summarizeAgentDraftAsText,
+  draftToConfirmedAgentDraft,
+} from '@/lib/agent-plan-summary';
+import type { ParsedAgentDraft } from '@/lib/agent-nl-parser';
+import type { AgentOrchestrationStep } from '@/store/types';
+
+function baseDraft(overrides: Partial<ParsedAgentDraft> = {}): ParsedAgentDraft {
+  return {
+    name: 'Daily X digest',
+    prompt: 'Summarize today and post it',
+    schedule: '0 8 * * *',
+    scheduleConfident: true,
+    scheduleLabel: 'Daily at 08:00',
+    action: { type: 'draft' },
+    tool: { type: 'local' },
+    toolLabel: 'Local LLM',
+    rawText: 'Every day at 8, summarize today and post it to X',
+    ...overrides,
+  };
+}
+
+describe('hasFireableSchedule', () => {
+  it('true for a confident cron', () => {
+    expect(hasFireableSchedule(baseDraft())).toBe(true);
+  });
+
+  it('true for a genuine one-shot (no recurrence stated at all)', () => {
+    expect(hasFireableSchedule(baseDraft({ schedule: null, scheduleConfident: false }))).toBe(true);
+  });
+
+  it('false when a recurrence was stated but no confirmable time exists (needs restatement)', () => {
+    expect(
+      hasFireableSchedule(
+        baseDraft({ schedule: null, scheduleConfident: false, suggestedFrequency: 'daily' }),
+      ),
+    ).toBe(false);
+    expect(
+      hasFireableSchedule(
+        baseDraft({
+          schedule: null,
+          scheduleConfident: false,
+          suggestedFrequency: 'weekly',
+          suggestedDowList: '1,5',
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('shouldUseChatConfirm', () => {
+  it('true for an app-act action', () => {
+    expect(
+      shouldUseChatConfirm(
+        baseDraft({ action: { type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } } }),
+      ),
+    ).toBe(true);
+  });
+
+  it('true when at least one orchestration step pins a tool', () => {
+    const steps: Array<string | AgentOrchestrationStep> = [
+      'search for news',
+      { instruction: 'summarize with local model', tool: { type: 'local' } },
+    ];
+    expect(shouldUseChatConfirm(baseDraft({ orchestrationSteps: steps }))).toBe(true);
+  });
+
+  it('false for a plain draft action with no orchestration', () => {
+    expect(shouldUseChatConfirm(baseDraft())).toBe(false);
+  });
+
+  it('false for a plain auto-routed multi-step chain with NO pinned tools (still card-routed)', () => {
+    const steps: Array<string | AgentOrchestrationStep> = ['first step', 'second step'];
+    expect(shouldUseChatConfirm(baseDraft({ orchestrationSteps: steps }))).toBe(false);
+  });
+});
+
+describe('summarizeAgentDraftAsText', () => {
+  it('single-step app-act (X-posting) with a confident daily schedule', () => {
+    const draft = baseDraft({
+      action: { type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } },
+    });
+    const text = summarizeAgentDraftAsText(draft);
+    expect(text).toContain('Daily X digest'); // name
+    expect(text).toContain('08:00'); // schedule time round-tripped through decodeCron
+    expect(text).toContain('agentplan.appact_line|'); // no literal preview -> the no-preview variant
+    expect(text).not.toContain('agentplan.schedule_restate_hint');
+    expect(text).toContain('agentplan.confirm_prompt');
+  });
+
+  it('surfaces a literal content preview when an app-act param is not the {{result}} placeholder', () => {
+    const draft = baseDraft({
+      action: {
+        type: 'app-act',
+        appActRecipeId: 'x.post',
+        appActParams: { text: 'Good morning from Shelly' },
+      },
+    });
+    const text = summarizeAgentDraftAsText(draft);
+    expect(text).toContain('Good morning from Shelly');
+    expect(text).toContain('agentplan.appact_line_with_preview|');
+  });
+
+  it('multi-step orchestration with MIXED pinned/unpinned steps lists each instruction and pinned-tool label', () => {
+    const steps: Array<string | AgentOrchestrationStep> = [
+      'search for news on the topic',
+      { instruction: 'summarize on the local model', tool: { type: 'local' } },
+      { instruction: 'post the digest to X', tool: { type: 'cli', cli: 'codex' } },
+    ];
+    const draft = baseDraft({
+      action: { type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } },
+      orchestrationSteps: steps,
+    });
+    const text = summarizeAgentDraftAsText(draft);
+    expect(text).toContain('1. search for news on the topic');
+    expect(text).toContain('2. [Local LLM] summarize on the local model');
+    expect(text).toContain('3. [Codex CLI] post the digest to X');
+  });
+
+  it('invalid-schedule case: ambiguous recurrence surfaces the restatement hint and omits the confirm prompt', () => {
+    const draft = baseDraft({
+      schedule: null,
+      scheduleConfident: false,
+      suggestedFrequency: 'daily',
+      action: { type: 'app-act', appActRecipeId: 'x.post', appActParams: { text: '{{result}}' } },
+    });
+    const text = summarizeAgentDraftAsText(draft);
+    expect(text).toContain('agentplan.schedule_restate_hint');
+    expect(text).not.toContain('agentplan.confirm_prompt');
+  });
+
+  it('includes autonomous, memory, matched-skill, and actionCaveat lines when present', () => {
+    const draft = baseDraft({
+      autonomous: true,
+      memory: { remember: true, rememberFact: 'the user prefers concise summaries' },
+      matchedSkill: { id: 'skill-1', name: 'news-digest', successCount: 3 },
+      actionCaveat: 'LINEへの投稿にはまだ対応していないため、下書き（ファイル保存）として登録します',
+    });
+    const text = summarizeAgentDraftAsText(draft);
+    expect(text).toContain('agentplan.autonomous_note');
+    expect(text).toContain('the user prefers concise summaries');
+    expect(text).toContain('news-digest');
+    expect(text).toContain('LINEへの投稿にはまだ対応していない');
+  });
+});
+
+describe('draftToConfirmedAgentDraft', () => {
+  it('carries the draft through verbatim with the SAME defaults AgentConfirmCard starts with (runOn auto, matched skill reused by default)', () => {
+    const draft = baseDraft({
+      matchedSkill: { id: 'skill-1', name: 'news-digest', successCount: 3 },
+      orchestrationSteps: ['a', 'b'],
+    });
+    const confirmed = draftToConfirmedAgentDraft(draft);
+    expect(confirmed).toEqual({
+      name: draft.name,
+      prompt: draft.prompt,
+      schedule: draft.schedule,
+      tool: draft.tool,
+      action: draft.action,
+      runOn: 'auto',
+      autonomous: false,
+      memory: draft.memory,
+      skillId: 'skill-1',
+      orchestrationSteps: draft.orchestrationSteps,
+      notificationTrigger: null,
+    });
+  });
+
+  it('defaults autonomous to false when the draft never set it', () => {
+    const confirmed = draftToConfirmedAgentDraft(baseDraft());
+    expect(confirmed.autonomous).toBe(false);
+  });
+});

--- a/components/panes/AIPane.tsx
+++ b/components/panes/AIPane.tsx
@@ -27,6 +27,7 @@ import type { ChatMessage } from '@/store/chat-store';
 import PaneInputBar from '@/components/panes/PaneInputBar';
 import InlineDiff, { hasDiffContent } from '@/components/panes/InlineDiff';
 import AgentConfirmCard, { type ConfirmedAgentDraft } from '@/components/panes/AgentConfirmCard';
+import AgentChatConfirm from '@/components/panes/AgentChatConfirm';
 import { CodeBlockWithAction, splitFencedCode } from '@/components/panes/CodeBlockWithAction';
 import { useAIPaneDispatch } from '@/hooks/use-ai-pane-dispatch';
 import VoiceWaveform from '@/components/panes/VoiceWaveform';
@@ -113,6 +114,27 @@ const MessageBubble = React.memo(function MessageBubble({
   // replaces the bubble text; once confirmed/cancelled it falls through to the
   // normal assistant text render (which now holds the result line).
   if (message.agentDraft && message.agentCardState === 'pending') {
+    // Phase 7: app-act / tool-pinned-orchestration drafts render chat-native —
+    // the plan is plain assistant text (message.content, set by
+    // summarizeAgentDraftAsText at creation) with a trailing inline
+    // Confirm/Cancel row, NOT a card. Everything else keeps AgentConfirmCard.
+    if (message.agentChatConfirm) {
+      const agentKeyChat = resolveAiPaneAgent(message.agent, 'local');
+      const agentLabelChat = getAiPaneAgentMeta(agentKeyChat).label.toUpperCase();
+      return (
+        <View style={[bubbleStyles.messageContainer, containerMaxWidth]}>
+          <Text style={[bubbleStyles.roleLabelAgent, { color: C.text2 }]}>{agentLabelChat}</Text>
+          <View style={bubbleStyles.assistantContent}>
+            <Text style={bubbleStyles.assistantText} selectable>{message.content}</Text>
+          </View>
+          <AgentChatConfirm
+            draft={message.agentDraft}
+            onConfirm={(c) => onConfirmAgentDraft?.(message.id, c)}
+            onCancel={() => onCancelAgentDraft?.(message.id)}
+          />
+        </View>
+      );
+    }
     return (
       <View style={[bubbleStyles.messageContainer, containerMaxWidth]}>
         <AgentConfirmCard

--- a/components/panes/AgentChatConfirm.tsx
+++ b/components/panes/AgentChatConfirm.tsx
@@ -1,0 +1,72 @@
+/**
+ * components/panes/AgentChatConfirm.tsx
+ *
+ * Chat-native confirmation affordance for NL-self-registered agents whose draft
+ * is app-act (e.g. X-posting) or a tool-pinned multi-step orchestration (Phase 7).
+ * The project owner rejected a structured card/modal for this: "カードも要らない
+ * って。チャットで自然言語で確認すればいいじゃん。" (no card — confirm via natural
+ * language in chat). The natural-language plan itself is rendered as ordinary
+ * assistant chat text (see `summarizeAgentDraftAsText` in lib/agent-plan-summary.ts,
+ * set as the message's `content` at creation time in hooks/use-ai-pane-dispatch.ts).
+ * This component is ONLY the trailing inline Confirm/Cancel affordance — two plain
+ * buttons, not a form. There is no field editing: if the user wants something
+ * different, the project's stated design is to cancel and re-describe it in chat.
+ *
+ * HARD REQUIREMENT (mirrors AgentConfirmCard's own, see its top doc comment):
+ * Confirm must be withheld until a valid schedule exists — "never register an
+ * agent that will never fire." `hasFireableSchedule` encodes the exact same
+ * invariant for the no-editing chat-native flow; when it's false, only Cancel is
+ * offered (the summary text already explains why, via schedule_restate_hint).
+ *
+ * Non-app-act / non-tool-pinned drafts are NOT routed here — they keep using
+ * AgentConfirmCard unchanged (see components/panes/AIPane.tsx and
+ * lib/agent-plan-summary.ts's `shouldUseChatConfirm`).
+ */
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme } from '@/hooks/use-theme';
+import { useTranslation } from '@/lib/i18n';
+import { ParsedAgentDraft } from '@/lib/agent-nl-parser';
+import { hasFireableSchedule, draftToConfirmedAgentDraft } from '@/lib/agent-plan-summary';
+import type { ConfirmedAgentDraft } from '@/components/panes/AgentConfirmCard';
+
+interface Props {
+  draft: ParsedAgentDraft;
+  onConfirm: (final: ConfirmedAgentDraft) => void;
+  onCancel: () => void;
+}
+
+export default function AgentChatConfirm({ draft, onConfirm, onCancel }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const canConfirm = hasFireableSchedule(draft);
+
+  return (
+    <View style={styles.row}>
+      <TouchableOpacity
+        onPress={onCancel}
+        style={[styles.btn, { borderColor: colors.border }]}
+        activeOpacity={0.7}
+      >
+        <Text style={[styles.btnText, { color: colors.muted }]}>{t('agentcard.cancel')}</Text>
+      </TouchableOpacity>
+      {canConfirm && (
+        <TouchableOpacity
+          onPress={() => onConfirm(draftToConfirmedAgentDraft(draft))}
+          style={[styles.btn, { backgroundColor: colors.success, borderColor: colors.success }]}
+          activeOpacity={0.7}
+        >
+          <Text style={[styles.btnText, { color: colors.background, fontWeight: '700' }]}>
+            {t('agentcard.confirm')}
+          </Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, paddingHorizontal: 12, paddingBottom: 6, marginTop: -2 },
+  btn: { borderRadius: 8, borderWidth: 1, paddingHorizontal: 16, paddingVertical: 6 },
+  btnText: { fontSize: 12 },
+});

--- a/components/panes/AgentConfirmCard.tsx
+++ b/components/panes/AgentConfirmCard.tsx
@@ -25,7 +25,7 @@ import { AgentAction, AgentActionType, AgentMemoryConfig, AgentOrchestrationStep
 import { useSettingsStore } from '@/store/settings-store';
 import { resolveAutonomousFinalTool, toolChoiceToLabel } from '@/lib/agent-tool-router';
 import { detectRouteSignals } from '@/lib/agent-router-scoring';
-import { decodeCron, buildCron, resolveInitialFrequency, type Frequency } from '@/lib/agent-card-cron';
+import { decodeCron, buildCron, resolveInitialFrequency, scheduleHuman, WEEKDAY_LABELS, type Frequency } from '@/lib/agent-card-cron';
 import { parseNotificationTriggerPackages } from '@/lib/notification-trigger';
 import { pairingConfidence, useDmPairingStore } from '@/store/dm-pairing-store';
 import TerminalEmulator from '@/modules/terminal-emulator/src/TerminalEmulatorModule';
@@ -56,7 +56,6 @@ export interface ConfirmedAgentDraft {
 // 'once' = run immediately on Confirm (no schedule). The others register a schedule.
 type RunOn = 'auto' | 'on-device' | 'cloud';
 
-const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土']; // cron dow 0..6
 const ACTION_TYPES: AgentActionType[] = ['draft', 'notify', 'webhook', 'cli', 'intent', 'dm-reply', 'app-act'];
 const RUN_ON: RunOn[] = ['auto', 'on-device', 'cloud'];
 
@@ -785,32 +784,6 @@ export default function AgentConfirmCard({ draft, onConfirm, onCancel }: Props) 
       </View>
     </View>
   );
-}
-
-function scheduleHuman(
-  f: Frequency,
-  hour: number,
-  minute: number,
-  weekday: number,
-  interval: number,
-  t: (k: string, p?: Record<string, string | number>) => string,
-  customDow = '',
-  dailyMultiHours: number[] = [],
-): string {
-  const hhmm = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
-  if (f === 'interval') return t('agentcard.sched_interval', { n: interval });
-  if (f === 'hourly') return t('agentcard.sched_hourly', { n: interval });
-  if (f === 'daily-multi') {
-    const hours = dailyMultiHours.length > 0 ? dailyMultiHours : [hour];
-    const times = hours.map((h) => `${String(h).padStart(2, '0')}:${String(minute).padStart(2, '0')}`).join('・');
-    return t('agentcard.sched_daily_multi', { times });
-  }
-  if (f === 'custom') {
-    const days = customDow.split(',').map((d) => WEEKDAY_LABELS[+d] ?? d).join('・');
-    return t('agentcard.sched_weekly', { day: days, time: hhmm });
-  }
-  if (f === 'weekly') return t('agentcard.sched_weekly', { day: WEEKDAY_LABELS[weekday], time: hhmm });
-  return t('agentcard.sched_daily', { time: hhmm });
 }
 
 // ─── Segmented control ──────────────────────────────────────────────────────

--- a/hooks/use-ai-pane-dispatch.ts
+++ b/hooks/use-ai-pane-dispatch.ts
@@ -44,6 +44,7 @@ import type { ToolChoice } from '@/store/types';
 import { resolveAutonomousFinalTool } from '@/lib/agent-tool-router';
 import { detectRouteSignals } from '@/lib/agent-router-scoring';
 import { parseAgentNL } from '@/lib/agent-nl-parser';
+import { shouldUseChatConfirm, summarizeAgentDraftAsText } from '@/lib/agent-plan-summary';
 import { matchSkillRecipes, readSkillRecipes } from '@/lib/agent-skills';
 import { readApprovedImportedSkillsAsRecipes } from '@/lib/skill-import';
 import { getHomePath } from '@/lib/home-path';
@@ -307,14 +308,23 @@ export function useAIPaneDispatch(paneId: string) {
             } catch {
               // skill match is best-effort
             }
+            // Phase 7: app-act (e.g. X-posting) and tool-pinned orchestration
+            // drafts (Phase 6's detectToolPinnedSteps) skip AgentConfirmCard
+            // entirely — the project owner explicitly rejected a card/modal for
+            // NEW confirmation surfaces and wants plain chat-native NL confirm
+            // instead. Every other draft shape (including plain auto-routed
+            // multi-step chains from Phase 4) is UNCHANGED and still uses the
+            // card. See lib/agent-plan-summary.ts's shouldUseChatConfirm.
+            const useChatConfirm = shouldUseChatConfirm(draft);
             store.addMessage(paneId, {
               id: generateId(),
               role: 'assistant',
-              content: '',
+              content: useChatConfirm ? summarizeAgentDraftAsText(draft) : '',
               timestamp: Date.now(),
               agent: agent as ChatMessage['agent'],
               agentDraft: draft,
               agentCardState: 'pending',
+              agentChatConfirm: useChatConfirm,
             });
             return;
           } else if (agentResult.type === 'run') {

--- a/lib/agent-card-cron.ts
+++ b/lib/agent-card-cron.ts
@@ -13,6 +13,12 @@
  */
 export type Frequency = 'once' | 'daily' | 'weekly' | 'interval' | 'hourly' | 'custom' | 'daily-multi';
 
+/** Cron dow (0=Sun..6=Sat) → display char. Deliberately JP kanji regardless of
+ *  locale — pre-existing convention inherited from AgentConfirmCard (the weekday
+ *  chips/summary always show 日月火水木金土, even under the EN locale). Not fixed
+ *  here; extracted verbatim so scheduleHuman below and the card stay in lockstep. */
+export const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
 export interface DecodedCron {
   frequency: Frequency;
   hour: number;
@@ -131,4 +137,38 @@ export function buildCron(
     return `${minute} ${hour} * * ${weekday}`;
   }
   return `${minute} ${hour} * * *`;
+}
+
+/**
+ * Render a decoded schedule as a human-readable phrase via the injected `t()`
+ * (either the React `useTranslation()` translator or the plain module-level
+ * `t` from lib/i18n — both share the same signature). Extracted verbatim from
+ * AgentConfirmCard's private `scheduleHuman` so lib/agent-plan-summary.ts (the
+ * chat-native confirm renderer) can produce IDENTICAL schedule phrasing to the
+ * card without duplicating the cron-shape → phrase mapping.
+ */
+export function scheduleHuman(
+  f: Frequency,
+  hour: number,
+  minute: number,
+  weekday: number,
+  interval: number,
+  t: (k: string, p?: Record<string, string | number>) => string,
+  customDow = '',
+  dailyMultiHours: number[] = [],
+): string {
+  const hhmm = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+  if (f === 'interval') return t('agentcard.sched_interval', { n: interval });
+  if (f === 'hourly') return t('agentcard.sched_hourly', { n: interval });
+  if (f === 'daily-multi') {
+    const hours = dailyMultiHours.length > 0 ? dailyMultiHours : [hour];
+    const times = hours.map((h) => `${String(h).padStart(2, '0')}:${String(minute).padStart(2, '0')}`).join('・');
+    return t('agentcard.sched_daily_multi', { times });
+  }
+  if (f === 'custom') {
+    const days = customDow.split(',').map((d) => WEEKDAY_LABELS[+d] ?? d).join('・');
+    return t('agentcard.sched_weekly', { day: days, time: hhmm });
+  }
+  if (f === 'weekly') return t('agentcard.sched_weekly', { day: WEEKDAY_LABELS[weekday], time: hhmm });
+  return t('agentcard.sched_daily', { time: hhmm });
 }

--- a/lib/agent-plan-summary.ts
+++ b/lib/agent-plan-summary.ts
@@ -1,0 +1,208 @@
+/**
+ * lib/agent-plan-summary.ts
+ *
+ * Chat-native natural-language rendering of a ParsedAgentDraft (Phase 7).
+ *
+ * The project owner has repeatedly rejected a structured confirm card/modal for
+ * NEW confirmation surfaces ("カードも要らないって。チャットで自然言語で確認すれば
+ * いいじゃん。" — no card, confirm via natural-language chat). app-act registration
+ * (X-posting etc.) and tool-pinned multi-step orchestration (Phase 6's
+ * `detectToolPinnedSteps`) are the first surfaces built chat-native from the start
+ * instead of retrofitting `AgentConfirmCard`.
+ *
+ * `summarizeAgentDraftAsText` is the NL equivalent of what AgentConfirmCard renders
+ * as editable form fields: name, schedule, per-step instruction + pinned tool,
+ * action-in-plain-language (app-act's recipe/target + resolved content preview when
+ * available), and any caveats. It is a PURE function — no store reads, no RN — so it
+ * is trivially unit-testable and reuses the exact schedule phrasing AgentConfirmCard
+ * uses via `scheduleHuman` (lib/agent-card-cron.ts) and the exact tool labels via
+ * `toolChoiceToLabel` (lib/agent-tool-router.ts). Do not duplicate either mapping.
+ *
+ * `hasFireableSchedule` mirrors AgentConfirmCard's HARD REQUIREMENT ("never register
+ * an agent that will never fire"): Confirm must be refused until either (a) the
+ * parser produced a confident, valid cron, or (b) the utterance is a genuine one-shot
+ * (no recurrence was stated at all — "run now"). An utterance that stated a
+ * recurrence but no confirmable time (`suggestedFrequency` set, `schedule` still
+ * null) is the exact "would silently never fire (or fire on an unreviewed default)"
+ * case the card blocks by forcing a manual time pick — this chat-native flow has no
+ * field-editing, so instead of silently defaulting it must refuse and ask the user
+ * to restate the schedule with an explicit time.
+ */
+import { ParsedAgentDraft } from './agent-nl-parser';
+import { AgentAction } from '@/store/types';
+import { toolChoiceToLabel } from './agent-tool-router';
+import { decodeCron, scheduleHuman } from './agent-card-cron';
+import { t } from './i18n';
+// Type-only: erased at compile time, so importing from the .tsx component this
+// pure module otherwise has nothing to do with never pulls React/RN into its
+// (or its jest unit-project's) runtime graph.
+import type { ConfirmedAgentDraft } from '@/components/panes/AgentConfirmCard';
+
+/**
+ * true = the draft carries either a confident recurring schedule or a genuine
+ * one-shot (no recurrence stated) — safe to register. false = the parser found a
+ * recurrence cue but no confirmable time; the schedule needs to be restated before
+ * this draft can be registered (see module doc comment).
+ */
+export function hasFireableSchedule(draft: ParsedAgentDraft): boolean {
+  if (draft.schedule !== null) return true;
+  return draft.suggestedFrequency === undefined;
+}
+
+/**
+ * true when this draft should use the chat-native confirm affordance instead of
+ * AgentConfirmCard: an app-act action (the explicit example the project owner
+ * named), or a multi-step orchestration where at least one step pins a concrete
+ * tool (Phase 6's `detectToolPinnedSteps`, as opposed to Phase 4's plain
+ * auto-routed step chain, which keeps using the card unchanged this phase).
+ */
+export function shouldUseChatConfirm(draft: ParsedAgentDraft): boolean {
+  if (draft.action.type === 'app-act') return true;
+  return (draft.orchestrationSteps ?? []).some((s) => typeof s !== 'string' && !!s.tool);
+}
+
+function scheduleText(draft: ParsedAgentDraft): string {
+  if (draft.schedule !== null) {
+    const decoded = decodeCron(draft.schedule);
+    return scheduleHuman(
+      decoded.frequency,
+      decoded.hour,
+      decoded.minute,
+      decoded.weekday,
+      decoded.interval,
+      t,
+      decoded.dowList,
+      decoded.hourList
+        ? decoded.hourList.split(',').map((h) => parseInt(h, 10)).filter((n) => !Number.isNaN(n))
+        : [],
+    );
+  }
+  if (draft.suggestedFrequency !== undefined) {
+    // Ambiguous — see hasFireableSchedule. Do not fabricate a time here; the
+    // dedicated hint line (schedule_restate_hint) covers this case.
+    return t('agentcard.schedule_unset');
+  }
+  return t('agentcard.sched_once');
+}
+
+/** First app-act param value that isn't the raw `{{result}}` placeholder — a
+ *  literal, already-resolved preview of what will be posted, when one exists. */
+function appActContentPreview(params: Record<string, string> | undefined): string | undefined {
+  if (!params) return undefined;
+  for (const value of Object.values(params)) {
+    const trimmed = value.trim();
+    if (trimmed && !trimmed.includes('{{result}}')) return trimmed;
+  }
+  return undefined;
+}
+
+function actionText(action: AgentAction): string {
+  if (action.type === 'app-act') {
+    const target = action.appActRecipeId === 'x.post'
+      ? t('agentplan.appact_x_target')
+      : (action.appActRecipeId ?? t('agentcard.action_app-act'));
+    const preview = appActContentPreview(action.appActParams);
+    return preview
+      ? t('agentplan.appact_line_with_preview', { target, preview })
+      : t('agentplan.appact_line', { target });
+  }
+  const label = t(`agentcard.action_${action.type}`);
+  switch (action.type) {
+    case 'webhook':
+      return action.webhookUrl ? `${label} → ${action.webhookUrl}` : label;
+    case 'cli':
+      return action.command ? `${label}: ${action.command}` : label;
+    case 'intent':
+      return action.intentMode === 'launch' && action.intentTarget
+        ? `${label} → ${action.intentTarget}`
+        : label;
+    case 'dm-reply':
+      return label;
+    default:
+      return label;
+  }
+}
+
+/**
+ * Deterministic NL rendering of a ParsedAgentDraft — the chat-native equivalent
+ * of AgentConfirmCard's form fields. Covers every field a draft can carry:
+ * name, schedule, action (with app-act recipe/target + content preview),
+ * orchestration steps (instruction + pinned tool label per Phase 5/6), the
+ * autonomous flag, memory intent, a matched reusable skill, and any actionCaveat
+ * the parser attached. Ends with the schedule-restatement hint when the schedule
+ * is not yet fireable (see hasFireableSchedule) so the chat bubble itself explains
+ * why no Confirm affordance is offered.
+ */
+export function summarizeAgentDraftAsText(draft: ParsedAgentDraft): string {
+  const lines: string[] = [];
+  lines.push(t('agentplan.summary_name', { name: draft.name }));
+  lines.push(t('agentplan.summary_schedule', { schedule: scheduleText(draft) }));
+  lines.push(t('agentplan.summary_action', { action: actionText(draft.action) }));
+
+  if (draft.orchestrationSteps && draft.orchestrationSteps.length >= 2) {
+    lines.push(t('agentcard.orchestration', { count: draft.orchestrationSteps.length }));
+    draft.orchestrationSteps.forEach((s, i) => {
+      const instruction = typeof s === 'string' ? s : s.instruction;
+      const pinnedTool = typeof s === 'string' ? undefined : s.tool;
+      lines.push(
+        pinnedTool
+          ? `${i + 1}. [${toolChoiceToLabel(pinnedTool)}] ${instruction}`
+          : `${i + 1}. ${instruction}`,
+      );
+    });
+  }
+
+  if (draft.autonomous) lines.push(t('agentplan.autonomous_note'));
+  if (draft.memory?.remember) {
+    lines.push(t('agentplan.memory_note', { fact: draft.memory.rememberFact ?? '' }));
+  }
+  if (draft.matchedSkill) {
+    lines.push(
+      t('agentplan.skill_note', {
+        name: draft.matchedSkill.name,
+        count: draft.matchedSkill.successCount,
+      }),
+    );
+  }
+  if (draft.actionCaveat) lines.push(draft.actionCaveat);
+
+  if (!hasFireableSchedule(draft)) {
+    lines.push(t('agentplan.schedule_restate_hint'));
+  } else {
+    lines.push(t('agentplan.confirm_prompt'));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the SAME ConfirmedAgentDraft shape AgentConfirmCard's `handleConfirm`
+ * emits, but taken verbatim from the parsed draft — no inline editing, per the
+ * project owner's stated design ("re-prompt in chat, don't edit fields"). Reuses
+ * `confirmAgentDraft`'s EXISTING autonomous-tool resolution (resolveAutonomousFinalTool
+ * in hooks/use-ai-pane-dispatch.ts) rather than duplicating it here: `tool` is
+ * passed through as the raw scored suggestion and `runOn: 'auto'` matches
+ * AgentConfirmCard's own unedited default state, so confirmAgentDraft resolves it
+ * identically regardless of whether the draft came from the card or this chat-native
+ * path.
+ *
+ * Callers MUST check `hasFireableSchedule(draft)` first — this function does not
+ * re-validate the schedule and will happily pass through a null schedule for the
+ * ambiguous (needs-restatement) case, registering a one-shot instead of the
+ * recurring agent the user actually asked for.
+ */
+export function draftToConfirmedAgentDraft(draft: ParsedAgentDraft): ConfirmedAgentDraft {
+  return {
+    name: draft.name,
+    prompt: draft.prompt,
+    schedule: draft.schedule,
+    tool: draft.tool,
+    action: draft.action,
+    runOn: 'auto',
+    autonomous: draft.autonomous ?? false,
+    memory: draft.memory,
+    skillId: draft.matchedSkill?.id,
+    orchestrationSteps: draft.orchestrationSteps,
+    notificationTrigger: null,
+  };
+}

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -298,6 +298,20 @@ const en: Record<string, string> = {
   'agentcard.run_now': 'Run now',
   'agentcard.confirm': 'Confirm',
   'agentcard.cancel': 'Cancel',
+
+  // ── Chat-native agent confirmation (Phase 7) — used for app-act / tool-pinned
+  // orchestration instead of the card: this summary text plus a Confirm/Cancel pair.
+  'agentplan.summary_name': 'Agent: {{name}}',
+  'agentplan.summary_schedule': 'Schedule: {{schedule}}',
+  'agentplan.summary_action': 'Action: {{action}}',
+  'agentplan.autonomous_note': 'Runs autonomously (no per-run human approval).',
+  'agentplan.memory_note': 'Will remember after running: {{fact}}',
+  'agentplan.skill_note': 'Reuses the existing skill "{{name}}" ({{count}} prior successes).',
+  'agentplan.schedule_restate_hint': '⚠ I could not pin down a firm schedule. Please restate it with an explicit time (e.g. "daily at 8am"). This cannot be registered until then.',
+  'agentplan.appact_x_target': 'Posting to X (Twitter)',
+  'agentplan.appact_line': '{{target}} (posts the run result as-is)',
+  'agentplan.appact_line_with_preview': '{{target}}: "{{preview}}"',
+  'agentplan.confirm_prompt': 'Register this agent as described above? Cancel and re-describe it if you want changes.',
   'api_keys.title': 'API Keys',
   'api_keys.paste_placeholder': 'Paste {{name}} API key',
   'codex_login.title': 'Codex Login',

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -298,6 +298,20 @@ const ja: Record<string, string> = {
   'agentcard.run_now': '実行',
   'agentcard.confirm': '登録',
   'agentcard.cancel': 'キャンセル',
+
+  // ── チャット内エージェント確認 (Phase 7) — app-act / ツール指定オーケストレーション向け。
+  // カードを出さず、この要約テキスト + 確認/キャンセルの2ボタンのみで登録する。
+  'agentplan.summary_name': 'エージェント名: {{name}}',
+  'agentplan.summary_schedule': '実行タイミング: {{schedule}}',
+  'agentplan.summary_action': '実行内容: {{action}}',
+  'agentplan.autonomous_note': '自律実行（実行のたびに人の承認は挟まれません）',
+  'agentplan.memory_note': '実行後に記憶: {{fact}}',
+  'agentplan.skill_note': '既存スキル「{{name}}」を再利用します（成功実績 {{count}}回）',
+  'agentplan.schedule_restate_hint': '⚠ 実行タイミングを確定できませんでした。時刻を含めて言い直してください（例:「毎日8時に」）。確定するまで登録できません。',
+  'agentplan.appact_x_target': 'X（旧Twitter）への投稿',
+  'agentplan.appact_line': '{{target}}（実行結果をそのまま投稿）',
+  'agentplan.appact_line_with_preview': '{{target}}：「{{preview}}」',
+  'agentplan.confirm_prompt': 'この内容で登録しますか？ 変更したい場合はキャンセルしてから言い直してください。',
   'api_keys.title': 'APIキー',
   'api_keys.paste_placeholder': '{{name}} APIキーを貼り付け',
   'codex_login.title': 'Codexログイン',

--- a/store/chat-store.ts
+++ b/store/chat-store.ts
@@ -81,6 +81,12 @@ export type ChatMessage = {
    *  text; on confirm the agent is created+installed. JSON-serializable. */
   agentDraft?: import('@/lib/agent-nl-parser').ParsedAgentDraft;
   agentCardState?: 'pending' | 'confirmed' | 'cancelled';
+  /** Phase 7: true = render the chat-native AgentChatConfirm affordance (summary
+   *  text already in `content` + inline Confirm/Cancel) instead of AgentConfirmCard
+   *  for this pending draft. Set for app-act / tool-pinned orchestration drafts —
+   *  see lib/agent-plan-summary.ts's shouldUseChatConfirm. Absent/false = the
+   *  existing card path, unchanged. */
+  agentChatConfirm?: boolean;
 };
 
 export type ChatSession = {


### PR DESCRIPTION
## Summary
Phase 7 of the app-act delivery series — implements the project owner's standing UX rule ("カードも要らないって。チャットで自然言語で確認すればいいじゃん。") for the first time on a new confirmation surface, rather than retrofitting the existing structured card.

- \`lib/agent-plan-summary.ts\` (new, pure): \`summarizeAgentDraftAsText()\` renders a draft's schedule/steps/action as plain chat text, reusing \`scheduleHuman\`/\`toolChoiceToLabel\` (no duplicated mapping logic).
- \`components/panes/AgentChatConfirm.tsx\` (new): the confirm affordance — two plain buttons trailing the assistant's chat message, no form fields.
- \`hasFireableSchedule()\` preserves \`AgentConfirmCard\`'s own hard requirement ("never register an agent that will never fire") for the no-editing chat flow: Confirm is withheld when the parser found a recurrence cue but no confirmable time, with a restate-the-schedule hint shown instead.
- \`shouldUseChatConfirm()\` scopes this to \`app-act\` actions or tool-pinned orchestration steps only — a plain auto-routed multi-step chain (no pins) still uses \`AgentConfirmCard\` unchanged, a deliberate scoping decision (broadening to all agent types is a bigger call left to the project owner).
- Zero changes to runtime approval logic (\`lib/agent-executor.ts\`, \`scripts/shelly-plan-executor.js\`, \`AgentActionApprovalBridge.kt\`) — this phase is registration-time confirmation only.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 114 relevant tests pass (\`agent-plan-summary\` 14 cases across draft shapes, \`AgentChatConfirm\` 4 cases including schedule-withholding, \`AgentConfirmCard\` regression, \`agent-nl-parser\`)
- [x] Confirmed zero overlap with runtime-approval files touched by parallel work tonight