### PR TITLE
fix(nacre-bridge): write via shell, not expo-file-system (on-device finding)

### DIFF
--- a/__tests__/nacre-bridge-context.test.ts
+++ b/__tests__/nacre-bridge-context.test.ts
@@ -1,9 +1,17 @@
 // Nacre Bridge (Shelly → Nacre IME context sharing, feature B) — sanitization
 // pipeline tests. These target the PURE functions in lib/nacre-bridge-context.ts;
-// no expo-file-system I/O is exercised here (mocked out below since the module
-// imports it at top level, matching the pattern __tests__/memory/shadow.test.ts
-// uses for the same reason).
-jest.mock('expo-file-system/legacy', () => ({}));
+// no shell I/O is exercised here (mocked out below since the module imports
+// execCommand at top level, and use-native-exec.ts transitively imports the
+// native TerminalEmulatorModule, which isn't available under Jest — matching
+// the pattern __tests__/memory/shadow.test.ts uses for the same reason).
+//
+// 2026-08-30: writeNacreBridgeContext()/invalidateNacreBridgeContext() were
+// switched from expo-file-system to execCommand (shell) after on-device
+// testing found expo-file-system's makeDirectoryAsync/writeAsStringAsync
+// reject Android/media/... paths as "not writable" even with
+// MANAGE_EXTERNAL_STORAGE granted — Expo's FileSystem module scopes writes
+// to its own sandboxed roots regardless of that OS-level permission.
+jest.mock('@/hooks/use-native-exec', () => ({ execCommand: jest.fn() }));
 
 import {
   sanitizeTerms,

--- a/lib/nacre-bridge-context.ts
+++ b/lib/nacre-bridge-context.ts
@@ -24,7 +24,7 @@
  * names as a defense against unexpected characters leaking through.
  */
 
-import * as FileSystem from 'expo-file-system/legacy';
+import { execCommand } from '@/hooks/use-native-exec';
 
 // ─── Contract constants ─────────────────────────────────────────────────────
 
@@ -264,8 +264,33 @@ export function buildNacreBridgeContext(input: NacreBridgeContextInput): NacreBr
 
 // ─── File I/O (device only) ─────────────────────────────────────────────────
 
-function toFileUri(path: string): string {
-  return path.startsWith('file://') ? path : `file://${path}`;
+/** Escape a string for safe use inside single quotes in shell commands
+ *  (matches lib/project-context.ts / lib/workflow-manager.ts's helper). */
+function shellEscape(s: string): string {
+  return s.replace(/'/g, "'\\''");
+}
+
+/**
+ * On-device testing (2026-08-30) found that `expo-file-system`'s
+ * `makeDirectoryAsync`/`writeAsStringAsync` REJECT `Android/media/...` with
+ * "isn't writable" even though this app holds `MANAGE_EXTERNAL_STORAGE` at
+ * the OS level — Expo's FileSystem module scopes writes to its own sandboxed
+ * roots regardless of that permission. Every other place in this codebase
+ * that writes to arbitrary shared-storage paths goes through the shell
+ * (`execCommand`) instead, which runs as the app's real Linux process and is
+ * unaffected by Expo's own path scoping (see lib/project-context.ts,
+ * lib/workflow-manager.ts). Content is piped through base64 to avoid shell
+ * escaping entirely — the JSON payload contains many quote characters.
+ */
+async function writeFileViaShell(path: string, content: string): Promise<void> {
+  const b64 = btoa(unescape(encodeURIComponent(content)));
+  const escapedPath = shellEscape(path);
+  const result = await execCommand(
+    `echo '${shellEscape(b64)}' | base64 -d > '${escapedPath}'`,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to write ${path}: ${result.stderr || result.stdout}`);
+  }
 }
 
 /** Writes the context file, creating the shared-storage directory first if
@@ -274,12 +299,11 @@ function toFileUri(path: string): string {
  *  caller can log/ignore, matching the other fire-and-forget bridge writes
  *  in this codebase (e.g. saveSessionState). */
 export async function writeNacreBridgeContext(context: NacreBridgeContext): Promise<void> {
-  const dirUri = toFileUri(NACRE_BRIDGE_DIR);
-  const info = await FileSystem.getInfoAsync(dirUri);
-  if (!info.exists) {
-    await FileSystem.makeDirectoryAsync(dirUri, { intermediates: true });
+  const mkdirResult = await execCommand(`mkdir -p '${shellEscape(NACRE_BRIDGE_DIR)}'`);
+  if (mkdirResult.exitCode !== 0) {
+    throw new Error(`Failed to create ${NACRE_BRIDGE_DIR}: ${mkdirResult.stderr}`);
   }
-  await FileSystem.writeAsStringAsync(toFileUri(NACRE_BRIDGE_FILE_PATH), JSON.stringify(context));
+  await writeFileViaShell(NACRE_BRIDGE_FILE_PATH, JSON.stringify(context));
 }
 
 /** Invalidates the shared context when Shelly leaves the foreground.
@@ -289,7 +313,7 @@ export async function writeNacreBridgeContext(context: NacreBridgeContext): Prom
  *  TTL is the actual safety net if deletion fails for any reason. */
 export async function invalidateNacreBridgeContext(): Promise<void> {
   try {
-    await FileSystem.deleteAsync(toFileUri(NACRE_BRIDGE_FILE_PATH), { idempotent: true });
+    await execCommand(`rm -f '${shellEscape(NACRE_BRIDGE_FILE_PATH)}'`);
   } catch {
     // best-effort cleanup only
   }


### PR DESCRIPTION
## Summary

On-device testing (immediately after merging #138) found the Nacre Bridge context-sharing feature was **completely non-functional in production** — the bridge file was never being created at all.

Root cause, confirmed via logcat:
```
E ReactNativeJS: '[Shelly][NacreBridge] write failed', 'Call to function
'ExponentFileSystem.makeDirectoryAsync' has been rejected.
Caused by: java.io.IOException: Location
'file:///storage/emulated/0/Android/media/dev.shelly.terminal/nacre-bridge'
isn't writable.'
```

`expo-file-system`'s `makeDirectoryAsync`/`writeAsStringAsync` reject `Android/media/...` paths as "not writable" even though the app holds `MANAGE_EXTERNAL_STORAGE` at the OS level (confirmed granted via `adb shell appops get`) — Expo's FileSystem module scopes writes to its own sandboxed roots regardless of that OS-level permission. This is exactly the kind of gap pure code review (including two rounds of Codex review on #138) can't catch — it only shows up when the code actually runs on a device.

Every other place in this codebase that writes to arbitrary shared-storage paths already goes through the shell (`execCommand`) instead, which runs as the app's real Linux process and is unaffected by Expo's own path scoping (see `lib/project-context.ts`, `lib/workflow-manager.ts`). Switched `writeNacreBridgeContext()`/`invalidateNacreBridgeContext()` to the same established pattern: `mkdir -p` via shell, content piped through base64 to sidestep shell-quoting the JSON payload entirely (it's full of double quotes).

Updated the test file's module mock accordingly (was mocking `expo-file-system/legacy`, now mocks `@/hooks/use-native-exec`) — no behavior change to the pure sanitization functions under test.

## Test plan
- [ ] `tsc --noEmit`: no errors.
- [ ] Jest: 84/84 passing (sanitization pipeline unaffected).
- [ ] On-device (this is the actual regression test): with Shelly foregrounded in a git repo, confirm `/storage/emulated/0/Android/media/dev.shelly.terminal/nacre-bridge/context.json` is actually created this time, with no `[Shelly][NacreBridge] write failed` in logcat.
- [ ] On-device: confirm the file is deleted when Shelly backgrounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)