### PR TITLE
fix(settings): revert to bug #170's validated slider fix, add nacre-bridge command tracking

### DIFF
--- a/components/layout/SettingsDropdown.tsx
+++ b/components/layout/SettingsDropdown.tsx
@@ -801,36 +801,25 @@ function SliderRow({
   latestValue.current = value;
   const panResponder = useRef(
     PanResponder.create({
-      // 2026-08-29 (`32a9c6a27`): scoping the responder to touches starting on
-      // the thumb (not the whole track) fixed the original "scrolls fine at
-      // first, then freezes" bug, but claiming unconditionally on touch-DOWN
-      // (onStartShouldSetPanResponder: () => true) left a residual gap: the
-      // thumb's hitSlop is 16px in every direction around a 10px thumb, so
-      // its ~42x42px capture zone still overlaps ordinary vertical scroll
-      // gestures that happen to start near wherever the thumb currently sits
-      // (its x position moves with the opacity value). A vertical drag
-      // captured there barely moves dx, so the slider visibly doesn't change
-      // either — it just silently eats the scroll, which is exactly the
-      // "sometimes scrolling just doesn't work" report this screen kept
-      // getting even after the first fix (2026-08-30, on-device retest).
-      // Deferring the claim to onMoveShouldSetPanResponder and requiring a
-      // clearly horizontal first move (both a minimum absolute dx and a
-      // dx:dy ratio, per Codex review — a bare few-px threshold still let
-      // ordinary scroll-start jitter tip the direction check) closes that
-      // gap: a touch that starts in the thumb's zone but moves vertically
-      // now falls through to the Settings ScrollView, while a genuine
-      // horizontal drag still wins the responder race (RN polls this on
-      // every move, before the ScrollView locks in its own vertical drag —
-      // though on Android, once claimed, PanResponder's default
-      // onShouldBlockNativeResponder makes it hard to hand back mid-gesture,
-      // which is why the threshold below stays conservative rather than
-      // minimal).
-      onStartShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponder: (_e, gestureState) => {
-        const absDx = Math.abs(gestureState.dx);
-        const absDy = Math.abs(gestureState.dy);
-        return absDx > 6 && absDx > absDy * 1.2;
-      },
+      // 2026-08-30 revert (Codex + on-device re-confirm): a same-day attempt
+      // to fix a *different*, narrower complaint (this thumb's hitSlop zone
+      // can overlap an ordinary scroll-start point) by deferring the claim to
+      // onMoveShouldSetPanResponder with a dx/dy heuristic UNKNOWINGLY
+      // reintroduced bug #170 (`ac8a7c4b3`, 2026-08-29): any heuristic here
+      // lets a brief horizontal jitter at the very start of a vertical scroll
+      // win the threshold check and claim the responder permanently — this
+      // screen has no horizontal scrolling to disambiguate against, so once
+      // that happens the whole ScrollView freezes for the rest of the drag,
+      // which is exactly what on-device testing reproduced again today
+      // ("最初だけ動いて止まる" — moves briefly, then stops). `ac8a7c4b3`
+      // already root-caused and fixed this via Codex review; restoring that
+      // fix verbatim (claim unconditionally on touch-down, but scope the
+      // responder to the thumb itself, not the whole track) rather than
+      // re-deriving a "better" heuristic that has already been shown to
+      // regress this. The thumb-hitSlop-overlaps-scroll-start complaint is
+      // real but strictly less severe than a fully frozen ScrollView — do
+      // not reintroduce a move-time direction heuristic here again.
+      onStartShouldSetPanResponder: () => true,
       onPanResponderGrant: () => {
         valueAtGrant.current = latestValue.current;
       },

--- a/hooks/use-nacre-bridge.ts
+++ b/hooks/use-nacre-bridge.ts
@@ -20,6 +20,7 @@ import { useEffect, useRef } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 import { useSettingsStore } from '@/store/settings-store';
 import { useTerminalStore } from '@/store/terminal-store';
+import type { TabSession } from '@/store/types';
 import { execCommand } from '@/hooks/use-native-exec';
 import { getHomePath } from '@/lib/home-path';
 import {
@@ -75,6 +76,41 @@ async function resolveGitContext(
   }
 }
 
+/**
+ * Recent command strings for a session, most-recent-first.
+ *
+ * On-device testing (2026-08-30) found `session.commandHistory` never
+ * reflects real usage: it's only ever written by terminal-store's own
+ * `runCommand()`, which is the OLD block-terminal UI's (TerminalBlock.tsx /
+ * FirstMateOverlay.tsx) choke point. The actual terminal UI in the app today
+ * — NativeTerminalView, PTY-direct — writes typed input straight to the PTY
+ * fd and never calls `runCommand()` (see TerminalPane.tsx's `onBlockCompleted`
+ * handler, which instead appends to `session.entries` via `addEntryBlock()`
+ * and calls `learnFromCommand()` as ITS OWN separate choke point — the exact
+ * same architectural split lib/agent-suggestion-engine.ts already hit for
+ * profile learning). Reading `commandHistory` alone meant `terms` stayed
+ * permanently empty and never updated for anyone actually typing in the
+ * terminal, which is the common case. Read both: `entries` (real native
+ * usage) and `commandHistory` (legacy block-UI, kept for completeness).
+ */
+function recentCommands(session: TabSession | undefined): string[] {
+  if (!session) return [];
+  const fromEntries = session.entries
+    .filter((e): e is Extract<typeof e, { command: string }> => 'command' in e)
+    .slice(-MAX_RECENT_COMMANDS)
+    .reverse()
+    .map((e) => e.command);
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const cmd of [...fromEntries, ...session.commandHistory]) {
+    if (!cmd || seen.has(cmd)) continue;
+    seen.add(cmd);
+    merged.push(cmd);
+    if (merged.length >= MAX_RECENT_COMMANDS) break;
+  }
+  return merged;
+}
+
 export function useNacreBridge(): void {
   const enabled = useSettingsStore((s) => s.settings.nacreBridgeEnabled ?? true);
   const currentDir = useTerminalStore((s) => {
@@ -83,7 +119,7 @@ export function useNacreBridge(): void {
   });
   const commandHistoryKey = useTerminalStore((s) => {
     const session = s.sessions.find((item) => item.id === s.activeSessionId);
-    return session ? session.commandHistory.slice(0, MAX_RECENT_COMMANDS).join('\0') : '';
+    return recentCommands(session).join('\0');
   });
 
   const lastWriteAtRef = useRef(0);
@@ -112,7 +148,7 @@ export function useNacreBridge(): void {
       const session = state.sessions.find((s) => s.id === state.activeSessionId);
       const home = getHomePath();
       const cwd = session?.currentDir || home;
-      const recentCommands = (session?.commandHistory || []).slice(0, MAX_RECENT_COMMANDS);
+      const recent = recentCommands(session);
       lastWriteAtRef.current = Date.now();
       try {
         const { repo, branch } = await resolveGitContext(cwd, home);
@@ -123,7 +159,7 @@ export function useNacreBridge(): void {
         // recreate it, violating "only share while Shelly is foregrounded"
         // (Codex review, 2026-08-30).
         if (!isCurrent() || AppState.currentState !== 'active') return;
-        const context = buildNacreBridgeContext({ cwd, repo, branch, recentCommands });
+        const context = buildNacreBridgeContext({ cwd, repo, branch, recentCommands: recent });
         await writeNacreBridgeContext(context);
         logInfo(
           'NacreBridge',


### PR DESCRIPTION
## Summary
1. **Settings slider scroll freeze (revert)**: earlier today I fixed a narrower complaint by switching the SliderRow's PanResponder to a deferred `onMoveShouldSetPanResponder` dx/dy heuristic. This unknowingly reintroduced bug #170 (`ac8a7c4b3`, 2026-08-29, already Codex-reviewed and fixed) — any heuristic here lets horizontal jitter at the start of a vertical scroll win the threshold and freeze the ScrollView for the rest of the drag. On-device testing today reproduced this exactly, and `adb getevent` raw touch capture confirmed the touchscreen itself reported a clean continuous drag throughout — the freeze was purely in the app's responder logic. Reverted to `ac8a7c4b3`'s fix verbatim (unconditional claim on touch-down, scoped to the thumb only). Kept the orthogonal stale-closure fix from today (a `latestValue` ref for `onPanResponderGrant`).
2. **Nacre Bridge terms extraction**: `session.commandHistory` (read for the shared context's `terms`) is only written by the OLD block-terminal UI's `runCommand()`; the actual NativeTerminalView PTY-direct path never calls it, so `terms` stayed permanently empty for real usage. Added `recentCommands()` reading both `session.entries` (real usage) and `commandHistory` (legacy), deduped.

## Test plan
- [ ] On-device: Settings screen, drag-scroll from any position — confirm it tracks the finger continuously start to finish, no freeze.
- [ ] On-device: drag an opacity slider — confirm it still works and lands on the correct value.
- [ ] On-device: type real commands in the terminal with Shelly foregrounded, confirm `terms` in `context.json` populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)