### PR TITLE
feat(ai-pane): insert code blocks into the focused Terminal pane, opening one if needed

### DIFF
--- a/components/panes/CodeBlockWithAction.tsx
+++ b/components/panes/CodeBlockWithAction.tsx
@@ -3,9 +3,10 @@
  *
  * Fenced-code renderer for assistant messages. Adds a header row with
  * the language tag and two one-tap actions: Copy and Insert-to-Terminal.
- * Insert routes through TerminalEmulator.writeToSession so the code
- * lands in the active terminal as if the user had pasted + pressed
- * Enter at the prompt.
+ * Insert routes through TerminalEmulator.pasteToSession — the same single
+ * paste choke point (bug #81) every other paste path uses — so the code
+ * lands in the active terminal's input WITHOUT a trailing Enter. Running it
+ * is always the user's own explicit keypress, never automatic.
  */
 
 import React, { useCallback } from 'react';
@@ -14,10 +15,13 @@ import { MaterialIcons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import TerminalEmulator from '@/modules/terminal-emulator/src/TerminalEmulatorModule';
 import { useTerminalStore } from '@/store/terminal-store';
+import { useMultiPaneStore } from '@/hooks/use-multi-pane';
+import { useAddPane } from '@/hooks/use-add-pane';
 import { getStagedEdit, applyStagedEdit } from '@/lib/ai-edit';
 import { playSound } from '@/lib/sounds';
 import { colors as C, fonts as F } from '@/theme.config';
 import { usePanelBackground } from '@/hooks/use-panel-background';
+import { useTranslation } from '@/lib/i18n';
 
 type Props = {
   lang?: string;
@@ -59,21 +63,47 @@ export function CodeBlockWithAction({ lang, code }: Props) {
   const trimmed = code.replace(/\s+$/, '');
   const rootBg = usePanelBackground(C.bgDeep);
   const headerBg = usePanelBackground(C.bgSidebar);
+  const { t } = useTranslation();
+  const addPane = useAddPane();
 
   const handleCopy = useCallback(async () => {
     await Clipboard.setStringAsync(trimmed);
     try { playSound('copy'); } catch {}
     if (Platform.OS === 'android') {
-      ToastAndroid.show('Copied to clipboard', ToastAndroid.SHORT);
+      ToastAndroid.show(t('code_block.copied_toast'), ToastAndroid.SHORT);
     }
-  }, [trimmed]);
+  }, [trimmed, t]);
 
   const handleInsert = useCallback(async () => {
     const sessionId = useTerminalStore.getState().activeSessionId;
     const session = useTerminalStore.getState().sessions.find((candidate) => candidate.id === sessionId);
-    if (!session?.nativeSessionId) {
+    // createSession() always stamps a nativeSessionId (e.g. "shelly-1") up
+    // front, even for a session that's never actually been shown in a pane —
+    // so `!session?.nativeSessionId` alone can't detect "no live Terminal
+    // pane" (Codex review, 2026-08-30). The real signal is whether any
+    // Terminal-type slot currently exists in the pane layout at all.
+    const hasTerminalPane = useMultiPaneStore.getState().slots.some((slot) => slot?.tab === 'terminal');
+    if (!hasTerminalPane || !session?.nativeSessionId) {
+      // No live Terminal pane to target (e.g. the AI Pane is the only pane
+      // open, or the last-focused Terminal pane's native session hasn't
+      // spawned yet). Nacre Bridge slice 1: rather than silently dropping the
+      // insert, open a fresh Terminal pane via the same useAddPane() path
+      // QuickLaunchSection uses — it already shows the standard cap-reached
+      // Alert when the layout/terminal limits are hit, so we only need to
+      // handle the success case here.
+      const result = addPane('terminal');
+      if (result !== null) return; // useAddPane already alerted (cap reached)
+      const newSessionId = useTerminalStore.getState().activeSessionId;
+      // The freshly created pane's native session hasn't forked yet (async
+      // JNI createSubprocess), so pasteToSession would race it. insertCommand
+      // queues the text through the same pendingCommand mechanism
+      // QuickLaunchSection/ProfilesSection use, which itself resolves through
+      // TerminalEmulator.pasteToSession the moment the session goes 'alive' —
+      // same choke point, no trailing newline, so nothing auto-runs.
+      useTerminalStore.getState().insertCommand(trimmed, newSessionId);
+      try { playSound('send'); } catch {}
       if (Platform.OS === 'android') {
-        ToastAndroid.show('No active terminal', ToastAndroid.SHORT);
+        ToastAndroid.show(t('code_block.inserted_new_pane_toast'), ToastAndroid.SHORT);
       }
       return;
     }
@@ -85,17 +115,17 @@ export function CodeBlockWithAction({ lang, code }: Props) {
       await TerminalEmulator.pasteToSession(session.nativeSessionId, trimmed);
       try { playSound('send'); } catch {}
       if (Platform.OS === 'android') {
-        ToastAndroid.show('Inserted into terminal', ToastAndroid.SHORT);
+        ToastAndroid.show(t('code_block.inserted_toast'), ToastAndroid.SHORT);
       }
     } catch (err) {
       if (Platform.OS === 'android') {
         ToastAndroid.show(
-          'Insert failed: ' + (err instanceof Error ? err.message : String(err)),
+          t('code_block.insert_failed_toast', { error: err instanceof Error ? err.message : String(err) }),
           ToastAndroid.SHORT,
         );
       }
     }
-  }, [trimmed]);
+  }, [trimmed, t, addPane]);
 
   const canInsert = isShellLike(lang);
   // If the AI pane has a staged file whose extension matches this block's
@@ -113,11 +143,13 @@ export function CodeBlockWithAction({ lang, code }: Props) {
     try { playSound(err === null ? 'success' : 'error'); } catch {}
     if (Platform.OS === 'android') {
       ToastAndroid.show(
-        err === null ? `Wrote ${staged.path}` : `Apply failed: ${err}`,
+        err === null
+          ? t('code_block.wrote_file_toast', { path: staged.path })
+          : t('code_block.apply_failed_toast', { error: err }),
         ToastAndroid.SHORT,
       );
     }
-  }, [staged, trimmed]);
+  }, [staged, trimmed, t]);
 
   return (
     <View style={[styles.root, { backgroundColor: rootBg }]}>
@@ -127,20 +159,20 @@ export function CodeBlockWithAction({ lang, code }: Props) {
           {canApplyToFile && staged ? `  ·  ${staged.path.split('/').pop()}` : ''}
         </Text>
         <View style={styles.actions}>
-          <Pressable onPress={handleCopy} style={styles.btn} hitSlop={6} accessibilityLabel="Copy code">
+          <Pressable onPress={handleCopy} style={styles.btn} hitSlop={6} accessibilityLabel={t('code_block.copy_a11y')}>
             <MaterialIcons name="content-copy" size={12} color={C.text2} />
-            <Text style={styles.btnLabel}>COPY</Text>
+            <Text style={styles.btnLabel}>{t('code_block.copy_label')}</Text>
           </Pressable>
           {canInsert ? (
-            <Pressable onPress={handleInsert} style={[styles.btn, styles.btnPrimary]} hitSlop={6} accessibilityLabel="Insert into terminal">
+            <Pressable onPress={handleInsert} style={[styles.btn, styles.btnPrimary]} hitSlop={6} accessibilityLabel={t('code_block.insert_a11y')}>
               <MaterialIcons name="arrow-forward" size={12} color={C.btnPrimaryText} />
-              <Text style={[styles.btnLabel, styles.btnLabelPrimary]}>INSERT</Text>
+              <Text style={[styles.btnLabel, styles.btnLabelPrimary]}>{t('code_block.insert_label')}</Text>
             </Pressable>
           ) : null}
           {canApplyToFile ? (
-            <Pressable onPress={handleApplyToFile} style={[styles.btn, styles.btnPrimary]} hitSlop={6} accessibilityLabel="Apply to staged file">
+            <Pressable onPress={handleApplyToFile} style={[styles.btn, styles.btnPrimary]} hitSlop={6} accessibilityLabel={t('code_block.apply_a11y')}>
               <MaterialIcons name="save" size={12} color={C.btnPrimaryText} />
-              <Text style={[styles.btnLabel, styles.btnLabelPrimary]}>APPLY</Text>
+              <Text style={[styles.btnLabel, styles.btnLabelPrimary]}>{t('code_block.apply_label')}</Text>
             </Pressable>
           ) : null}
         </View>

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -2422,6 +2422,22 @@ const en: Record<string, string> = {
   'ai_pane_images_require_gemini': 'Image attachments need the Gemini provider — switch this pane to Gemini (or add a Gemini API key in Settings), then send again.',
   'ai_pane_image_default_prompt': 'Describe this image.',
   'ai_pane_stop_streaming': 'Stop',
+
+  // ── Code Block Actions (Nacre Bridge slice 1: AI Pane → Terminal insert) ──
+  'code_block.copy_label': 'COPY',
+  'code_block.insert_label': 'INSERT',
+  'code_block.apply_label': 'APPLY',
+  'code_block.copy_a11y': 'Copy code',
+  'code_block.insert_a11y': 'Insert into terminal',
+  'code_block.apply_a11y': 'Apply to staged file',
+  'code_block.copied_toast': 'Copied to clipboard',
+  'code_block.inserted_toast': 'Inserted into terminal',
+  // Shown when no Terminal pane was open/live, so a new one was opened and
+  // the text queued for it instead — see CodeBlockWithAction's handleInsert.
+  'code_block.inserted_new_pane_toast': 'Opened a new terminal and queued the insert',
+  'code_block.insert_failed_toast': 'Insert failed: {{error}}',
+  'code_block.wrote_file_toast': 'Wrote {{path}}',
+  'code_block.apply_failed_toast': 'Apply failed: {{error}}',
 };
 
 export default en;

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -2386,6 +2386,20 @@ const ja: Record<string, string> = {
   'ai_pane_images_require_gemini': '画像の添付にはGeminiプロバイダが必要です — このペインをGeminiに切り替える（または設定でGemini APIキーを追加する）か、対応するペインで送信し直してください。',
   'ai_pane_image_default_prompt': 'この画像について説明してください。',
   'ai_pane_stop_streaming': '停止',
+
+  // ── Code Block Actions (Nacre Bridge 第一弾: AIペイン→ターミナル挿入) ──
+  'code_block.copy_label': 'コピー',
+  'code_block.insert_label': '挿入',
+  'code_block.apply_label': '適用',
+  'code_block.copy_a11y': 'コードをコピー',
+  'code_block.insert_a11y': 'ターミナルに挿入',
+  'code_block.apply_a11y': 'ステージ中のファイルに適用',
+  'code_block.copied_toast': 'クリップボードにコピーしました',
+  'code_block.inserted_toast': 'ターミナルに挿入しました',
+  'code_block.inserted_new_pane_toast': '新しいターミナルを開いて挿入を予約しました',
+  'code_block.insert_failed_toast': '挿入に失敗しました: {{error}}',
+  'code_block.wrote_file_toast': '{{path}} に書き込みました',
+  'code_block.apply_failed_toast': '適用に失敗しました: {{error}}',
 };
 
 export default ja;


### PR DESCRIPTION
## Summary

First "C" feature of the Shelly↔Nacre Bridge brainstorm (per Fable5 + Codex design consult): the AI Pane's existing per-code-block COPY/INSERT/APPLY actions (`CodeBlockWithAction.tsx`, from `63bbdbcb5`) had an unfinished fallback — if no live Terminal pane existed to target (e.g. only the AI Pane was open), INSERT just showed a "No active terminal" toast and did nothing. This completes it: INSERT now opens a fresh Terminal pane and queues the text into it instead of silently failing.

- Uses the existing `useAddPane('terminal')` path (same as `QuickLaunchSection`) — the standard pane-cap Alert still fires if the layout is full, and we bail out in that case.
- The newly created pane's native PTY session hasn't forked yet (async JNI `createSubprocess`), so a direct `pasteToSession` call would race it. Instead the text is queued via `terminal-store`'s `insertCommand()` (the same `pendingCommand` mechanism `QuickLaunchSection`/`ProfilesSection` already use), which itself resolves through `TerminalEmulator.pasteToSession` — the single paste choke point (bug #81) — the moment the session goes `'alive'`.
- No trailing newline anywhere in this path, so nothing auto-executes — the user must press Enter themselves.
- i18n: replaced hardcoded English toast/label/a11y strings with `t()` lookups, added `code_block.*` keys to both `en.ts` and `ja.ts`.

### Codex review — one issue found and fixed
Codex caught that the original "is there a live Terminal pane?" check (`!session?.nativeSessionId`) was wrong: `terminal-store`'s `createSession()` always stamps a `nativeSessionId` up front (even for a session object that was never actually shown in a pane), so that check could never actually detect "AI Pane is the only pane open." Fixed by additionally checking whether any Terminal-type slot exists in the current pane layout (`useMultiPaneStore.getState().slots.some(slot => slot?.tab === 'terminal')`) — the real signal for "is there a live Terminal pane to target." Also fixed a stale/backwards module doc comment that described the old `writeToSession` (auto-Enter) behavior instead of the current safe `pasteToSession` (no auto-Enter) behavior.

## Test plan
- [ ] `tsc --noEmit`: no errors.
- [ ] `__tests__/ai-pane-dispatch-interaction-order.test.tsx`: 83/83 passing (verified during implementation).
- [ ] On-device: with only the AI Pane open, tap INSERT on a shell code block — confirm a new Terminal pane opens and the text lands in its input with no trailing newline and no auto-run.
- [ ] On-device: with an existing Terminal pane focused, tap INSERT — confirm the text is pasted into that pane's current input.
- [ ] On-device: with the pane layout already at capacity, tap INSERT with no Terminal pane open — confirm the existing pane-cap Alert fires instead of a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)