### PR TITLE
feat(nacre-bridge): share sanitized terminal context with Nacre IME

### DIFF
--- a/__tests__/nacre-bridge-context.test.ts
+++ b/__tests__/nacre-bridge-context.test.ts
@@ -1,0 +1,285 @@
+// Nacre Bridge (Shelly → Nacre IME context sharing, feature B) — sanitization
+// pipeline tests. These target the PURE functions in lib/nacre-bridge-context.ts;
+// no expo-file-system I/O is exercised here (mocked out below since the module
+// imports it at top level, matching the pattern __tests__/memory/shadow.test.ts
+// uses for the same reason).
+jest.mock('expo-file-system/legacy', () => ({}));
+
+import {
+  sanitizeTerms,
+  sanitizeCwdSegments,
+  sanitizeRepoOrBranch,
+  isSafeToken,
+  buildNacreBridgeContext,
+  NACRE_BRIDGE_TTL_MS,
+  NACRE_BRIDGE_MAX_TERMS,
+} from '@/lib/nacre-bridge-context';
+
+describe('isSafeToken — shared character-class gate', () => {
+  it('accepts alnum + _.-/ within 1-40 chars', () => {
+    expect(isSafeToken('git')).toBe(true);
+    expect(isSafeToken('terminal-store')).toBe(true);
+    expect(isSafeToken('ConfigTUI.tsx')).toBe(true);
+    expect(isSafeToken('components/layout')).toBe(true);
+    expect(isSafeToken('feature/nacre-bridge')).toBe(true);
+  });
+
+  it('rejects empty, oversized, or oddly-charactered strings', () => {
+    expect(isSafeToken('')).toBe(false);
+    expect(isSafeToken('a'.repeat(41))).toBe(false);
+    expect(isSafeToken('has space')).toBe(false);
+    expect(isSafeToken('KEY=value')).toBe(false);
+    expect(isSafeToken('Authorization:Bearer')).toBe(false);
+    expect(isSafeToken('https://example.com')).toBe(false);
+    expect(isSafeToken('a"b')).toBe(false);
+  });
+});
+
+describe('sanitizeTerms — secret-prefix exclusion', () => {
+  it.each([
+    ['sk-abcdefghijklmnopqrstuvwx', 'sk-'],
+    ['ghp_abcdefghijklmnopqrstuvwx', 'ghp_'],
+    ['github_pat_abcdefghijklmnopqrstuvwx', 'github_pat_'],
+    ['glpat-abcdefghijklmnopqrstuvwx', 'glpat-'],
+    ['xoxb-abcdefghijklmnopqrstuvwx', 'xoxb-'],
+    ['xoxp-abcdefghijklmnopqrstuvwx', 'xoxp-'],
+    ['AKIAABCDEFGHIJKLMNOP', 'AKIA'],
+    ['ASIAABCDEFGHIJKLMNOP', 'ASIA'],
+    ['AIzaAbCdEfGhIjKlMnOpQrStUvWx', 'AIza'],
+    ['ya29.abcdefghijklmnopqrstuvwx', 'ya29.'],
+    ['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', 'eyJ'],
+  ])('drops a token starting with %s (%s prefix)', (token) => {
+    const result = sanitizeTerms([`curl -H ${token} https://api.example.com`]);
+    expect(result.some((t) => t.startsWith(token.slice(0, 3)))).toBe(false);
+    expect(result).not.toContain(token);
+  });
+
+  it('keeps the safe surrounding command tokens while dropping the secret', () => {
+    const result = sanitizeTerms(['curl sk-abcdefghijklmnopqrstuvwxyz123']);
+    expect(result).toContain('curl');
+    expect(result.some((t) => t.startsWith('sk-'))).toBe(false);
+  });
+});
+
+describe('sanitizeTerms — high-entropy string exclusion', () => {
+  it('drops a 20+ char base64-looking token', () => {
+    const token = 'QWxhZGRpbjpvcGVuc2VzYW1l1234'; // 28 chars, base64 charset
+    const result = sanitizeTerms([`export TOKEN_VAR ${token}`]);
+    expect(result).not.toContain(token);
+  });
+
+  it('drops a 20+ char hex-looking token', () => {
+    const token = 'deadbeefcafebabe0123456789abcdef'; // hex charset, 33 chars
+    const result = sanitizeTerms([`git commit ${token}`]);
+    expect(result).not.toContain(token);
+    expect(result).toContain('git');
+    expect(result).toContain('commit');
+  });
+
+  it('keeps a short hex-looking token (git short SHA) under the entropy threshold', () => {
+    const result = sanitizeTerms(['git checkout a1b2c3d']);
+    expect(result).toContain('a1b2c3d');
+  });
+});
+
+describe('sanitizeTerms — flag/env-var secret assignment exclusion', () => {
+  it('drops --token= style flags', () => {
+    const result = sanitizeTerms(['mycli --token=abcdefghijklmnop deploy']);
+    expect(result.some((t) => t.includes('token'))).toBe(false);
+    expect(result).toContain('mycli');
+    expect(result).toContain('deploy');
+  });
+
+  it('drops KEY=/PASSWORD=/SECRET= assignments', () => {
+    const result = sanitizeTerms(['export KEY=abc123 PASSWORD=hunter2 SECRET=xyz789 node app.js']);
+    expect(result).not.toContain('KEY=abc123');
+    expect(result).not.toContain('PASSWORD=hunter2');
+    expect(result).not.toContain('SECRET=xyz789');
+    expect(result).toContain('export');
+    expect(result).toContain('node');
+    expect(result).toContain('app.js');
+  });
+
+  it('drops an Authorization: header style token', () => {
+    const result = sanitizeTerms(['curl -H Authorization:Bearer-abc123 https://api.example.com']);
+    expect(result.some((t) => /authorization/i.test(t))).toBe(false);
+  });
+});
+
+describe('sanitizeTerms — URL query parameter exclusion', () => {
+  it('strips the query string from a schemeless path token', () => {
+    const result = sanitizeTerms(['curl api/resource?token=abc123&user=me']);
+    expect(result).toContain('api/resource');
+    expect(result.some((t) => t.includes('token=abc123'))).toBe(false);
+  });
+
+  it('excludes an absolute URL entirely via the char-class gate (colon not allowed)', () => {
+    const result = sanitizeTerms(['curl https://example.com/path?token=abc123']);
+    expect(result.some((t) => t.includes('://'))).toBe(false);
+  });
+});
+
+describe('sanitizeTerms — quoted long string exclusion', () => {
+  it('drops a quoted string longer than 20 chars entirely', () => {
+    const result = sanitizeTerms(['git commit -m "this is a very long commit message"']);
+    expect(result.join(' ')).not.toMatch(/this is a very long/);
+    expect(result).toContain('git');
+    expect(result).toContain('commit');
+    expect(result).toContain('-m');
+  });
+
+  it('keeps a short quoted string, unwrapped, subject to the normal filters', () => {
+    const result = sanitizeTerms(['echo "hello"']);
+    expect(result).toContain('echo');
+    expect(result).toContain('hello');
+  });
+});
+
+describe('sanitizeTerms — suspicious character exclusion (step 6)', () => {
+  it('drops tokens with disallowed characters like spaces or shell metacharacters baked in', () => {
+    const result = sanitizeTerms(['echo $(whoami)']);
+    expect(result.some((t) => t.includes('$') || t.includes('(') || t.includes(')'))).toBe(false);
+  });
+});
+
+describe('sanitizeTerms — command names and paths pass through', () => {
+  it('keeps common CLI names, flags, and file paths', () => {
+    const result = sanitizeTerms([
+      'git status',
+      'pnpm install',
+      'npm run build',
+      'node lib/pseudo-shell.ts',
+      'cat components/config/ConfigTUI.tsx',
+    ]);
+    expect(result).toEqual(
+      expect.arrayContaining(['git', 'status', 'pnpm', 'install', 'npm', 'run', 'build', 'node']),
+    );
+    expect(result).toContain('lib/pseudo-shell.ts');
+    expect(result).toContain('components/config/ConfigTUI.tsx');
+  });
+});
+
+describe('sanitizeTerms — dedup and 20-item cap', () => {
+  it('deduplicates repeated terms', () => {
+    const result = sanitizeTerms(['git status', 'git status', 'git log']);
+    expect(result.filter((t) => t === 'git').length).toBe(1);
+  });
+
+  it('truncates to NACRE_BRIDGE_MAX_TERMS', () => {
+    const commands = Array.from({ length: 30 }, (_, i) => `tool${i} arg${i}`);
+    const result = sanitizeTerms(commands);
+    expect(result.length).toBeLessThanOrEqual(NACRE_BRIDGE_MAX_TERMS);
+    expect(result.length).toBe(NACRE_BRIDGE_MAX_TERMS);
+  });
+
+  it('handles empty/blank input safely', () => {
+    expect(sanitizeTerms([])).toEqual([]);
+    expect(sanitizeTerms(['', '   ', '\n'])).toEqual([]);
+  });
+});
+
+describe('sanitizeCwdSegments', () => {
+  it('splits an absolute path into safe segments', () => {
+    expect(sanitizeCwdSegments('/Users/info/Shelly/components')).toEqual([
+      'Users',
+      'info',
+      'Shelly',
+      'components',
+    ]);
+  });
+
+  it('handles Android-style paths', () => {
+    expect(sanitizeCwdSegments('/data/user/0/dev.shelly.terminal/files/home')).toEqual([
+      'data',
+      'user',
+      '0',
+      'dev.shelly.terminal',
+      'files',
+      'home',
+    ]);
+  });
+
+  it('drops a segment containing disallowed characters', () => {
+    expect(sanitizeCwdSegments('/Users/info/weird name/proj')).toEqual(['Users', 'info', 'proj']);
+  });
+
+  it('returns an empty array for empty/invalid input', () => {
+    expect(sanitizeCwdSegments('')).toEqual([]);
+  });
+
+  it('drops a segment that looks like a secret, even though it passes the char-class gate (Codex review)', () => {
+    expect(sanitizeCwdSegments('/Users/info/sk-testtoken/proj')).toEqual(['Users', 'info', 'proj']);
+  });
+
+  it('drops a high-entropy-looking segment, even though it passes the char-class gate (Codex review)', () => {
+    expect(sanitizeCwdSegments('/Users/info/AAAAAAAAAAAAAAAAAAAA/proj')).toEqual([
+      'Users',
+      'info',
+      'proj',
+    ]);
+  });
+});
+
+describe('sanitizeRepoOrBranch', () => {
+  it('keeps a safe repo name', () => {
+    expect(sanitizeRepoOrBranch('Shelly')).toBe('Shelly');
+  });
+
+  it('keeps a safe branch name containing a slash', () => {
+    expect(sanitizeRepoOrBranch('feature/nacre-bridge-shelly-writer')).toBe(
+      'feature/nacre-bridge-shelly-writer',
+    );
+  });
+
+  it('omits (returns undefined for) missing, empty, or unsafe values — never coerces to empty string', () => {
+    expect(sanitizeRepoOrBranch(undefined)).toBeUndefined();
+    expect(sanitizeRepoOrBranch(null)).toBeUndefined();
+    expect(sanitizeRepoOrBranch('')).toBeUndefined();
+    expect(sanitizeRepoOrBranch('  ')).toBeUndefined();
+    expect(sanitizeRepoOrBranch('weird branch name')).toBeUndefined();
+  });
+
+  it('omits a value with a known secret prefix, even though it passes the char-class gate (Codex review)', () => {
+    expect(sanitizeRepoOrBranch('sk-testtoken')).toBeUndefined();
+    expect(sanitizeRepoOrBranch('AKIAIOSFODNN7EXAMPLE')).toBeUndefined();
+  });
+
+  it('omits a high-entropy-looking value, even though it passes the char-class gate (Codex review)', () => {
+    expect(sanitizeRepoOrBranch('a1B2c3D4e5F6g7H8i9J0')).toBeUndefined();
+  });
+});
+
+describe('buildNacreBridgeContext', () => {
+  it('assembles the full contract shape with a 5-minute TTL', () => {
+    const now = 1_735_500_000_000;
+    const ctx = buildNacreBridgeContext({
+      cwd: '/Users/info/Shelly/components',
+      repo: 'Shelly',
+      branch: 'main',
+      recentCommands: ['pnpm jest', 'git status'],
+      now,
+    });
+    expect(ctx).toEqual({
+      schema: 1,
+      generatedAt: now,
+      expiresAt: now + NACRE_BRIDGE_TTL_MS,
+      repo: 'Shelly',
+      branch: 'main',
+      cwdSegments: ['Users', 'info', 'Shelly', 'components'],
+      terms: expect.arrayContaining(['pnpm', 'jest', 'git', 'status']),
+    });
+    expect(NACRE_BRIDGE_TTL_MS).toBe(300_000);
+  });
+
+  it('omits repo/branch fields entirely when not resolvable', () => {
+    const ctx = buildNacreBridgeContext({
+      cwd: '/Users/info/Shelly',
+      recentCommands: [],
+      now: 0,
+    });
+    expect(ctx.repo).toBeUndefined();
+    expect(ctx.branch).toBeUndefined();
+    expect('repo' in ctx).toBe(false);
+    expect('branch' in ctx).toBe(false);
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -55,6 +55,7 @@ import {
 import { detectCodexApprovalPrompt, detectCodexInteractivePrompt } from '@/lib/codex-pty-detection';
 import { execCommand } from '@/hooks/use-native-exec';
 import { useTelegramInbound } from '@/hooks/use-telegram-inbound';
+import { useNacreBridge } from '@/hooks/use-nacre-bridge';
 import TerminalEmulator from '@/modules/terminal-emulator/src/TerminalEmulatorModule';
 import { getOptionalPack } from '@/lib/optional-packs';
 import { installOptionalPack } from '@/lib/optional-pack-installer';
@@ -249,6 +250,10 @@ export default function RootLayout() {
   // Phase 3 inbound gateway: long-poll Telegram for the authorized chat (no-op
   // unless enabled + token + chat id are configured). Enqueues confirm cards only.
   useTelegramInbound();
+  // Nacre Bridge (feature B): while foregrounded, shares a sanitized slice of
+  // terminal context with the Nacre IME via shared storage. No-op when
+  // settings.nacreBridgeEnabled is off. See hooks/use-nacre-bridge.ts.
+  useNacreBridge();
   const [pendingAgentActionApproval, setPendingAgentActionApproval] =
     useState<AgentActionApprovalRequest | null>(null);
   const [agentActionResolving, setAgentActionResolving] = useState(false);

--- a/components/config/ConfigTUI.tsx
+++ b/components/config/ConfigTUI.tsx
@@ -208,6 +208,7 @@ const SECTIONS: { title: string; icon: string; items: SettingDef[] }[] = [
       { key: 'customContext', label: 'Custom System Prompt', type: 'string', source: 'custom', description: 'Injected into AI context' },
       { key: 'llmInterpreterEnabled', label: 'LLM Interpreter', type: 'boolean', source: 'settings' },
       { key: 'realtimeTranslateEnabled', label: 'Realtime Translate', type: 'boolean', source: 'settings' },
+      { key: 'nacreBridgeEnabled', label: 'Nacre Bridge', labelKey: 'settings.nacre_bridge_label', type: 'boolean', source: 'settings', description: 'While Shelly is in the foreground, share your current directory, git branch, and safe recent command terms (never raw commands or secrets) with the Nacre IME to improve its conversion suggestions. Default on.', descriptionKey: 'settings.nacre_bridge_desc' },
     ],
   },
   {

--- a/hooks/use-nacre-bridge.ts
+++ b/hooks/use-nacre-bridge.ts
@@ -1,0 +1,178 @@
+/**
+ * hooks/use-nacre-bridge.ts — Shelly → Nacre bridge (feature B), foreground-only.
+ *
+ * Mount once near the app root (see app/_layout.tsx). While Shelly is in the
+ * foreground, writes a sanitized context.json (lib/nacre-bridge-context.ts —
+ * the fixed file-path/JSON-schema/sanitization contract shared with the
+ * Nacre IME side) whenever the active session's cwd, git branch, or recent
+ * command history changes. Writes are debounced (batch bursty triggers) and
+ * throttled to roughly once every MIN_WRITE_INTERVAL_MS, per the contract's
+ * "don't write too frequently" requirement. The file is deleted the moment
+ * the app leaves the foreground (background/inactive), and is never written
+ * at all while backgrounded — its `expiresAt` TTL is the backstop if deletion
+ * itself fails for any reason.
+ *
+ * Gated by settings.nacreBridgeEnabled (default ON). Pure sanitization /
+ * JSON-assembly / file I/O live in lib/nacre-bridge-context.ts (unit-tested);
+ * this hook only owns wiring: WHEN to call it.
+ */
+import { useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+import { useSettingsStore } from '@/store/settings-store';
+import { useTerminalStore } from '@/store/terminal-store';
+import { execCommand } from '@/hooks/use-native-exec';
+import { getHomePath } from '@/lib/home-path';
+import {
+  buildNacreBridgeContext,
+  writeNacreBridgeContext,
+  invalidateNacreBridgeContext,
+} from '@/lib/nacre-bridge-context';
+import { logInfo, logError } from '@/lib/debug-logger';
+
+/** Throttle floor: never write more often than this even under a burst of
+ *  triggers (contract: "数秒〜十数秒に1回程度にデバウンス/スロットルする"). */
+const MIN_WRITE_INTERVAL_MS = 8_000;
+/** Debounce window: wait for triggers to go quiet before writing, so a
+ *  rapid-fire sequence (e.g. several commands typed in a row) collapses
+ *  into one write instead of one per keystroke/command. */
+const DEBOUNCE_MS = 1_500;
+/** How many recent raw commands to feed into the sanitizer per write — the
+ *  sanitizer itself further caps its OUTPUT terms at 20 regardless. */
+const MAX_RECENT_COMMANDS = 20;
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/** Mirrors components/layout/ContextBar.tsx's canonicalizeAndroidDataPath:
+ *  /data/data/<pkg> and /data/user/0/<pkg> are two OS aliases for the same
+ *  app-private directory, so a plain string compare against HOME can
+ *  spuriously mismatch. Used here to avoid ever reporting Shelly's own HOME
+ *  as if it were a git repo. */
+function canonicalizeAndroidDataPath(path: string): string {
+  return path
+    .replace(/^\/data\/user\/0\/dev\.shelly\.terminal\//, '/__shelly_data__/')
+    .replace(/^\/data\/data\/dev\.shelly\.terminal\//, '/__shelly_data__/');
+}
+
+async function resolveGitContext(
+  cwd: string,
+  home: string,
+): Promise<{ repo?: string; branch?: string }> {
+  if (canonicalizeAndroidDataPath(cwd) === canonicalizeAndroidDataPath(home)) {
+    return {};
+  }
+  try {
+    const r = await execCommand(
+      `cd ${shellQuote(cwd)} && git rev-parse --show-toplevel 2>/dev/null && git branch --show-current 2>/dev/null`,
+    );
+    if (r.exitCode !== 0) return {};
+    const [toplevel, branch] = r.stdout.split('\n').map((l) => l.trim());
+    const repo = toplevel ? toplevel.split('/').filter(Boolean).pop() : undefined;
+    return { repo: repo || undefined, branch: branch || undefined };
+  } catch {
+    return {};
+  }
+}
+
+export function useNacreBridge(): void {
+  const enabled = useSettingsStore((s) => s.settings.nacreBridgeEnabled ?? true);
+  const currentDir = useTerminalStore((s) => {
+    const session = s.sessions.find((item) => item.id === s.activeSessionId);
+    return session?.currentDir;
+  });
+  const commandHistoryKey = useTerminalStore((s) => {
+    const session = s.sessions.find((item) => item.id === s.activeSessionId);
+    return session ? session.commandHistory.slice(0, MAX_RECENT_COMMANDS).join('\0') : '';
+  });
+
+  const lastWriteAtRef = useRef(0);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Generation guard (matches hooks/use-telegram-inbound.ts's pattern): only
+  // the newest effect instance's async callbacks are allowed to act, so a
+  // rapid cwd/history change can't leave a stale in-flight write racing a
+  // fresher one.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    const myGeneration = ++generationRef.current;
+    const isCurrent = () => myGeneration === generationRef.current;
+
+    const clearPending = () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+
+    const performWrite = async () => {
+      if (!isCurrent()) return;
+      if (!enabled || AppState.currentState !== 'active') return;
+      const state = useTerminalStore.getState();
+      const session = state.sessions.find((s) => s.id === state.activeSessionId);
+      const home = getHomePath();
+      const cwd = session?.currentDir || home;
+      const recentCommands = (session?.commandHistory || []).slice(0, MAX_RECENT_COMMANDS);
+      lastWriteAtRef.current = Date.now();
+      try {
+        const { repo, branch } = await resolveGitContext(cwd, home);
+        // Re-check both generation AND foreground state: resolveGitContext()
+        // awaits a subprocess, and the app can background mid-flight. If it
+        // does, the AppState listener's invalidateNacreBridgeContext() may
+        // already have deleted the file — writing here would silently
+        // recreate it, violating "only share while Shelly is foregrounded"
+        // (Codex review, 2026-08-30).
+        if (!isCurrent() || AppState.currentState !== 'active') return;
+        const context = buildNacreBridgeContext({ cwd, repo, branch, recentCommands });
+        await writeNacreBridgeContext(context);
+        logInfo(
+          'NacreBridge',
+          `context written (${context.terms.length} terms, repo=${context.repo ?? '-'}, branch=${context.branch ?? '-'})`,
+        );
+      } catch (e) {
+        logError('NacreBridge', 'write failed', e);
+      }
+    };
+
+    const scheduleWrite = () => {
+      if (!enabled) return;
+      if (AppState.currentState !== 'active') return;
+      clearPending();
+      debounceTimerRef.current = setTimeout(() => {
+        const elapsed = Date.now() - lastWriteAtRef.current;
+        const wait = Math.max(0, MIN_WRITE_INTERVAL_MS - elapsed);
+        if (wait > 0) {
+          debounceTimerRef.current = setTimeout(() => void performWrite(), wait);
+        } else {
+          void performWrite();
+        }
+      }, DEBOUNCE_MS);
+    };
+
+    if (enabled) {
+      scheduleWrite();
+    } else {
+      // Setting flipped off (or was already off) — make sure nothing stale
+      // lingers on shared storage.
+      clearPending();
+      void invalidateNacreBridgeContext();
+    }
+
+    const sub = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (!isCurrent()) return;
+      if (state === 'active') {
+        scheduleWrite();
+      } else if (state === 'background' || state === 'inactive') {
+        clearPending();
+        void invalidateNacreBridgeContext();
+      }
+    });
+
+    return () => {
+      generationRef.current += 1;
+      clearPending();
+      sub.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, currentDir, commandHistoryKey]);
+}

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -1442,6 +1442,8 @@ const en: Record<string, string> = {
   'settings.reset_hints_done_toast': 'One-time hints will show again.',
   'settings.profile_learning_label': 'Profile Learning',
   'settings.profile_learning_desc': 'Learn command, project, and AI usage patterns locally for personalized suggestions and AI context.',
+  'settings.nacre_bridge_label': 'Nacre Bridge',
+  'settings.nacre_bridge_desc': 'While Shelly is in the foreground, share your current directory, git branch, and safe recent command terms (never raw commands or secrets) with the Nacre IME to improve its conversion suggestions. Default on.',
   'settings.app_act_recipe_draft_label': 'App-Act Recipe Draft (Beta)',
   'settings.app_act_recipe_draft_action': 'Capture',
   'settings.app_act_recipe_draft_desc': 'Capture the current screen (LINE or X only) and draft a new app.act recipe from it.',

--- a/lib/i18n/locales/ja.ts
+++ b/lib/i18n/locales/ja.ts
@@ -1410,6 +1410,8 @@ const ja: Record<string, string> = {
   'settings.reset_hints_done_toast': '一度きりのヒントが再び表示されるようになります。',
   'settings.profile_learning_label': 'プロファイル学習',
   'settings.profile_learning_desc': 'コマンド・プロジェクト・AI利用傾向を端末内で学習し、提案とAI文脈に使います。',
+  'settings.nacre_bridge_label': 'Nacre連携',
+  'settings.nacre_bridge_desc': 'Shellyが前面表示中、現在のディレクトリ・gitブランチ・安全な最近のコマンド用語(生のコマンドやシークレットは含みません)をNacre IMEと共有し、変換候補の精度を上げます。既定でオン。',
   'settings.app_act_recipe_draft_label': 'App-Actレシピ下書き(ベータ)',
   'settings.app_act_recipe_draft_action': 'キャプチャ',
   'settings.app_act_recipe_draft_desc': '現在の画面(LINEまたはXのみ)をキャプチャして新しいapp.actレシピを下書きします。',

--- a/lib/nacre-bridge-context.ts
+++ b/lib/nacre-bridge-context.ts
@@ -1,0 +1,296 @@
+/**
+ * lib/nacre-bridge-context.ts — Shelly → Nacre bridge (feature B).
+ *
+ * While Shelly is in the foreground, share a small, sanitized slice of the
+ * current terminal context (cwd path segments, repo/branch, "safe" recent
+ * command terms) with the Nacre IME (space.manus.nacre) so its henkan
+ * (conversion) candidates can be biased toward the user's current work.
+ *
+ * Shelly and Nacre are signed with different keys, so ContentProvider +
+ * signature permissions are not available, and Binder/Intent bridges have
+ * caused Knox sepolicy trouble before (see CLAUDE.md's shell→RN bridge
+ * entry). This uses a shared-storage file instead:
+ *
+ *   /storage/emulated/0/Android/media/dev.shelly.terminal/nacre-bridge/context.json
+ *
+ * This is a FIXED CONTRACT agreed with the Nacre side (file path, JSON
+ * schema, sanitization rules) — do not change it without updating both
+ * sides in lockstep.
+ *
+ * Raw command text is NEVER written verbatim. sanitizeTerms() below is a
+ * pure, independently unit-tested function that extracts only tokens that
+ * survive a strict allow-list + secret/entropy deny-list pipeline. The same
+ * character-class check is applied to cwd path segments and repo/branch
+ * names as a defense against unexpected characters leaking through.
+ */
+
+import * as FileSystem from 'expo-file-system/legacy';
+
+// ─── Contract constants ─────────────────────────────────────────────────────
+
+/** Directory Nacre reads from. `Android/media` (not `Android/data`) is
+ *  shared storage with looser cross-app read access than app-private dirs. */
+export const NACRE_BRIDGE_DIR =
+  '/storage/emulated/0/Android/media/dev.shelly.terminal/nacre-bridge';
+
+export const NACRE_BRIDGE_FILE_PATH = `${NACRE_BRIDGE_DIR}/context.json`;
+
+/** Context is considered stale after this long — Nacre must not trust an
+ *  entry whose `expiresAt` is in the past. */
+export const NACRE_BRIDGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Hard cap on the number of extracted terms. */
+export const NACRE_BRIDGE_MAX_TERMS = 20;
+
+export interface NacreBridgeContext {
+  schema: 1;
+  generatedAt: number;
+  expiresAt: number;
+  repo?: string;
+  branch?: string;
+  cwdSegments: string[];
+  terms: string[];
+}
+
+export interface NacreBridgeContextInput {
+  /** Absolute current working directory. */
+  cwd: string;
+  /** Git repository name (e.g. "Shelly"), if resolvable. */
+  repo?: string;
+  /** Git branch name (e.g. "main"), if resolvable. */
+  branch?: string;
+  /** Recent raw command strings (terminal-store command history), most
+   *  recent first or last — order only affects which terms are kept once
+   *  the 20-item cap is hit. */
+  recentCommands: string[];
+  /** Injected clock for deterministic tests; defaults to Date.now(). */
+  now?: number;
+}
+
+// ─── Sanitization: shared character-class gate ─────────────────────────────
+
+/**
+ * Step 6 of the sanitization pipeline (see module doc): alnum + `_.-/` only,
+ * 1-40 chars. Applied to every surviving command term AND to cwd path
+ * segments / repo / branch as a second line of defense against stray
+ * unexpected characters.
+ */
+const SAFE_TOKEN_RE = /^[A-Za-z0-9_.\-\/]{1,40}$/;
+
+export function isSafeToken(value: string): boolean {
+  return SAFE_TOKEN_RE.test(value);
+}
+
+// ─── Sanitization: command-term extraction pipeline ────────────────────────
+
+/** Known secret-value prefixes (step 4). Case-sensitive — these are real
+ *  provider token formats and are defined with a fixed case. */
+const SECRET_PREFIXES = [
+  'sk-',
+  'ghp_',
+  'github_pat_',
+  'glpat-',
+  'xoxb-',
+  'xoxp-',
+  'AKIA',
+  'ASIA',
+  'AIza',
+  'ya29.',
+  'eyJ', // JWT header ("{" base64-encoded) — covers Bearer JWTs
+];
+
+/** High-entropy string shapes (step 5): base64-ish or hex-ish, 20+ chars. */
+const HIGH_ENTROPY_BASE64_RE = /^[A-Za-z0-9+/=]{20,}$/;
+const HIGH_ENTROPY_HEX_RE = /^[0-9a-fA-F]{20,}$/;
+
+/** Flag / env-var assignments that carry a secret-shaped name, e.g.
+ *  `--token=abc`, `Authorization:Bearer-xyz`, `KEY=...`, `PASSWORD=...`,
+ *  `SECRET=...`, `API_KEY=...` — step 3's first bullet. Anchored (`^...$`)
+ *  and applied to ONE already-split token at a time (see
+ *  extractSafeTermsFromCommand below) rather than the raw command string:
+ *  applying it unanchored across a whole whitespace-delimited run before
+ *  splitting would let a single `?`-attached match (e.g.
+ *  `api/resource?token=abc123`) swallow the safe path prefix along with
+ *  the secret suffix. Case-insensitive: env var names and flags vary in
+ *  case across tools. */
+const SECRET_ASSIGNMENT_RE = /^\S*(?:token|password|secret|key|auth)\S*[:=]\S*$/i;
+
+/** Shell-ish separators used to split a command into candidate tokens:
+ *  whitespace plus the common pipe/redirect/grouping punctuation. */
+const SHELL_SEPARATOR_RE = /[\s|;&<>(){}]+/;
+
+/**
+ * Unwraps or drops quoted spans (step 3's third bullet) before tokenizing.
+ * A quoted span whose INNER content is longer than 20 chars is dropped
+ * entirely (quotes + content); a short quoted span has its quotes removed
+ * so the inner text re-enters the token stream as plain words, still
+ * subject to every later filter.
+ */
+function stripLongQuotedSpans(command: string): string {
+  return command.replace(/"([^"]*)"|'([^']*)'/g, (_match, dq, sq) => {
+    const inner: string = dq !== undefined ? dq : sq;
+    if (inner.length > 20) return ' ';
+    return ` ${inner} `;
+  });
+}
+
+/** Step 2's URL-query-parameter bullet: drop everything from the first `?`
+ *  onward in a single token (covers both absolute and schemeless paths —
+ *  an absolute `https://...` token is excluded anyway once `:` hits the
+ *  step-6 char-class gate, but a schemeless `api/resource?token=x` would
+ *  otherwise leak the query string). */
+function stripUrlQuery(token: string): string {
+  const qIndex = token.indexOf('?');
+  return qIndex === -1 ? token : token.slice(0, qIndex);
+}
+
+function hasSecretPrefix(token: string): boolean {
+  return SECRET_PREFIXES.some((prefix) => token.startsWith(prefix));
+}
+
+function isHighEntropy(token: string): boolean {
+  return HIGH_ENTROPY_BASE64_RE.test(token) || HIGH_ENTROPY_HEX_RE.test(token);
+}
+
+/**
+ * Full token safety check: char-class gate AND secret-prefix AND high-entropy
+ * rejection. `sanitizeTerms()` already applies all three per-token via
+ * `extractSafeTermsFromCommand`; this is the same bar applied to cwd path
+ * segments and repo/branch, which previously only went through the
+ * char-class gate (`isSafeToken`) — a directory or branch literally named
+ * e.g. `sk-testtoken` or a 20+ char hex/base64-looking string would pass the
+ * char-class check and get written to shared storage even though Nacre's
+ * own re-filter would later drop it — the leak onto disk already happened by
+ * then (Codex review, 2026-08-30).
+ */
+function isSafeAndUnsecretive(value: string): boolean {
+  return isSafeToken(value) && !hasSecretPrefix(value) && !isHighEntropy(value);
+}
+
+/** Extracts the "safe technical terms" allow-listed by the bridge contract
+ *  out of one raw command string. Pure function — no I/O.
+ *
+ *  Order matters: tokenize (on whitespace/shell separators) BEFORE running
+ *  the per-token secret-assignment / prefix / entropy / char-class checks,
+ *  so each check only ever sees one already-whitespace-bounded candidate
+ *  and can't bleed across an unrelated safe prefix (see SECRET_ASSIGNMENT_RE's
+ *  doc comment for the specific bug this avoids). */
+function extractSafeTermsFromCommand(command: string): string[] {
+  const withoutQuotedSpans = stripLongQuotedSpans(command);
+  const rawTokens = withoutQuotedSpans.split(SHELL_SEPARATOR_RE).filter(Boolean);
+
+  const kept: string[] = [];
+  for (const rawToken of rawTokens) {
+    const token = stripUrlQuery(rawToken);
+    if (!token) continue;
+    if (SECRET_ASSIGNMENT_RE.test(token)) continue;
+    if (hasSecretPrefix(token)) continue;
+    if (isHighEntropy(token)) continue;
+    if (!isSafeToken(token)) continue;
+    kept.push(token);
+  }
+  return kept;
+}
+
+/**
+ * Full sanitization pipeline for the bridge's `terms` field: given raw
+ * recent command strings, returns a deduplicated list of "safe technical
+ * terms" (command names, flags without values, file paths, project/tool
+ * identifiers) with all secret-shaped, high-entropy, and oddly-charactered
+ * content removed. Never includes anything not already present verbatim in
+ * the input, and never invents or reorders content across commands beyond
+ * dedup + truncation.
+ *
+ * Pure function — safe to unit test directly, no mocking required.
+ */
+export function sanitizeTerms(commands: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const command of commands) {
+    if (typeof command !== 'string' || !command.trim()) continue;
+    for (const term of extractSafeTermsFromCommand(command)) {
+      if (seen.has(term)) continue;
+      seen.add(term);
+      result.push(term);
+      if (result.length >= NACRE_BRIDGE_MAX_TERMS) return result;
+    }
+  }
+  return result;
+}
+
+// ─── Sanitization: path / repo / branch ────────────────────────────────────
+
+/** Splits an absolute (or relative) path into its non-empty segments and
+ *  drops any segment that doesn't pass the full token safety check (char
+ *  class + secret-prefix + high-entropy — see isSafeAndUnsecretive). */
+export function sanitizeCwdSegments(cwd: string): string[] {
+  if (typeof cwd !== 'string' || !cwd) return [];
+  return cwd
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .filter(isSafeAndUnsecretive);
+}
+
+/** Repo/branch are single free-text-ish values from git; omit the field
+ *  entirely (never coerce to '') if it's missing or fails the full token
+ *  safety check (char class + secret-prefix + high-entropy) — matches the
+ *  contract's "省略可...空文字列にしない" rule. */
+export function sanitizeRepoOrBranch(value: string | undefined | null): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return isSafeAndUnsecretive(trimmed) ? trimmed : undefined;
+}
+
+// ─── JSON assembly ──────────────────────────────────────────────────────────
+
+/** Builds the exact JSON contract object (does not write it). Pure
+ *  function — the caller decides when/whether to persist it. */
+export function buildNacreBridgeContext(input: NacreBridgeContextInput): NacreBridgeContext {
+  const now = input.now ?? Date.now();
+  const context: NacreBridgeContext = {
+    schema: 1,
+    generatedAt: now,
+    expiresAt: now + NACRE_BRIDGE_TTL_MS,
+    cwdSegments: sanitizeCwdSegments(input.cwd),
+    terms: sanitizeTerms(input.recentCommands),
+  };
+  const repo = sanitizeRepoOrBranch(input.repo);
+  if (repo) context.repo = repo;
+  const branch = sanitizeRepoOrBranch(input.branch);
+  if (branch) context.branch = branch;
+  return context;
+}
+
+// ─── File I/O (device only) ─────────────────────────────────────────────────
+
+function toFileUri(path: string): string {
+  return path.startsWith('file://') ? path : `file://${path}`;
+}
+
+/** Writes the context file, creating the shared-storage directory first if
+ *  needed. Requires MANAGE_EXTERNAL_STORAGE (already held by this app —
+ *  see lib/first-launch-setup.ts). Best-effort: throws on failure so the
+ *  caller can log/ignore, matching the other fire-and-forget bridge writes
+ *  in this codebase (e.g. saveSessionState). */
+export async function writeNacreBridgeContext(context: NacreBridgeContext): Promise<void> {
+  const dirUri = toFileUri(NACRE_BRIDGE_DIR);
+  const info = await FileSystem.getInfoAsync(dirUri);
+  if (!info.exists) {
+    await FileSystem.makeDirectoryAsync(dirUri, { intermediates: true });
+  }
+  await FileSystem.writeAsStringAsync(toFileUri(NACRE_BRIDGE_FILE_PATH), JSON.stringify(context));
+}
+
+/** Invalidates the shared context when Shelly leaves the foreground.
+ *  Deletes the file outright (simplest correct way to make it
+ *  unavailable); idempotent, and swallows errors since this is a
+ *  best-effort courtesy cleanup, not a safety boundary — the `expiresAt`
+ *  TTL is the actual safety net if deletion fails for any reason. */
+export async function invalidateNacreBridgeContext(): Promise<void> {
+  try {
+    await FileSystem.deleteAsync(toFileUri(NACRE_BRIDGE_FILE_PATH), { idempotent: true });
+  } catch {
+    // best-effort cleanup only
+  }
+}

--- a/store/settings-store.ts
+++ b/store/settings-store.ts
@@ -222,6 +222,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // lib/companion-brain.ts's resolveCompanionBrain. 'local-only' opts back
   // out to byte-identical pre-Design-C behavior.
   companionBrainMode: 'auto',
+  // Nacre Bridge (feature B) — default ON, opt-out. See AppSettings.nacreBridgeEnabled
+  // for what this shares and lib/nacre-bridge-context.ts for the sanitization contract.
+  nacreBridgeEnabled: true,
 };
 
 const ACTIVE_TEAM_PRIORITY: AppSettings['teamFacilitatorPriority'] = ['gemini', 'cerebras', 'groq', 'codex', 'perplexity', 'local'];

--- a/store/types.ts
+++ b/store/types.ts
@@ -402,6 +402,17 @@ export type AppSettings = {
    *  (lib/companion-journal.ts's digestConversationForJournal) always stays
    *  on-device regardless of this setting. */
   companionBrainMode?: 'auto' | 'local-only';
+  // ─── Nacre Bridge (Shelly → Nacre IME context sharing, feature B) ──────────
+  /** While Shelly is in the foreground, share a small sanitized slice of the
+   *  current terminal context (cwd path segments, repo/branch, "safe"
+   *  recent-command terms — never raw command text, never secrets) with the
+   *  Nacre IME (space.manus.nacre) via a shared-storage JSON file so its
+   *  conversion candidates can be biased toward the user's current work. See
+   *  lib/nacre-bridge-context.ts for the sanitization pipeline and the fixed
+   *  file-path/JSON-schema contract shared with the Nacre side. Default ON;
+   *  the file is only ever written while the app is foregrounded and is
+   *  deleted (or left to expire within 5 minutes) once it backgrounds. */
+  nacreBridgeEnabled?: boolean;
   // ─── Autonomous cloud opt-in (N1) ──────────────────────────────────────────
   /** Informed consent: autonomous agents may use cloud API keys (Gemini /
    *  Perplexity) UNATTENDED for web-mandatory tasks. Default OFF — fail-closed:


### PR DESCRIPTION
## Summary

Shelly-side half of the Shelly↔Nacre Bridge V1 (feature B, per Fable5 + Codex design consult). While Shelly is in the foreground, writes a small, sanitized snapshot of the current terminal context (cwd path segments, git repo/branch, "safe" recent-command terms) to a fixed shared-storage path so the Nacre IME (a separate self-built app, different signing key) can bias its conversion/prediction candidates toward the user's current work. The reader side (`feat/nacre-bridge-reader` on `RYOITABASHI/Nacre`) was implemented independently against the same fixed contract and both sides were reviewed together.

- **Transfer mechanism**: `ContentProvider` + signature permission isn't available (different signing keys), and Binder/Intent bridges have caused Knox sepolicy trouble before (see CLAUDE.md's shell→RN bridge entry). Instead writes JSON to `/storage/emulated/0/Android/media/dev.shelly.terminal/nacre-bridge/context.json` — `Android/media` (not `Android/data`) is shared storage with looser cross-app read access.
- **Raw command text is never written verbatim.** `sanitizeTerms()` (pure, unit-tested) extracts only tokens that survive: tokenization → URL-query stripping → secret-assignment-pattern rejection (`token=`/`password=`/`key=`/etc) → known secret-prefix rejection (`sk-`, `ghp_`, `AKIA`, `AIza`, `eyJ`, ...) → high-entropy (base64/hex-shaped, 20+ chars) rejection → a strict char-class allowlist (`^[A-Za-z0-9_.\-\/]{1,40}$`). The same char-class + secret-prefix + high-entropy checks apply to `cwdSegments`/`repo`/`branch`.
- **Foreground-only**: `useNacreBridge()` writes only while `AppState.currentState === 'active'`, debounced (1.5s) and throttled (min 8s between writes) on cwd/command-history changes; the file is deleted the instant the app backgrounds, with the 5-minute `expiresAt` TTL as the backstop if deletion fails.
- Git repo/branch resolved via the same `execCommand` pattern `ContextBar.tsx` already uses.
- Gated by `settings.nacreBridgeEnabled` (default ON), with a toggle in ConfigTUI's Context section.

### Codex review (joint review with the Nacre reader side) — 3 issues found and fixed
1. **Foreground re-check race (major)**: `performWrite()` awaited `resolveGitContext()` (a subprocess call) but only re-checked the effect's generation counter afterward, not `AppState.currentState`. If the app backgrounded mid-write, the background handler's `invalidateNacreBridgeContext()` could delete the file and then the in-flight write could still land afterward, recreating it — violating "only share while foregrounded." Fixed by re-checking `AppState.currentState === 'active'` after the await too.
2. **`cwdSegments`/`repo`/`branch` skipped the secret-prefix/entropy checks (major)**: only `terms` (from command history) went through the full sanitization pipeline; these three fields only got the char-class gate. A directory or branch literally named `sk-testtoken` or a 20+ char hex/base64-looking string would have passed straight through to the shared-storage file — a leak Nacre's own re-filter can't undo, since the damage (writing to disk) already happened. Fixed by applying the same secret-prefix + high-entropy checks to all three fields (new shared `isSafeAndUnsecretive()` helper). Added regression tests.
3. (Addressed on the Nacre side, not this repo: unbounded file read size.)

## Test plan
- [ ] `tsc --noEmit`: no errors.
- [ ] Jest: 84/84 passing (38 original + 4 new regression tests for the secret-prefix/entropy fix), verified via a temporary jest config workaround for a known `.claude`-path testMatch glob issue in this sandboxed worktree (not a real config change — the actual `jest.config.cjs` is untouched).
- [ ] On-device: with Shelly foregrounded in a git repo, confirm `context.json` appears at the documented path with sanitized repo/branch/cwd/terms.
- [ ] On-device: background Shelly, confirm the file is deleted promptly.
- [ ] On-device: type a command containing something secret-shaped (e.g. `export API_KEY=sk-abc123`), confirm none of it appears in the written file.
- [ ] On-device: toggle `nacreBridgeEnabled` off in Settings, confirm the file stops updating and any existing file is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)